### PR TITLE
Add ecube-setup console script entry point

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -5,7 +5,7 @@ and seeds the database with the admin role mapping.
 
 Must be run as root/sudo::
 
-    sudo python -m app.setup
+    sudo ecube-setup
 """
 
 from __future__ import annotations
@@ -215,7 +215,7 @@ def _seed_database(username: str, install_dir: str) -> bool:
 
 def main() -> None:
     if os.geteuid() != 0:
-        print("Error: this script must be run as root (sudo python -m app.setup)", file=sys.stderr)
+        print("Error: this script must be run as root (sudo ecube-setup)", file=sys.stderr)
         sys.exit(1)
 
     install_dir = os.environ.get("ECUBE_INSTALL_DIR", DEFAULT_INSTALL_DIR)

--- a/documents/operations/00-operational-guide.md
+++ b/documents/operations/00-operational-guide.md
@@ -241,7 +241,7 @@ The setup script creates OS groups, an initial admin user, generates the `.env`
 configuration, and seeds the database with the admin role.
 
 ```bash
-sudo python -m app.setup
+sudo /opt/ecube/venv/bin/ecube-setup
 ```
 
 See [First-Run Setup Script](#first-run-setup-script) below for full details.
@@ -278,7 +278,7 @@ docker compose up -d
 docker compose exec app alembic upgrade head
 
 # Run first-run setup (creates admin user, seeds DB role)
-docker compose exec app python -m app.setup
+docker compose exec app ecube-setup
 
 # View logs
 docker compose logs -f app
@@ -731,7 +731,7 @@ User "bob" calls POST /auth/token
 | Day-to-day operations | `user_roles` table (DB) | Admin via API |
 
 The OS group fallback ensures that a freshly deployed system works immediately
-after `sudo python -m app.setup` — the admin user is a member of `ecube-admins`
+after `sudo ecube-setup` — the admin user is a member of `ecube-admins`
 **and** has an explicit DB role. As the deployment matures, admins can manage
 all role assignments through the API and the DB takes precedence.
 
@@ -813,7 +813,7 @@ The first-run setup script bootstraps a new ECUBE installation. It must be
 run as root.
 
 ```bash
-sudo python -m app.setup
+sudo /opt/ecube/venv/bin/ecube-setup
 ```
 
 **What it creates:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
     "python-pam>=2.0.0",
 ]
 
+[project.scripts]
+ecube-setup = "app.setup:main"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0.0",


### PR DESCRIPTION
Replace sudo python -m app.setup with a proper console script entry point so the setup command can be invoked as sudo ecube-setup after package installation.