### PR TITLE
Refactor drive state management: remove FINALIZED state and update related proceduresmmar

### DIFF
--- a/docs/design/04-functional-design.md
+++ b/docs/design/04-functional-design.md
@@ -23,7 +23,7 @@ Recommended legal transitions:
 
 - `EMPTY → AVAILABLE` on discovery of a usable drive.
 - `AVAILABLE → IN_USE` on initialize or job assignment.
-- `IN_USE → AVAILABLE` on finalize.
+- `IN_USE → AVAILABLE` on prepare-eject.
 - `AVAILABLE → EMPTY` on removal or disabled-port reconciliation.
 
 Illegal transitions should be rejected with `409 Conflict`.
@@ -57,7 +57,7 @@ Illegal transitions should be rejected with `409 Conflict`.
   - Formatting commands run with bounded timeouts.
   - Only `admin` and `manager` roles may format drives.
 
-## 4.2 Drive Finalize Procedure
+## 4.2 Drive Prepare-Eject Procedure
 
 - **Precondition:** Drive must be in `IN_USE` state; reject with 409 if not
 - **Initial validation:** Capture drive state and filesystem path at request start
@@ -81,15 +81,15 @@ Illegal transitions should be rejected with `409 Conflict`.
   - This ensures audit trail records the device path actually used for OS operations
 - Failure handling: If any operation fails, keep drive `IN_USE` and audit the failure with details
 - Success: Transition drive to `AVAILABLE` only after all operations succeed
-- No-op case: If device is not currently mounted, consider finalize successful (return success)
+- No-op case: If device is not currently mounted, consider prepare-eject successful (return success)
 
-### 4.2.1 Finalize Semantics
+### 4.2.1 Prepare-Eject Semantics
 
-- `POST /drives/{drive_id}/finalize` is the safe-removal endpoint.
+- `POST /drives/{drive_id}/prepare-eject` is the safe-removal endpoint.
 - It flushes pending writes, unmounts all partitions, and transitions the drive from `IN_USE` to `AVAILABLE`.
 - It does **not** imply legal handoff, write protection, or export completion.
-- It does **not** clear `current_project_id`; the drive remains bound to its project after finalization.
-- After finalize, the drive is immediately reusable within the current workflow and can be assigned back to `IN_USE` under existing project-isolation rules.
+- It does **not** clear `current_project_id`; the drive remains bound to its project after prepare-eject.
+- After prepare-eject, the drive is immediately reusable within the current workflow and can be assigned back to `IN_USE` under existing project-isolation rules.
 
 ## 4.3 Project Isolation Design
 

--- a/docs/design/04-functional-design.md
+++ b/docs/design/04-functional-design.md
@@ -11,24 +11,19 @@
 
 - Implement a finite-state machine for drive states and legal transitions.
 - Gate all transitions through a single service module to ensure consistency.
-- The recommended persisted drive states are `EMPTY`, `AVAILABLE`, `IN_USE`, and `FINALIZED`.
-- `FINALIZED` is distinct from `AVAILABLE`: it represents a drive that has completed export handling and is logically sealed against further writes until an explicit reopen action is performed.
+- The recommended persisted drive states are `EMPTY`, `AVAILABLE`, and `IN_USE`.
 
 ### 4.1.0 Recommended Drive State Semantics
 
 - `EMPTY` — drive record exists but hardware is not presently available for use.
 - `AVAILABLE` — drive is present, writable, and eligible for initialization or job assignment.
 - `IN_USE` — drive is actively assigned to a project/job workflow and may receive data writes.
-- `FINALIZED` — drive has been explicitly finalized for handoff/custody; it remains project-bound but is not eligible for new writes, auto-assignment, or reinitialization until reopened.
 
 Recommended legal transitions:
 
 - `EMPTY → AVAILABLE` on discovery of a usable drive.
 - `AVAILABLE → IN_USE` on initialize or job assignment.
-- `IN_USE → AVAILABLE` on prepare-eject.
-- `IN_USE → FINALIZED` on finalize.
-- `AVAILABLE → FINALIZED` on finalize when the drive was already safely prepared and no additional OS-level unmount work is needed.
-- `FINALIZED → AVAILABLE` on explicit reopen/unfinalize.
+- `IN_USE → AVAILABLE` on finalize.
 - `AVAILABLE → EMPTY` on removal or disabled-port reconciliation.
 
 Illegal transitions should be rejected with `409 Conflict`.
@@ -62,7 +57,7 @@ Illegal transitions should be rejected with `409 Conflict`.
   - Formatting commands run with bounded timeouts.
   - Only `admin` and `manager` roles may format drives.
 
-## 4.2 Drive Prepare-Eject Procedure
+## 4.2 Drive Finalize Procedure
 
 - **Precondition:** Drive must be in `IN_USE` state; reject with 409 if not
 - **Initial validation:** Capture drive state and filesystem path at request start
@@ -86,62 +81,15 @@ Illegal transitions should be rejected with `409 Conflict`.
   - This ensures audit trail records the device path actually used for OS operations
 - Failure handling: If any operation fails, keep drive `IN_USE` and audit the failure with details
 - Success: Transition drive to `AVAILABLE` only after all operations succeed
-- No-op case: If device is not currently mounted, consider it successfully prepared (return success)
+- No-op case: If device is not currently mounted, consider finalize successful (return success)
 
-### 4.2.1 Relationship Between Prepare-Eject and Finalize
+### 4.2.1 Finalize Semantics
 
-- `prepare-eject` remains the operational safe-removal endpoint.
+- `POST /drives/{drive_id}/finalize` is the safe-removal endpoint.
+- It flushes pending writes, unmounts all partitions, and transitions the drive from `IN_USE` to `AVAILABLE`.
 - It does **not** imply legal handoff, write protection, or export completion.
-- It does **not** clear `current_project_id`; the drive remains bound to its project after prepare-eject.
-- A prepare-ejected drive remains reusable within the current workflow and can later be assigned back to `IN_USE` under existing project-isolation rules.
-- Finalization, if implemented, must be a separate endpoint and separate persisted state, not an alias for prepare-eject.
-
-### 4.2.2 Drive Finalization Design
-
-- Provide an API endpoint (`POST /drives/{drive_id}/finalize`) to mark a drive as export-complete and logically sealed.
-- Finalization is exposed as an explicit sealed-state transition after copy-oriented work is complete.
-- Recommended allowed starting states:
-  - `IN_USE` — perform safe-eject operations as part of finalization, then transition to `FINALIZED`.
-  - `AVAILABLE` — permit finalization if the drive is already safely unmounted/prepared and remains project-bound to the intended export.
-- Recommended preconditions:
-  - Drive must be bound to a project (`current_project_id` is not `NULL`).
-  - No active copy/verify/manifest job may still be operating against the drive.
-  - If a job is associated with the drive, it should be in a terminal successful state before finalization is accepted.
-  - If manifest completion is part of the deployment policy, manifest generation should already be complete.
-- Finalization procedure:
-  1. Validate state and project binding.
-  2. Validate no active job is still using the drive.
-  3. If state is `IN_USE`, reuse prepare-eject OS behavior (sync + unmount + race validation).
-  4. Transition drive state to `FINALIZED`.
-  5. Persist finalization metadata (`finalized_at`, `finalized_by`, and optional operator note/reason).
-  6. Emit a dedicated audit event such as `DRIVE_FINALIZED`.
-- Finalization effects:
-  - Finalized drives must not be eligible for new job creation or auto-assignment.
-  - Finalized drives must not be reinitialized, formatted, or returned to `IN_USE` implicitly.
-  - Finalized drives remain associated with their existing `current_project_id` until explicitly reopened or reset.
-- Failure handling:
-  - If OS-level prepare-eject work fails, do not mark the drive finalized.
-  - If database persistence of finalization fails after OS work succeeded, return `500` and require operator review; state must not silently degrade to `AVAILABLE` without an audit trail.
-
-### 4.2.3 Drive Reopen / Unfinalize Design
-
-- Provide an API endpoint (`POST /drives/{drive_id}/reopen`) or equivalent to reverse finalization when additional data must be exported.
-- Reopen is intentionally explicit because it breaks the sealed-handoff assumption established by finalization.
-- Recommended preconditions:
-  - Drive must currently be in `FINALIZED` state.
-  - Caller must have elevated privileges (`admin`, or stricter if policy requires).
-  - Request body should include a mandatory human-readable reason.
-- Reopen procedure:
-  1. Validate the drive is `FINALIZED`.
-  2. Record the operator-supplied reason.
-  3. Transition drive state from `FINALIZED` to `AVAILABLE`.
-  4. Preserve `current_project_id` by default so additional exports remain constrained to the same case/project.
-  5. Emit a dedicated audit event such as `DRIVE_REOPENED` or `DRIVE_UNFINALIZED` containing actor, reason, prior finalization metadata, and drive/project identifiers.
-- Reopen effects:
-  - The drive becomes eligible for explicit reuse.
-  - Subsequent writes must still respect project isolation.
-  - Operators may then assign/start an additional job and later finalize the drive again.
-- Reopen must never happen implicitly as a side effect of discovery, job creation, or initialize.
+- It does **not** clear `current_project_id`; the drive remains bound to its project after finalization.
+- After finalize, the drive is immediately reusable within the current workflow and can be assigned back to `IN_USE` under existing project-isolation rules.
 
 ## 4.3 Project Isolation Design
 
@@ -173,9 +121,6 @@ The binding is persisted as part of the drive's authoritative state. A drive wit
 4. **Release** — The project binding persists until the drive is explicitly
    re-initialized for a different project or reset. Removing a drive
    physically does not clear its `current_project_id` in the database.
-5. **Finalization interaction** — Finalization does not clear project binding.
-  A finalized drive remains bound to its project but is write-ineligible
-  until explicitly reopened.
 
 ### Concurrency
 
@@ -284,13 +229,13 @@ The callback body is a JSON object containing:
 - Hub and port records are upserted using stable hardware identity keys.
 - **Hardware enrichment:** Discovery should capture vendor, product, and negotiated-speed metadata when available, without erasing previously known values with empty readings.
 - **Label preservation:** Admin-assigned hub and port labels are never overwritten by discovery.
-- Drive state transitions follow FSM rules: `EMPTY → AVAILABLE` on reconnection, `AVAILABLE → EMPTY` on removal (unless `IN_USE` or `FINALIZED` — project isolation and custody state are preserved).
+- Drive state transitions follow FSM rules: `EMPTY → AVAILABLE` on reconnection, `AVAILABLE → EMPTY` on removal (unless `IN_USE` — project isolation takes priority).
 - **Port enablement filtering:** Each USB port has an `enabled` flag (default `false`). Discovery uses this flag to gate drive availability:
   - A newly discovered drive on a **disabled** port is inserted in `EMPTY` state (not `AVAILABLE`).
   - A reconnecting drive (previously `EMPTY`) on a **disabled** port remains `EMPTY`.
   - An `AVAILABLE` drive whose port is subsequently **disabled** is demoted to `EMPTY` on the next discovery sync.
   - Drives with no associated port (`port_id = NULL`) are treated as **disabled** — they remain in `EMPTY` state.
-  - Drives already in `IN_USE` or `FINALIZED` state are **never** changed by the enablement filter — project isolation and custody state take priority.
+  - Drives already in `IN_USE` state are **never** changed by the enablement filter — project isolation takes priority.
   - Port enablement changes take effect on the next discovery sync.
 - Refresh operation is fully idempotent: running multiple times without hardware changes produces no mutations.
 - **Concurrency safety:** Discovery must remain idempotent under multi-worker execution and tolerate concurrent upsert attempts against the same hardware identities.

--- a/docs/operations/07-compliance-and-evidence-handling.md
+++ b/docs/operations/07-compliance-and-evidence-handling.md
@@ -386,8 +386,9 @@ After ECUBE completes a copy job, the destination USB drive should be write-prot
 2. Physically enable write-protection switch on the USB device (if available).
 3. Store in secure facility with access controls.
 
-**ECUBE Support (Future):**
-- An admin endpoint may be added to "finalize" a drive after copy, preventing further writes: `POST /drives/{drive_id}/finalize` (not yet implemented).
+**ECUBE Support:**
+- ECUBE provides a drive safe-removal endpoint (`POST /drives/{drive_id}/prepare-eject`) for safe removal (flush + unmount + return to available state).
+- Prepare-eject does **not** enforce write-protection or seal custody state; operational write-protection controls remain a physical and procedural responsibility.
 
 ### Evidence Segregation
 

--- a/docs/operations/07-compliance-and-evidence-handling.md
+++ b/docs/operations/07-compliance-and-evidence-handling.md
@@ -387,8 +387,8 @@ After ECUBE completes a copy job, the destination USB drive should be write-prot
 3. Store in secure facility with access controls.
 
 **ECUBE Support:**
-- ECUBE provides a drive safe-removal endpoint (`POST /drives/{drive_id}/prepare-eject`) for safe removal (flush + unmount + return to available state).
-- Prepare-eject does **not** enforce write-protection or seal custody state; operational write-protection controls remain a physical and procedural responsibility.
+- ECUBE provides a drive safe-removal endpoint (`POST /drives/{drive_id}/prepare-eject`) for safe removal (flush + unmount + transition back to `AVAILABLE`).
+- Prepare-eject does **not** enforce write-protection or seal custody state, and it does **not** clear `current_project_id`; project binding is preserved. Operational write-protection controls remain a physical and procedural responsibility.
 
 ### Evidence Segregation
 

--- a/docs/operations/15-dba-data-model-reference.md
+++ b/docs/operations/15-dba-data-model-reference.md
@@ -166,7 +166,7 @@ stateDiagram-v2
   [*] --> EMPTY
   EMPTY --> AVAILABLE: Discovery detects present drive
   AVAILABLE --> IN_USE: Initialize with project_id
-  IN_USE --> AVAILABLE: Prepare-eject/finalize
+  IN_USE --> AVAILABLE: Prepare-eject
   AVAILABLE --> EMPTY: Drive removed
   IN_USE --> IN_USE: Project isolation enforced
 ```

--- a/docs/requirements/04-functional-requirements.md
+++ b/docs/requirements/04-functional-requirements.md
@@ -201,7 +201,7 @@ Acceptance criteria:
 The system must emit audit records for security-relevant and operationally significant events, including at minimum:
 
 - Drive initialization.
-- Drive finalize (safe-removal) success and failure.
+- Drive prepare-eject (safe-removal) success and failure.
 - Job creation and job state changes.
 - Copy execution outcomes.
 - Manifest generation.

--- a/docs/requirements/04-functional-requirements.md
+++ b/docs/requirements/04-functional-requirements.md
@@ -83,9 +83,9 @@ Acceptance criteria:
 - An unsupported filesystem target is rejected.
 - Successful formatting changes the reported filesystem classification.
 
-### 4.2.3 Finalize Requirements
+### 4.2.3 Prepare-Eject (Safe Removal) Requirements
 
-Drive finalize behavior is the safe-removal capability. It must:
+Drive prepare-eject behavior is the safe-removal capability. It must:
 
 - Flush pending writes and unmount all partitions belonging to the device.
 - Transition the drive from `IN_USE` to `AVAILABLE`.
@@ -96,9 +96,9 @@ Drive finalize behavior is the safe-removal capability. It must:
 
 Acceptance criteria:
 
-- After a successful finalize, the drive is in `AVAILABLE` state and retains its `current_project_id`.
-- A finalize attempt on a drive not in `IN_USE` is rejected with an appropriate error.
-- All finalize attempts (successful and failed) are audit-logged.
+- After a successful prepare-eject, the drive is in `AVAILABLE` state and retains its `current_project_id`.
+- A prepare-eject attempt on a drive not in `IN_USE` is rejected with an appropriate error.
+- All prepare-eject attempts (successful and failed) are audit-logged.
 
 ## 4.3 Project Isolation Requirements
 

--- a/docs/requirements/04-functional-requirements.md
+++ b/docs/requirements/04-functional-requirements.md
@@ -39,8 +39,6 @@ ECUBE must:
 - Support operator-initiated formatting when policy and lifecycle state allow it.
 - Support drive initialization for a project-bound workflow.
 - Support safe operational removal of a drive without implying export completion.
-- Support explicit drive finalization when export handling is complete.
-- Support an explicitly audited reopen of a finalized drive when additional export work is required.
 - Preserve sufficient drive history to support audit and operational review.
 
 Managed drive states must include:
@@ -48,13 +46,11 @@ Managed drive states must include:
 - `EMPTY`
 - `AVAILABLE`
 - `IN_USE`
-- `FINALIZED`
 
 State constraints:
 
 - `AVAILABLE` means the drive is eligible for initialization or assignment.
 - `IN_USE` means the drive is actively participating in a write-capable workflow.
-- `FINALIZED` means the drive is logically sealed against further writes until explicitly reopened.
 - Illegal lifecycle transitions must be rejected.
 
 ### 4.2.1 Filesystem Detection Requirements
@@ -87,40 +83,22 @@ Acceptance criteria:
 - An unsupported filesystem target is rejected.
 - Successful formatting changes the reported filesystem classification.
 
-### 4.2.3 Prepare-Eject, Finalize, and Reopen Requirements
+### 4.2.3 Finalize Requirements
 
-ECUBE must distinguish operational safe removal from custody finalization.
+Drive finalize behavior is the safe-removal capability. It must:
 
-Prepare-eject requirements:
-
-- Safe-removal preparation must flush pending writes and leave the drive in a removable, non-writing state.
-- Safe-removal preparation must not imply export completion or write sealing.
-- Safe-removal preparation must not clear project binding.
-
-Finalization requirements:
-
-- Finalization must be a distinct capability from safe-removal preparation.
-- Finalization must transition the drive to `FINALIZED`.
-- Finalization must only be allowed for project-bound drives.
-- Finalization must be rejected while active work still depends on the drive.
-- If the drive is not already safely removable, finalization must include the behavior required to make it safely removable before the finalized state is committed.
-- Finalization must produce dedicated audit evidence including actor, drive, project, and finalization context.
-- Finalized drives must not become eligible for new writes, reinitialization, formatting, or implicit return to active use.
-
-Reopen requirements:
-
-- Reopen is only allowed from `FINALIZED`.
-- Reopen requires elevated privilege.
-- Reopen requires an explicit operator-provided reason.
-- Reopen returns the drive to an eligible non-finalized state without implicitly changing its project binding.
-- Reopen produces dedicated audit evidence including actor, reason, drive, and project context.
-- Reopen must never occur implicitly as a side effect of unrelated operations.
+- Flush pending writes and unmount all partitions belonging to the device.
+- Transition the drive from `IN_USE` to `AVAILABLE`.
+- Not imply export completion, write sealing, or custody transfer.
+- Not clear `current_project_id`; the drive remains bound to its project.
+- Emit an audit event recording the actor, drive, and outcome.
+- Reject the operation if the drive is not in `IN_USE` state.
 
 Acceptance criteria:
 
-- Safe-removal preparation and finalization remain behaviorally distinct.
-- A finalized drive cannot accept additional export work until explicitly reopened.
-- Reopen without a reason or sufficient privilege is rejected.
+- After a successful finalize, the drive is in `AVAILABLE` state and retains its `current_project_id`.
+- A finalize attempt on a drive not in `IN_USE` is rejected with an appropriate error.
+- All finalize attempts (successful and failed) are audit-logged.
 
 ## 4.3 Project Isolation Requirements
 
@@ -130,9 +108,7 @@ To prevent evidence contamination:
 - A drive must not accept writes for a different project than the one to which it is currently bound.
 - Cross-project write attempts must be blocked before data movement begins.
 - Each denial must produce audit evidence.
-- The active project association of in-use and finalized drives must remain visible to operators.
-- Finalization must not clear project binding.
-- A finalized drive must remain project-bound until explicitly reopened or reset by an authorized lifecycle action.
+- The active project association of in-use drives must remain visible to operators.
 
 Acceptance criteria:
 
@@ -154,8 +130,6 @@ ECUBE must support job workflows that include:
 Assignment constraints:
 
 - Only drives in an eligible writable state may be assigned to new work.
-- Finalized drives must be excluded from new assignment until explicitly reopened.
-- Additional export to a finalized drive must require an explicit reopen first.
 
 Acceptance criteria:
 
@@ -227,9 +201,7 @@ Acceptance criteria:
 The system must emit audit records for security-relevant and operationally significant events, including at minimum:
 
 - Drive initialization.
-- Drive safe-removal preparation success and failure.
-- Drive finalization.
-- Drive reopen or unfinalize.
+- Drive finalize (safe-removal) success and failure.
 - Job creation and job state changes.
 - Copy execution outcomes.
 - Manifest generation.
@@ -253,13 +225,10 @@ Discovery and refresh behavior must preserve protected drive states and policy g
 - Reconnected eligible drives may return to an available state when policy permits.
 - Removed drives may leave the available set when no longer present or when policy disables their port.
 - In-use drives must not be demoted by discovery while project isolation remains active.
-- Finalized drives must not be demoted or implicitly reopened by discovery or reconciliation.
-- A finalized drive that is removed and later reinserted must remain finalized until an explicit reopen occurs.
 
 Acceptance criteria:
 
 - Discovery refresh does not silently defeat project isolation.
-- Discovery refresh does not silently convert a finalized drive back into a writable drive.
 
 ## References
 

--- a/docs/requirements/05-data-model.md
+++ b/docs/requirements/05-data-model.md
@@ -71,17 +71,16 @@ Lifecycle requirements:
 
 - Drive state must change in ways that preserve an auditable lifecycle.
 - Project binding must persist across temporary removal and reinsertion unless an explicit reset or lifecycle transition changes it.
-- Finalized state, when present, must remain represented until an explicit reopen or equivalent authorized action occurs.
+- Finalize behavior must transition drive lifecycle state from `IN_USE` to `AVAILABLE` without clearing project binding.
 
 Constraints:
 
 - A drive cannot simultaneously represent mutually incompatible lifecycle meanings.
-- A drive represented as finalized cannot also be represented as eligible for ordinary writable reuse.
 - Filesystem classification must distinguish recognized media from unknown or unformatted media.
 
 Acceptance criteria:
 
-- Reviewers can determine from stored drive data whether the media is writable, in use, finalized, or absent.
+- Reviewers can determine from stored drive data whether the media is writable, in use, or absent.
 - Reviewers can determine whether a drive remains bound to a project after temporary removal.
 
 ## 5.4 Mount Representation Requirements

--- a/docs/requirements/05-data-model.md
+++ b/docs/requirements/05-data-model.md
@@ -71,7 +71,7 @@ Lifecycle requirements:
 
 - Drive state must change in ways that preserve an auditable lifecycle.
 - Project binding must persist across temporary removal and reinsertion unless an explicit reset or lifecycle transition changes it.
-- Finalize behavior must transition drive lifecycle state from `IN_USE` to `AVAILABLE` without clearing project binding.
+- Prepare-eject (safe removal) behavior must transition drive lifecycle state from `IN_USE` to `AVAILABLE` without clearing project binding.
 
 Constraints:
 

--- a/docs/requirements/06-rest-api-requirements.md
+++ b/docs/requirements/06-rest-api-requirements.md
@@ -152,13 +152,13 @@ Acceptance criteria:
 - The platform shall expose drive inventory and project-binding status.
 - Drive initialization shall enforce project isolation before any write-oriented workflow proceeds.
 - Drive formatting shall be restricted to valid lifecycle states and supported filesystem choices.
-- Drive finalize behavior shall flush and unmount relevant storage state before the drive is treated as removable.
+- Drive prepare-eject (safe removal) behavior shall flush and unmount relevant storage state before the drive is treated as removable.
 - Drive refresh and discovery capabilities shall preserve authoritative state where policy requires it and reconcile stale physical-state assumptions.
 
 Acceptance criteria:
 
 - A drive cannot be rebound across projects without the intended lifecycle transition.
-- An operator cannot finalize a drive from an invalid lifecycle state.
+- An operator cannot prepare-eject a drive from an invalid lifecycle state.
 - Discovery refresh does not silently defeat project isolation guarantees.
 
 ### 4.5 Job Lifecycle Management

--- a/docs/requirements/06-rest-api-requirements.md
+++ b/docs/requirements/06-rest-api-requirements.md
@@ -152,15 +152,14 @@ Acceptance criteria:
 - The platform shall expose drive inventory and project-binding status.
 - Drive initialization shall enforce project isolation before any write-oriented workflow proceeds.
 - Drive formatting shall be restricted to valid lifecycle states and supported filesystem choices.
-- Safe-eject preparation shall flush and unmount relevant storage state before the drive is treated as removable.
-- If finalized drive semantics are implemented, finalized state shall preserve chain-of-custody expectations and prevent reuse until explicitly reopened according to policy.
+- Drive finalize behavior shall flush and unmount relevant storage state before the drive is treated as removable.
 - Drive refresh and discovery capabilities shall preserve authoritative state where policy requires it and reconcile stale physical-state assumptions.
 
 Acceptance criteria:
 
 - A drive cannot be rebound across projects without the intended lifecycle transition.
-- An operator cannot prepare a drive for eject from an invalid lifecycle state.
-- Discovery refresh does not silently defeat project isolation or finalized-state guarantees.
+- An operator cannot finalize a drive from an invalid lifecycle state.
+- Discovery refresh does not silently defeat project isolation guarantees.
 
 ### 4.5 Job Lifecycle Management
 


### PR DESCRIPTION
## Summary
Implements issue #183. This PR aligns requirements and design documentation with the current product decision that custody-sealing is out of scope, and that drive safe-removal is an operational lifecycle action rather than a separate `FINALIZED` state workflow.

## Why
Docs had conflicting narratives:
- Some sections described a `FINALIZED` state and reopen/unfinalize flow.
- Other sections (and implementation behavior) treat drive offboarding as safe removal.
- This mismatch made requirements misleading for implementers and reviewers.

## What changed
- Removed `FINALIZED`/reopen semantics from core lifecycle requirements and data-model expectations.
- Reframed drive finalization language as safe-removal behavior (`IN_USE -> AVAILABLE`, project binding preserved, no custody sealing).
- Updated acceptance criteria and constraints so they no longer require reopen/finalized-state behavior.
- Updated compliance wording to avoid claiming finalize enforces write-protection/custody sealing.
- Corrected operations/compliance endpoint wording to reflect current implementation endpoint naming (`prepare-eject`).

## Files updated
- 04-functional-requirements.md
- 04-functional-design.md
- 05-data-model.md
- 06-rest-api-requirements.md
- 07-compliance-and-evidence-handling.md

## Scope
- Documentation only.
- No application logic, database schema, or migration changes in this PR.

## Validation
- Verified removal of stale `FINALIZED`/reopen terminology in updated requirements/design/data-model sections.
- Verified compliance text now states safe-removal semantics and no longer claims custody sealing.

## Notes
- Current implementation route remains `POST /drives/{drive_id}/prepare-eject` in drives.py.
