### PR TITLE
Enhance OS user authentication and setup process

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -23,7 +23,7 @@ from app.exceptions import AuthorizationError
 from app.repositories.audit_repository import best_effort_audit
 from app.repositories.user_role_repository import UserRoleRepository
 from app.infrastructure.pam_protocol import PamAuthenticator
-from app.schemas.errors import R_400, R_401, R_404, R_422
+from app.schemas.errors import R_400, R_401, R_403, R_404, R_422
 from app.utils.client_ip import get_client_ip
 
 logger = logging.getLogger(__name__)
@@ -74,7 +74,7 @@ class TokenResponse(BaseModel):
 # Endpoint
 # ---------------------------------------------------------------------------
 
-@router.post("/token", response_model=TokenResponse, responses={**R_400, **R_401, **R_404, **R_422})
+@router.post("/token", response_model=TokenResponse, responses={**R_400, **R_401, **R_403, **R_404, **R_422})
 def login(
     body: TokenRequest,
     *,

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -104,15 +104,11 @@ def login(
         )
 
     # Resolve ECUBE roles for the user.
-    # Local mode requires explicit DB ``user_roles`` assignments.
-    # LDAP mode falls back to resolver-derived roles from groups when no DB
-    # override exists.
+    # Priority: 1) Explicit roles from DB ``user_roles`` table,
+    #           2) Roles derived from groups via the configured resolver.
     groups = pam.get_user_groups(body.username)
     db_roles = UserRoleRepository(db).get_roles(body.username)
-    if settings.role_resolver == "local":
-        roles = db_roles
-    else:
-        roles = db_roles if db_roles else get_role_resolver().resolve(groups)
+    roles = db_roles if db_roles else get_role_resolver().resolve(groups)
 
     if not roles:
         best_effort_audit(

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import Session
 from app.auth_providers import get_role_resolver
 from app.config import settings
 from app.database import get_db
+from app.exceptions import AuthorizationError
 from app.repositories.audit_repository import best_effort_audit
 from app.repositories.user_role_repository import UserRoleRepository
 from app.infrastructure.pam_protocol import PamAuthenticator
@@ -83,7 +84,7 @@ def login(
 ) -> TokenResponse:
     """Authenticate with OS credentials and receive a signed JWT.
 
-    No role is required — this is the login route.
+    Authentication requires valid OS credentials and at least one ECUBE role.
 
     This endpoint is available when ``role_resolver`` is ``local`` or ``ldap``.
     When OIDC mode is active, users authenticate externally via the identity
@@ -103,11 +104,29 @@ def login(
         )
 
     # Resolve ECUBE roles for the user.
-    # Priority: 1) Explicit roles from DB ``user_roles`` table,
-    #            2) Roles derived from OS groups via the configured resolver.
+    # Local mode requires explicit DB ``user_roles`` assignments.
+    # LDAP mode falls back to resolver-derived roles from groups when no DB
+    # override exists.
     groups = pam.get_user_groups(body.username)
     db_roles = UserRoleRepository(db).get_roles(body.username)
-    roles = db_roles if db_roles else get_role_resolver().resolve(groups)
+    if settings.role_resolver == "local":
+        roles = db_roles
+    else:
+        roles = db_roles if db_roles else get_role_resolver().resolve(groups)
+
+    if not roles:
+        best_effort_audit(
+            db,
+            "AUTH_FAILURE",
+            body.username,
+            {
+                "reason": "No ECUBE roles assigned",
+                "path": str(request.url.path),
+                "groups": groups,
+            },
+            client_ip=get_client_ip(request),
+        )
+        raise AuthorizationError("User is not assigned any ECUBE roles")
 
     # Build JWT payload
     now = datetime.now(timezone.utc)

--- a/app/routers/setup.py
+++ b/app/routers/setup.py
@@ -445,7 +445,13 @@ def _run_os_setup(
 ) -> tuple[list[str], Literal["created_admin_user", "reconciled_existing_user"]]:
     """Execute OS-level setup: create groups and the admin user.
 
-    Returns the list of groups created.
+    Returns a tuple ``(groups_created, setup_status)`` where:
+
+    - ``groups_created`` is the list of ECUBE OS groups created.
+    - ``setup_status`` is ``"created_admin_user"`` when a new OS admin user
+      is created, or ``"reconciled_existing_user"`` when an existing OS user
+      is reconciled (added to ``ecube-admins`` and password reset).
+
     Raises :class:`HTTPException` on failure.
     """
     provider = get_os_user_provider()

--- a/app/routers/setup.py
+++ b/app/routers/setup.py
@@ -477,7 +477,7 @@ def _run_os_setup(
         raise HTTPException(status_code=422, detail=str(exc))
     except OSUserError as exc:
         # User may already exist (e.g. re-running setup after partial failure).
-        if "already exists" not in exc.message:
+        if "already exists" not in exc.message.lower():
             raise HTTPException(
                 status_code=500,
                 detail=f"Failed to create admin user: {exc.message}",

--- a/app/routers/setup.py
+++ b/app/routers/setup.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 import threading
 from datetime import datetime, timezone
+from typing import Literal
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -323,7 +324,7 @@ def _do_initialize(
     # From here on, this worker owns initialization.  If OS operations fail,
     # we must remove the lock row so that setup can be retried.
     try:
-        groups_created = _run_os_setup(body)
+        groups_created, setup_status = _run_os_setup(body)
     except HTTPException as exc:
         if not _release_init_lock(db):
             exc.detail += _LOCK_STUCK_SUFFIX
@@ -386,14 +387,23 @@ def _do_initialize(
             details={
                 "groups_created": groups_created,
                 "admin_user": body.username,
+                "setup_status": setup_status,
             },
             client_ip=client_ip,
         )
     except Exception:
         logger.error("Failed to write audit log for SYSTEM_INITIALIZED")
 
+    message = "Setup complete"
+    if setup_status == "reconciled_existing_user":
+        message = (
+            "Setup complete. Existing OS admin user was reconciled, "
+            "added to ecube-admins, and synced to ECUBE as an admin."
+        )
+
     return SetupInitializeResponse(
-        message="Setup complete",
+        status=setup_status,
+        message=message,
         username=body.username,
         groups_created=groups_created,
     )
@@ -432,7 +442,7 @@ def _release_init_lock(db: Session) -> bool:
 
 def _run_os_setup(
     body: SetupInitializeRequest,
-) -> list[str]:
+) -> tuple[list[str], Literal["created_admin_user", "reconciled_existing_user"]]:
     """Execute OS-level setup: create groups and the admin user.
 
     Returns the list of groups created.
@@ -456,6 +466,7 @@ def _run_os_setup(
             password=body.password,
             groups=["ecube-admins"],
         )
+        setup_status: Literal["created_admin_user", "reconciled_existing_user"] = "created_admin_user"
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
     except OSUserError as exc:
@@ -485,5 +496,6 @@ def _run_os_setup(
                 status_code=500,
                 detail=f"User exists but failed to reset password: {pw_exc}",
             )
+        setup_status = "reconciled_existing_user"
 
-    return groups_created
+    return groups_created, setup_status

--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -308,6 +308,10 @@ class SetupInitializeRequest(BaseModel):
 class SetupInitializeResponse(BaseModel):
     """Response for ``POST /setup/initialize``."""
 
+    status: Literal["created_admin_user", "reconciled_existing_user"] = Field(
+        ...,
+        description="Initialization outcome indicating whether the admin OS user was created or reconciled",
+    )
     message: str
     username: str
     groups_created: List[str] = Field(default_factory=list)

--- a/docs/operations/13-user-manual.md
+++ b/docs/operations/13-user-manual.md
@@ -4,7 +4,7 @@
 |---|---|
 | Title | ECUBE User Manual |
 | Purpose | Guides end users, processors, managers, and auditors through day-to-day ECUBE workflows and operational tasks. |
-| Updated on | 04/08/26 |
+| Updated on | 04/09/26 |
 | Audience | Processors, managers, auditors, administrators, end users. |
 
 ## Table of Contents
@@ -173,6 +173,13 @@ The setup wizard walks through:
 2. Provisioning the application database
 3. Creating the first administrative account
 4. Completing setup and returning to login
+
+Important first-run behavior:
+
+- If the admin username entered in setup does not yet exist on the host, ECUBE creates that OS user, adds it to `ecube-admins`, and grants the ECUBE `admin` role.
+- If the admin username already exists on the host, ECUBE treats that as a reconciliation path instead of an error. The wizard adds the existing OS user to `ecube-admins`, syncs the ECUBE `admin` role, resets the password entered in the wizard, and then completes setup successfully.
+- In the existing-user path, the setup screen shows an informational success message indicating that the existing OS admin user was reconciled.
+- After either path completes, return to the login page and sign in with the username and password entered during setup.
 
 If you are not responsible for installation, stop here and contact the administrator who owns the deployment.
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -249,6 +249,7 @@
     "provisionAlready": "Database is already provisioned. Continuing with existing schema.",
     "createAdmin": "Create Admin User",
     "adminCreated": "Admin user created successfully. Continue to the next step.",
+    "adminReconciled": "Existing OS admin user reconciled successfully. Continue to the next step.",
     "completeTitle": "Setup Complete",
     "completeBody": "System initialization has completed successfully.",
     "goToLogin": "Go to Login",

--- a/frontend/src/views/SetupWizardView.vue
+++ b/frontend/src/views/SetupWizardView.vue
@@ -21,6 +21,7 @@ const busy = ref(false)
 const error = ref('')
 const complete = ref(false)
 const provisionNote = ref('')
+const setupSuccessMessage = ref('')
 
 const db = ref({
   host: 'localhost',
@@ -146,10 +147,17 @@ async function runInitializeSetup() {
   busy.value = true
   error.value = ''
   try {
-    await initializeSetup({
+    const response = await initializeSetup({
       username: admin.value.username,
       password: admin.value.password,
     })
+    if (typeof response?.message === 'string' && response.message.trim()) {
+      setupSuccessMessage.value = response.message
+    } else if (response?.status === 'reconciled_existing_user') {
+      setupSuccessMessage.value = t('setup.adminReconciled')
+    } else {
+      setupSuccessMessage.value = t('setup.adminCreated')
+    }
     complete.value = true
   } catch (err) {
     if (err?.response?.status === 401) {
@@ -262,7 +270,7 @@ onMounted(async () => {
         <button class="btn" :disabled="busy || !step3Valid() || complete" @click="runInitializeSetup">
           {{ t('setup.createAdmin') }}
         </button>
-        <p v-if="complete" class="ok-text">{{ t('setup.adminCreated') }}</p>
+        <p v-if="complete" class="ok-text">{{ setupSuccessMessage || t('setup.adminCreated') }}</p>
       </div>
 
       <div v-else class="step-grid">

--- a/frontend/src/views/__tests__/SetupWizardView.spec.js
+++ b/frontend/src/views/__tests__/SetupWizardView.spec.js
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import i18n from '@/i18n/index.js'
+import SetupWizardView from '@/views/SetupWizardView.vue'
+
+const mocks = vi.hoisted(() => ({
+  replace: vi.fn(),
+  push: vi.fn(),
+  authStore: {
+    isAuthenticated: false,
+  },
+  getSetupStatus: vi.fn(),
+  getDatabaseProvisionStatus: vi.fn(),
+  getSystemInfo: vi.fn(),
+  connectDatabase: vi.fn(),
+  provisionDatabase: vi.fn(),
+  initializeSetup: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    replace: mocks.replace,
+    push: mocks.push,
+  }),
+}))
+
+vi.mock('@/stores/auth.js', () => ({
+  useAuthStore: () => mocks.authStore,
+}))
+
+vi.mock('@/api/setup.js', () => ({
+  getSetupStatus: (...args) => mocks.getSetupStatus(...args),
+  getDatabaseProvisionStatus: (...args) => mocks.getDatabaseProvisionStatus(...args),
+  getSystemInfo: (...args) => mocks.getSystemInfo(...args),
+  connectDatabase: (...args) => mocks.connectDatabase(...args),
+  provisionDatabase: (...args) => mocks.provisionDatabase(...args),
+  initializeSetup: (...args) => mocks.initializeSetup(...args),
+}))
+
+async function flushPromises() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function mountView() {
+  return mount(SetupWizardView, {
+    global: {
+      plugins: [i18n],
+    },
+  })
+}
+
+describe('SetupWizardView existing admin reconciliation', () => {
+  beforeEach(() => {
+    mocks.replace.mockReset()
+    mocks.push.mockReset()
+    mocks.authStore.isAuthenticated = false
+    mocks.getSetupStatus.mockReset()
+    mocks.getDatabaseProvisionStatus.mockReset()
+    mocks.getSystemInfo.mockReset()
+    mocks.connectDatabase.mockReset()
+    mocks.provisionDatabase.mockReset()
+    mocks.initializeSetup.mockReset()
+
+    mocks.getSystemInfo.mockResolvedValue({
+      in_docker: false,
+    })
+    mocks.getSetupStatus.mockResolvedValue({ initialized: false })
+    mocks.getDatabaseProvisionStatus.mockResolvedValue({ provisioned: false })
+    mocks.connectDatabase.mockResolvedValue({})
+    mocks.provisionDatabase.mockResolvedValue({})
+  })
+
+  it('shows reconciliation success text when setup syncs an existing OS admin user', async () => {
+    mocks.initializeSetup.mockResolvedValue({
+      status: 'reconciled_existing_user',
+      message: 'Setup complete. Existing OS admin user was reconciled, added to ecube-admins, and synced to ECUBE as an admin.',
+      username: 'admin',
+      groups_created: [],
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('#db-admin-pass').setValue('DbAdmin#123')
+    await wrapper.findAll('button').find((node) => node.text() === i18n.global.t('setup.connectDatabase')).trigger('click')
+    await flushPromises()
+
+    await wrapper.findAll('button').find((node) => node.text() === i18n.global.t('common.actions.next')).trigger('click')
+    await flushPromises()
+
+    await wrapper.find('#app-db-pass').setValue('AppDb#123')
+    await wrapper.findAll('button').find((node) => node.text() === i18n.global.t('setup.provisionDb')).trigger('click')
+    await flushPromises()
+
+    await wrapper.findAll('button').find((node) => node.text() === i18n.global.t('common.actions.next')).trigger('click')
+    await flushPromises()
+
+    await wrapper.find('#admin-password').setValue('Admin#123')
+    await wrapper.findAll('button').find((node) => node.text() === i18n.global.t('setup.createAdmin')).trigger('click')
+    await flushPromises()
+
+    expect(mocks.initializeSetup).toHaveBeenCalledWith({
+      username: 'admin',
+      password: 'Admin#123',
+    })
+    expect(wrapper.text()).toContain('Existing OS admin user was reconciled')
+    expect(wrapper.text()).not.toContain(i18n.global.t('setup.adminCreated'))
+  })
+})

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -111,6 +111,49 @@ def test_login_without_roles_returns_403(unauthenticated_client):
     assert "not assigned any ecube roles" in body["message"].lower()
 
 
+def test_login_local_mode_uses_group_mapping_when_db_roles_missing(unauthenticated_client):
+    mock_pam = MagicMock()
+    mock_pam.authenticate.return_value = True
+    mock_pam.get_user_groups.return_value = ["ecube-processors"]
+    fastapi_app.dependency_overrides[_get_pam] = lambda: mock_pam
+
+    with patch.object(settings, "role_resolver", "local"), patch(
+        "app.routers.auth.get_role_resolver",
+    ) as mock_resolver_fn:
+        mock_resolver_fn.return_value.resolve.return_value = ["processor"]
+
+        resp = unauthenticated_client.post(
+            "/auth/token",
+            json={"username": "mappedlocal", "password": "secret"},
+        )
+
+    assert resp.status_code == 200
+    claims = _decode_token(resp.json()["access_token"])
+    assert claims["roles"] == ["processor"]
+
+
+def test_login_db_roles_override_resolver_mapping(unauthenticated_client, db):
+    db.add(UserRole(username="dboverride", role="auditor"))
+    db.commit()
+
+    mock_pam = MagicMock()
+    mock_pam.authenticate.return_value = True
+    mock_pam.get_user_groups.return_value = ["ecube-admins"]
+    fastapi_app.dependency_overrides[_get_pam] = lambda: mock_pam
+
+    with patch("app.routers.auth.get_role_resolver") as mock_resolver_fn:
+        mock_resolver_fn.return_value.resolve.return_value = ["admin"]
+
+        resp = unauthenticated_client.post(
+            "/auth/token",
+            json={"username": "dboverride", "password": "secret"},
+        )
+
+    assert resp.status_code == 200
+    claims = _decode_token(resp.json()["access_token"])
+    assert claims["roles"] == ["auditor"]
+
+
 def test_login_missing_username_returns_422(unauthenticated_client):
     mock_pam = MagicMock()
     fastapi_app.dependency_overrides[_get_pam] = lambda: mock_pam

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -9,6 +9,7 @@ import pytest
 
 from app.config import settings
 from app.main import app as fastapi_app
+from app.models.users import UserRole
 from app.routers.auth import _get_pam
 
 
@@ -25,19 +26,19 @@ def _decode_token(token: str) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def test_login_success_returns_token(unauthenticated_client):
+def test_login_success_returns_token(unauthenticated_client, db):
     """Valid credentials yield a JWT with expected claims."""
+    db.add(UserRole(username="testuser", role="processor"))
+    db.commit()
+
     mock_pam = MagicMock()
     mock_pam.authenticate.return_value = True
     mock_pam.get_user_groups.return_value = ["evidence-team", "users"]
     fastapi_app.dependency_overrides[_get_pam] = lambda: mock_pam
-    with patch("app.routers.auth.get_role_resolver") as mock_resolver_fn:
-        mock_resolver_fn.return_value.resolve.return_value = ["processor"]
-
-        resp = unauthenticated_client.post(
-            "/auth/token",
-            json={"username": "testuser", "password": "secret"},
-        )
+    resp = unauthenticated_client.post(
+        "/auth/token",
+        json={"username": "testuser", "password": "secret"},
+    )
 
     assert resp.status_code == 200
     data = resp.json()
@@ -53,19 +54,19 @@ def test_login_success_returns_token(unauthenticated_client):
     assert "iat" in claims
 
 
-def test_login_success_token_is_usable(unauthenticated_client):
+def test_login_success_token_is_usable(unauthenticated_client, db):
     """A token obtained from /auth/token can authenticate subsequent requests."""
+    db.add(UserRole(username="admin-user", role="admin"))
+    db.commit()
+
     mock_pam = MagicMock()
     mock_pam.authenticate.return_value = True
     mock_pam.get_user_groups.return_value = ["admins"]
     fastapi_app.dependency_overrides[_get_pam] = lambda: mock_pam
-    with patch("app.routers.auth.get_role_resolver") as mock_resolver_fn:
-        mock_resolver_fn.return_value.resolve.return_value = ["admin"]
-
-        resp = unauthenticated_client.post(
-            "/auth/token",
-            json={"username": "admin-user", "password": "pass"},
-        )
+    resp = unauthenticated_client.post(
+        "/auth/token",
+        json={"username": "admin-user", "password": "pass"},
+    )
 
     token = resp.json()["access_token"]
     # Use the token to call an authenticated endpoint (e.g. /health is open,
@@ -91,6 +92,23 @@ def test_login_invalid_credentials_returns_401(unauthenticated_client):
 
     assert resp.status_code == 401
     assert "invalid" in resp.json()["message"].lower()
+
+
+def test_login_without_roles_returns_403(unauthenticated_client):
+    mock_pam = MagicMock()
+    mock_pam.authenticate.return_value = True
+    mock_pam.get_user_groups.return_value = ["ecube-processors"]
+    fastapi_app.dependency_overrides[_get_pam] = lambda: mock_pam
+
+    resp = unauthenticated_client.post(
+        "/auth/token",
+        json={"username": "norole", "password": "secret"},
+    )
+
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["code"] == "FORBIDDEN"
+    assert "not assigned any ecube roles" in body["message"].lower()
 
 
 def test_login_missing_username_returns_422(unauthenticated_client):
@@ -154,21 +172,21 @@ def test_login_empty_password_returns_422(unauthenticated_client):
 # ---------------------------------------------------------------------------
 
 
-def test_token_expiration_uses_config(unauthenticated_client, monkeypatch):
+def test_token_expiration_uses_config(unauthenticated_client, monkeypatch, db):
     """Token exp claim reflects TOKEN_EXPIRE_MINUTES setting."""
     monkeypatch.setattr(settings, "token_expire_minutes", 30)
+
+    db.add(UserRole(username="testuser", role="processor"))
+    db.commit()
 
     mock_pam = MagicMock()
     mock_pam.authenticate.return_value = True
     mock_pam.get_user_groups.return_value = []
     fastapi_app.dependency_overrides[_get_pam] = lambda: mock_pam
-    with patch("app.routers.auth.get_role_resolver") as mock_resolver_fn:
-        mock_resolver_fn.return_value.resolve.return_value = []
-
-        resp = unauthenticated_client.post(
-            "/auth/token",
-            json={"username": "testuser", "password": "secret"},
-        )
+    resp = unauthenticated_client.post(
+        "/auth/token",
+        json={"username": "testuser", "password": "secret"},
+    )
 
     claims = _decode_token(resp.json()["access_token"])
     # exp should be approximately 30 minutes from iat
@@ -185,17 +203,17 @@ def test_login_success_creates_audit_log(unauthenticated_client, db):
     """Successful login writes AUTH_SUCCESS to audit_logs."""
     from app.models.audit import AuditLog
 
+    db.add(UserRole(username="testuser", role="processor"))
+    db.commit()
+
     mock_pam = MagicMock()
     mock_pam.authenticate.return_value = True
     mock_pam.get_user_groups.return_value = ["evidence-team"]
     fastapi_app.dependency_overrides[_get_pam] = lambda: mock_pam
-    with patch("app.routers.auth.get_role_resolver") as mock_resolver_fn:
-        mock_resolver_fn.return_value.resolve.return_value = ["processor"]
-
-        unauthenticated_client.post(
-            "/auth/token",
-            json={"username": "testuser", "password": "secret"},
-        )
+    unauthenticated_client.post(
+        "/auth/token",
+        json={"username": "testuser", "password": "secret"},
+    )
 
     logs = db.query(AuditLog).filter(AuditLog.action == "AUTH_SUCCESS").all()
     assert len(logs) == 1
@@ -229,19 +247,19 @@ def test_login_failure_creates_audit_log(unauthenticated_client, db):
 # ---------------------------------------------------------------------------
 
 
-def test_auth_token_endpoint_requires_no_auth(unauthenticated_client):
+def test_auth_token_endpoint_requires_no_auth(unauthenticated_client, db):
     """The /auth/token endpoint must be accessible without a bearer token."""
+    db.add(UserRole(username="noauth", role="processor"))
+    db.commit()
+
     mock_pam = MagicMock()
     mock_pam.authenticate.return_value = True
     mock_pam.get_user_groups.return_value = []
     fastapi_app.dependency_overrides[_get_pam] = lambda: mock_pam
-    with patch("app.routers.auth.get_role_resolver") as mock_resolver_fn:
-        mock_resolver_fn.return_value.resolve.return_value = []
-
-        resp = unauthenticated_client.post(
-            "/auth/token",
-            json={"username": "noauth", "password": "test"},
-        )
+    resp = unauthenticated_client.post(
+        "/auth/token",
+        json={"username": "noauth", "password": "test"},
+    )
 
     assert resp.status_code == 200
 

--- a/tests/test_os_user_management.py
+++ b/tests/test_os_user_management.py
@@ -1706,6 +1706,29 @@ class TestSetupEndpoints:
         data = resp.json()
         assert data["status"] == "reconciled_existing_user"
 
+    @patch("app.routers.setup.get_os_user_provider")
+    def test_run_os_setup_existing_user_match_is_case_insensitive(self, mock_get_provider):
+        from app.routers.setup import _run_os_setup
+        from app.schemas.admin import SetupInitializeRequest
+
+        provider = MagicMock()
+        provider.ensure_ecube_groups.return_value = ["ecube-admins"]
+        provider.create_user.side_effect = OSUserError("User ALREADY EXISTS")
+        mock_get_provider.return_value = provider
+
+        groups_created, status = _run_os_setup(
+            SetupInitializeRequest(username="admin1", password="s3cret"),
+        )
+
+        assert groups_created == ["ecube-admins"]
+        assert status == "reconciled_existing_user"
+        provider.add_user_to_groups.assert_called_once_with(
+            "admin1", ["ecube-admins"], _skip_managed_check=True,
+        )
+        provider.reset_password.assert_called_once_with(
+            "admin1", "s3cret", _skip_managed_check=True,
+        )
+
     @patch("app.services.os_user_service.subprocess.run")
     @patch("app.services.os_user_service.grp")
     @patch("app.services.os_user_service.pwd")

--- a/tests/test_os_user_management.py
+++ b/tests/test_os_user_management.py
@@ -1476,6 +1476,7 @@ class TestSetupEndpoints:
         ) as mock_migrate, patch(
             "app.routers.setup._do_initialize",
             return_value={
+                "status": "created_admin_user",
                 "message": "Setup complete",
                 "username": "admin1",
                 "groups_created": [],
@@ -1540,6 +1541,7 @@ class TestSetupEndpoints:
         })
         assert resp.status_code == 200
         data = resp.json()
+        assert data["status"] == "created_admin_user"
         assert data["message"] == "Setup complete"
         assert data["username"] == "admin1"
         assert isinstance(data["groups_created"], list)
@@ -1659,8 +1661,13 @@ class TestSetupEndpoints:
         assert len(chpasswd_calls) >= 1
         # Verify groups_created is reported.
         data = resp.json()
+        assert data["status"] == "reconciled_existing_user"
+        assert "existing os admin user was reconciled" in data["message"].lower()
         assert isinstance(data["groups_created"], list)
         assert len(data["groups_created"]) == 4
+
+        repo = UserRoleRepository(db)
+        assert "admin" in repo.get_roles("admin1")
 
     @patch("app.services.os_user_service.subprocess.run")
     @patch("app.services.os_user_service.grp")
@@ -1696,6 +1703,8 @@ class TestSetupEndpoints:
             "password": "s3cret",
         })
         assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "reconciled_existing_user"
 
     @patch("app.services.os_user_service.subprocess.run")
     @patch("app.services.os_user_service.grp")


### PR DESCRIPTION
Completes issue #164 by turning setup initialization for an already-existing OS admin user into a successful reconciliation flow instead of a fatal error.

When the setup wizard is given an admin username that already exists on the host, the backend now treats that as a recoverable/idempotent path: it adds the user to `ecube-admins`, resets the password, preserves/syncs the `admin` role in ECUBE, and returns a successful response that explicitly identifies the outcome as an existing-user reconciliation. The setup audit record now also captures whether initialization created a new admin user or reconciled an existing one.

On the frontend, the setup wizard now uses the initialization response message so it can show the correct success copy for reconciled existing users rather than always claiming a new admin account was created. This closes the UX gap from the original issue.

**Changes**
- Added an explicit setup initialization outcome to distinguish:
  - `created_admin_user`
  - `reconciled_existing_user`
- Updated setup initialization to return a reconciliation-specific success message when the OS admin user already exists.
- Recorded the initialization outcome in setup audit details.
- Updated setup wizard success handling to display the API-provided reconciliation message.
- Added backend coverage for both created-user and reconciled-existing-user setup outcomes.
- Added a frontend regression test proving the wizard shows reconciliation success text for the existing-admin path.

**Behavior After This Change**
- Existing OS admin user no longer causes setup failure.
- Existing OS admin user is synced into ECUBE with the `admin` role.
- Existing OS admin user is added to `ecube-admins`.
- Setup completes successfully and the user can proceed to login with the configured credentials.
- The UI shows an informational success message for reconciliation instead of a generic creation message.

**Validation**
- Focused backend setup tests passed.
- Focused frontend setup wizard test passed.