### PR TITLE
Fix HTTP status code for username validation and update test cases for clarity

### DIFF
--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -33,7 +33,7 @@ def _validate_username(username: str) -> str:
     """Reject usernames with shell metacharacters or invalid format."""
     if not _USERNAME_RE.match(username):
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Invalid username. Must start with a lowercase letter or "
             "underscore, contain only lowercase letters, digits, hyphens, "
             "or underscores, and be 1–32 characters.",
@@ -90,7 +90,7 @@ def set_user_roles(
         repo.set_roles(username, deduplicated)
     except ValueError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(exc),
         )
     except Exception:

--- a/tests/test_user_roles.py
+++ b/tests/test_user_roles.py
@@ -286,7 +286,8 @@ class TestUsernameValidation:
     @pytest.mark.parametrize("bad_name", [
         "Admin",          # uppercase
         "root;rm",        # shell metacharacter
-        "../etc",         # path traversal
+        # "../etc" omitted — Starlette normalises the path before routing,
+        # so the request never reaches _validate_username (returns 404).
         "a" * 33,         # too long (max 32)
         "1user",          # starts with digit
         "user name",      # space


### PR DESCRIPTION
This implements issue #85.

Two changes made:

1. **test_user_roles.py** — Removed `"../etc"` from the `test_invalid_usernames_rejected` parametrize list with a comment explaining that Starlette normalizes the path before routing, so the request never reaches `_validate_username`.

2. **users.py** — Replaced both uses of `HTTP_422_UNPROCESSABLE_ENTITY` with `HTTP_422_UNPROCESSABLE_CONTENT` to fix the deprecation warning.
