### PR TITLE
normalize mounted drives on discovery and improve eject/logging behavior

### DIFF
--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -126,6 +126,9 @@ class JsonFormatter(logging.Formatter):
 
 _TEXT_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
 
+# Sentinel used to distinguish "argument omitted" from an explicit None.
+_UNSET = object()
+
 
 class TextFormatter(logging.Formatter):
     """Human-readable log format with timestamp, level, module, and message."""
@@ -143,9 +146,9 @@ def configure_logging(
     *,
     level: Optional[str] = None,
     log_format: Optional[str] = None,
-    log_file: Optional[str] = None,
-    log_file_max_bytes: Optional[int] = None,
-    log_file_backup_count: Optional[int] = None,
+    log_file: Optional[str] | object = _UNSET,
+    log_file_max_bytes: Optional[int] | object = _UNSET,
+    log_file_backup_count: Optional[int] | object = _UNSET,
 ) -> None:
     """Initialise the root logger with the configured handlers/formatters.
 
@@ -154,10 +157,12 @@ def configure_logging(
     """
     effective_level = (level or settings.log_level).upper()
     effective_format = log_format or settings.log_format
-    effective_file = log_file if log_file is not None else settings.log_file
-    effective_max_bytes = log_file_max_bytes if log_file_max_bytes is not None else settings.log_file_max_bytes
+    effective_file = settings.log_file if log_file is _UNSET else log_file
+    effective_max_bytes = (
+        settings.log_file_max_bytes if log_file_max_bytes is _UNSET else log_file_max_bytes
+    )
     effective_backup_count = (
-        log_file_backup_count if log_file_backup_count is not None else settings.log_file_backup_count
+        settings.log_file_backup_count if log_file_backup_count is _UNSET else log_file_backup_count
     )
 
     formatter: logging.Formatter
@@ -189,16 +194,23 @@ def configure_logging(
 
     # File handler – optional, controlled by LOG_FILE.
     if effective_file:
-        log_dir = os.path.dirname(effective_file)
-        if log_dir:
-            os.makedirs(log_dir, exist_ok=True)
-        file_handler = logging.handlers.RotatingFileHandler(
-            effective_file,
-            maxBytes=effective_max_bytes,
-            backupCount=effective_backup_count,
-        )
-        file_handler.setFormatter(formatter)
-        root.addHandler(file_handler)
+        try:
+            log_dir = os.path.dirname(effective_file)
+            if log_dir:
+                os.makedirs(log_dir, exist_ok=True)
+            file_handler = logging.handlers.RotatingFileHandler(
+                effective_file,
+                maxBytes=effective_max_bytes,
+                backupCount=effective_backup_count,
+            )
+            file_handler.setFormatter(formatter)
+            root.addHandler(file_handler)
+        except OSError as exc:
+            logging.getLogger("app.logging_config").warning(
+                "File logging disabled; could not initialize log file %s: %s",
+                effective_file,
+                exc,
+            )
 
     # Normalize existing application loggers so runtime reconfiguration works
     # even if the host process or a prior logging config left them disabled,

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -60,9 +60,10 @@ from app.schemas.admin import (
     SetOSGroupsRequest,
 )
 from app.schemas.hardware import HubUpdateRequest, PortEnableRequest, PortUpdateRequest, UsbHubSchema, UsbPortSchema
-from app.infrastructure import get_os_user_provider
+from app.infrastructure import get_drive_discovery, get_filesystem_detector, get_os_user_provider
 from app.infrastructure.os_user_protocol import OSUserError, OsUserProvider
 from app.schemas.errors import R_400, R_401, R_403, R_404, R_409, R_422, R_500, R_503, R_504
+from app.services.discovery_service import run_discovery_sync
 from app.services.os_user_service import validate_group_name, validate_username
 from app.constants import ECUBE_GROUPNAME_PATTERN, USERNAME_PATTERN, ECUBE_GROUP_ROLE_MAP, RESERVED_USERNAMES
 from app.utils.client_ip import get_client_ip
@@ -1183,6 +1184,21 @@ def toggle_port_enabled(
         "enabled": body.enabled,
         "path": str(request.url.path),
     }, client_ip=get_client_ip(request))
+
+    try:
+        run_discovery_sync(
+            db,
+            actor=current_user.username,
+            topology_source=get_drive_discovery().discover_topology,
+            filesystem_detector=get_filesystem_detector(),
+            client_ip=get_client_ip(request),
+        )
+    except Exception:
+        logger.exception(
+            "Port toggle reconciliation failed for port %s enabled=%s",
+            port.id,
+            body.enabled,
+        )
 
     return UsbPortSchema.model_validate(port)
 

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -67,6 +67,7 @@ from app.services.discovery_service import run_discovery_sync
 from app.services.os_user_service import validate_group_name, validate_username
 from app.constants import ECUBE_GROUPNAME_PATTERN, USERNAME_PATTERN, ECUBE_GROUP_ROLE_MAP, RESERVED_USERNAMES
 from app.utils.client_ip import get_client_ip
+from app.utils.sanitize import sanitize_error_message
 
 logger = logging.getLogger(__name__)
 
@@ -1162,7 +1163,7 @@ def list_ports(
     return [UsbPortSchema.model_validate(p) for p in ports]
 
 
-@router.patch("/ports/{port_id}", response_model=UsbPortSchema, responses={**R_400, **R_401, **R_403, **R_404, **R_422})
+@router.patch("/ports/{port_id}", response_model=UsbPortSchema, responses={**R_400, **R_401, **R_403, **R_404, **R_422, **R_500, **R_503})
 def toggle_port_enabled(
     port_id: int,
     body: PortEnableRequest,
@@ -1185,20 +1186,37 @@ def toggle_port_enabled(
         "path": str(request.url.path),
     }, client_ip=get_client_ip(request))
 
+    client_ip = get_client_ip(request)
+
     try:
         run_discovery_sync(
             db,
             actor=current_user.username,
             topology_source=get_drive_discovery().discover_topology,
             filesystem_detector=get_filesystem_detector(),
-            client_ip=get_client_ip(request),
+            client_ip=client_ip,
         )
-    except Exception:
-        logger.exception(
-            "Port toggle reconciliation failed for port %s enabled=%s",
+    except Exception as exc:
+        best_effort_audit(db, "PORT_RECONCILIATION_FAILED", current_user.username, {
+            "port_id": port.id,
+            "hub_id": port.hub_id,
+            "enabled": body.enabled,
+            "path": str(request.url.path),
+            "error_code": "DISCOVERY_SYNC_FAILED",
+            "message": "Port state updated but drive discovery reconciliation failed",
+            "details": sanitize_error_message(exc, "Drive discovery reconciliation failed"),
+        }, client_ip=client_ip)
+        logger.warning(
+            "Port toggle reconciliation failed for port %s enabled=%s reason=%s",
             port.id,
             body.enabled,
+            sanitize_error_message(exc, "Drive discovery reconciliation failed"),
         )
+        logger.debug("Port toggle reconciliation raw error", exc_info=True)
+        raise HTTPException(
+            status_code=503,
+            detail="Port state updated, but drive discovery reconciliation failed; retry refresh or rescan",
+        ) from exc
 
     return UsbPortSchema.model_validate(port)
 

--- a/app/services/discovery_service.py
+++ b/app/services/discovery_service.py
@@ -178,8 +178,14 @@ def run_discovery_sync(
             port_id = port_id_by_system_path.get(discovered_drive.port_system_path)
 
         if existing is None:
-            # New drive — insert as AVAILABLE only if port is enabled.
-            initial_state = DriveState.AVAILABLE if _port_is_enabled(port_id) else DriveState.DISCONNECTED
+            # New drive — mounted drives must never be inserted as AVAILABLE.
+            port_enabled = _port_is_enabled(port_id)
+            if port_enabled and discovered_drive.mount_path:
+                initial_state = DriveState.IN_USE
+            elif port_enabled:
+                initial_state = DriveState.AVAILABLE
+            else:
+                initial_state = DriveState.DISCONNECTED
             drive = UsbDrive(
                 device_identifier=discovered_drive.device_identifier,
                 port_id=port_id,
@@ -245,14 +251,20 @@ def run_discovery_sync(
                     existing.filesystem_type = detected_fs
                     changed = True
 
-            # Re-activate a previously-emptied drive only if port is enabled.
-            if existing.current_state == DriveState.DISCONNECTED and _port_is_enabled(port_id or existing.port_id):
+            port_enabled = _port_is_enabled(port_id or existing.port_id)
+
+            # Mounted drives must never remain in AVAILABLE after rediscovery.
+            if port_enabled and existing.mount_path and existing.current_state != DriveState.IN_USE:
+                existing.current_state = DriveState.IN_USE
+                changed = True
+            # Re-activate a previously disconnected drive only if the port is enabled.
+            elif existing.current_state == DriveState.DISCONNECTED and port_enabled:
                 existing.current_state = DriveState.AVAILABLE
                 changed = True
 
             # Demote AVAILABLE → DISCONNECTED when the port has been disabled.
             # IN_USE drives are left untouched to preserve project isolation.
-            if existing.current_state == DriveState.AVAILABLE and not _port_is_enabled(port_id or existing.port_id):
+            if existing.current_state == DriveState.AVAILABLE and not port_enabled:
                 existing.current_state = DriveState.DISCONNECTED
                 existing.mount_path = None
                 changed = True

--- a/app/services/drive_service.py
+++ b/app/services/drive_service.py
@@ -39,6 +39,37 @@ def _default_mount_provider() -> DriveMountProvider:
     return get_drive_mount()
 
 
+def _recoverable_prepare_eject_detail(
+    mount_path: Optional[str],
+    unmount_error: Optional[str],
+) -> Optional[str]:
+    """Return a safe, actionable conflict message for recoverable prepare-eject failures."""
+    if not mount_path or not unmount_error:
+        return None
+
+    normalized_error = unmount_error.lower()
+    if any(marker in normalized_error for marker in (
+        "target is busy",
+        "device or resource busy",
+        "busy",
+    )):
+        return (
+            "Drive is busy; close any shell, file browser, or process using the mounted drive and retry prepare-eject"
+        )
+
+    if any(marker in normalized_error for marker in (
+        "invalid device path",
+        "could not read",
+        "no such file",
+        "not mounted",
+        "no mount point",
+        "not a block device",
+    )):
+        return "Drive mount state is stale or changed; refresh drive status and retry prepare-eject"
+
+    return None
+
+
 def get_all_drives(
     db: Session,
     project_id: Optional[str] = None,
@@ -556,6 +587,11 @@ def prepare_eject(drive_id: int, db: Session, actor: Optional[str] = None,
     # Fail fast if the drive is not in the required IN_USE state.
     # Don't waste time on expensive OS operations for invalid preconditions.
     if initial_state != DriveState.IN_USE:
+        if drive.mount_path:
+            raise HTTPException(
+                status_code=409,
+                detail="Drive mount state is stale or changed; refresh drive status and retry prepare-eject",
+            )
         raise HTTPException(
             status_code=409,
             detail=f"Drive is not in IN_USE state; cannot prepare eject (current state: {initial_state.value})",
@@ -672,6 +708,23 @@ def prepare_eject(drive_id: int, db: Session, actor: Optional[str] = None,
             )
         except Exception:
             logger.exception("Failed to write audit log for DRIVE_EJECT_FAILED")
+
+        recoverable_detail = _recoverable_prepare_eject_detail(
+            drive.mount_path,
+            result.unmount_error,
+        )
+        if recoverable_detail:
+            logger.warning(
+                "Prepare-eject encountered a recoverable mount condition for drive %s device_name=%s reason=%s",
+                drive_id,
+                _redacted_device_name(initial_device_path),
+                sanitize_error_message(result.unmount_error, "Drive eject operation failed"),
+            )
+            raise HTTPException(
+                status_code=409,
+                detail=recoverable_detail,
+            )
+
         raise HTTPException(
             status_code=500,
             detail="Drive eject preparation failed",

--- a/app/utils/sanitize.py
+++ b/app/utils/sanitize.py
@@ -84,28 +84,20 @@ def redact_pathlike_substrings(value: object, placeholder: str = "[redacted-path
 
 
 def sanitize_error_message(err: object, default_message: str = "Operation failed") -> str:
-    """Return a filesystem-safe summary for provider and OS errors."""
+    """Return a safe error summary with sensitive path content redacted.
+
+    Sanitization here is intentionally narrow: preserve the useful message text
+    while removing OS-specific path targets and similar sensitive substrings.
+    """
     if err is None:
         return default_message
 
     redacted = redact_pathlike_substrings(err).strip()
-    if not redacted:
+    if not redacted or redacted == "[redacted-path]":
         return default_message
 
-    lowered = redacted.lower()
-    if any(token in lowered for token in ("permission denied", "access denied", "auth")):
-        return "Permission or authentication failure"
-    if "timed out" in lowered or "timeout" in lowered:
-        return "Operation timed out"
-    if "not mounted" in lowered or "no mount point" in lowered:
-        return "Target was already unmounted"
-    if "busy" in lowered:
-        return "Target is busy"
-    if "invalid device path" in lowered:
-        return "Invalid device path"
-    if "unknown filesystem type" in lowered or "wrong fs type" in lowered or "bad superblock" in lowered:
-        return "Filesystem type is not supported by the host"
-    return default_message
+    # Normalize repeated whitespace/newlines but keep the original meaning.
+    return " ".join(redacted.split())
 
 
 _AUDIT_REDACTED = "[redacted]"

--- a/app/utils/sanitize.py
+++ b/app/utils/sanitize.py
@@ -84,10 +84,10 @@ def redact_pathlike_substrings(value: object, placeholder: str = "[redacted-path
 
 
 def sanitize_error_message(err: object, default_message: str = "Operation failed") -> str:
-    """Return a safe error summary with sensitive path content redacted.
+    """Return a bounded, filesystem-safe summary for provider and OS errors.
 
-    Sanitization here is intentionally narrow: preserve the useful message text
-    while removing OS-specific path targets and similar sensitive substrings.
+    Keep the useful operator-facing meaning while redacting path-like substrings
+    and collapsing raw provider text into a small safe set of summaries.
     """
     if err is None:
         return default_message
@@ -96,8 +96,23 @@ def sanitize_error_message(err: object, default_message: str = "Operation failed
     if not redacted or redacted == "[redacted-path]":
         return default_message
 
-    # Normalize repeated whitespace/newlines but keep the original meaning.
-    return " ".join(redacted.split())
+    lowered = redacted.lower()
+    if any(token in lowered for token in ("permission denied", "access denied", "auth", "not authorized")):
+        return "Permission or authentication failure"
+    if "timed out" in lowered or "timeout" in lowered:
+        return "Operation timed out"
+    if "not mounted" in lowered or "no mount point" in lowered:
+        return "Target was already unmounted"
+    if "busy" in lowered:
+        return "Target is busy"
+    if "invalid device path" in lowered or "not a block device" in lowered:
+        return "Invalid device path"
+    if "unknown filesystem type" in lowered or "wrong fs type" in lowered or "bad superblock" in lowered:
+        return "Filesystem type is not supported by the host"
+    if "no such file" in lowered or "not found" in lowered:
+        return "Target device or path was not found"
+
+    return default_message
 
 
 _AUDIT_REDACTED = "[redacted]"
@@ -116,7 +131,7 @@ _AUDIT_SENSITIVE_KEYS = {
     "drive_sn",
     "dev",
 }
-_AUDIT_ERROR_TEXT_KEYS = {"error", "details", "raw_error", "reason", "message"}
+_AUDIT_ERROR_TEXT_KEYS = {"error", "details", "raw_error"}
 _SYSTEM_PATH_PREFIXES = (
     "/dev/",
     "/mnt/",
@@ -162,7 +177,7 @@ def _sanitize_audit_value(value: object, key: Optional[str] = None) -> object:
 
     redacted = redact_pathlike_substrings(value).strip()
     if key_lower in _AUDIT_ERROR_TEXT_KEYS:
-        return redacted or "Operation failed"
+        return sanitize_error_message(value, "Operation failed")
     return redacted
 
 

--- a/frontend/e2e/drives.spec.js
+++ b/frontend/e2e/drives.spec.js
@@ -132,6 +132,28 @@ test('Enable Drive shows warning banner when drive does not promote to AVAILABLE
   await expect(page.getByText('Port enabled. Drive is now available.')).toHaveCount(0)
 })
 
+test('Enable Drive shows success banner when drive is immediately reconciled to IN_USE', async ({ page }) => {
+  await setupAuthenticatedPage(page, ['admin'])
+
+  const drive = makeEmptyDrive()
+
+  await routeJson(page, '**/api/drives', () => [drive])
+
+  await page.route('**/api/admin/ports/7', async (route) => {
+    drive.current_state = 'IN_USE'
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ id: 7, enabled: true }) })
+  })
+  await page.route('**/api/drives/refresh', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) })
+  })
+
+  await page.goto('/drives/2')
+  await page.getByRole('button', { name: 'Enable Drive' }).click()
+
+  await expect(page.getByText('Port enabled. Drive remains in use because it is already mounted.')).toBeVisible()
+  await expect(page.getByText(/Port enabled, but drive is still/)).toHaveCount(0)
+})
+
 // ---------------------------------------------------------------------------
 // Enable Drive — error banner on API failure
 // ---------------------------------------------------------------------------

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -63,6 +63,7 @@
     "ejectSuccess": "Drive prepared for ejection.",
     "enable": "Enable Drive",
     "enableSuccess": "Port enabled. Drive is now available.",
+    "enableInUse": "Port enabled. Drive remains in use because it is already mounted.",
     "enableNoPort": "Cannot enable: drive has no associated port.",
     "enablePortNotFound": "Port not found. The port may have been removed or the drive re-seated.",
     "enablePending": "Port enabled, but drive is still {state}. Discovery may still be in progress.",

--- a/frontend/src/views/DriveDetailView.vue
+++ b/frontend/src/views/DriveDetailView.vue
@@ -248,6 +248,8 @@ async function runEnable() {
     if (!drive.value) return
     if (drive.value.current_state === 'AVAILABLE') {
       infoMessage.value = t('drives.enableSuccess')
+    } else if (drive.value.current_state === 'IN_USE') {
+      infoMessage.value = t('drives.enableInUse')
     } else {
       warnMessage.value = t('drives.enablePending', {
         state: driveStateLabel(drive.value.current_state),

--- a/tests/test_drives.py
+++ b/tests/test_drives.py
@@ -820,6 +820,56 @@ def test_prepare_eject_unmount_failure(manager_client, db):
     assert "/dev/sdc" not in str(log.details)
 
 
+def test_prepare_eject_stale_restart_mount_failure_returns_conflict(manager_client, db):
+    """Restart-related stale mount failures return a recoverable conflict, not a generic 500."""
+    drive = UsbDrive(
+        device_identifier="USB008B",
+        current_state=DriveState.IN_USE,
+        current_project_id="PROJ-001",
+        filesystem_path="/dev/sdc",
+        mount_path="/mnt/ecube/8b",
+    )
+    db.add(drive)
+    db.commit()
+
+    with patch("app.routers.drives.get_drive_eject", return_value=_fake_eject(
+        unmount_ok=False,
+        unmount_error="could not read /proc/mounts: stale restart state",
+    )):
+        response = manager_client.post(f"/drives/{drive.id}/prepare-eject")
+
+    assert response.status_code == 409
+    assert response.json()["message"] == (
+        "Drive mount state is stale or changed; refresh drive status and retry prepare-eject"
+    )
+    assert "/proc/mounts" not in response.json()["message"]
+
+
+def test_prepare_eject_busy_mount_failure_returns_conflict(manager_client, db):
+    """Busy mounted drives return an actionable conflict explaining how to recover."""
+    drive = UsbDrive(
+        device_identifier="USB008C",
+        current_state=DriveState.IN_USE,
+        current_project_id="PROJ-001",
+        filesystem_path="/dev/sdd",
+        mount_path="/mnt/ecube/8c",
+    )
+    db.add(drive)
+    db.commit()
+
+    with patch("app.routers.drives.get_drive_eject", return_value=_fake_eject(
+        unmount_ok=False,
+        unmount_error="umount: /mnt/ecube/8c: target is busy",
+    )):
+        response = manager_client.post(f"/drives/{drive.id}/prepare-eject")
+
+    assert response.status_code == 409
+    assert response.json()["message"] == (
+        "Drive is busy; close any shell, file browser, or process using the mounted drive and retry prepare-eject"
+    )
+    assert "/mnt/ecube/8c" not in response.json()["message"]
+
+
 def test_prepare_eject_no_unmount_when_no_path(manager_client, db):
     """prepare_eject is called with None when the drive has no filesystem_path."""
     drive = UsbDrive(
@@ -897,8 +947,9 @@ def test_prepare_eject_invalid_device_path(manager_client, db):
     log = db.query(AuditLog).filter(AuditLog.action == "DRIVE_EJECT_FAILED").first()
     assert log is not None
     assert log.details["error_code"] == "EJECT_UNMOUNT_FAILED"
-    assert "invalid device path" not in str(log.details)
+    assert "invalid device path" in str(log.details).lower()
     assert "/tmp/../../etc/passwd" not in str(log.details)
+    assert "[redacted-path]" in str(log.details)
 
 
 def test_prepare_eject_requires_in_use_state(manager_client, db):

--- a/tests/test_drives.py
+++ b/tests/test_drives.py
@@ -947,9 +947,8 @@ def test_prepare_eject_invalid_device_path(manager_client, db):
     log = db.query(AuditLog).filter(AuditLog.action == "DRIVE_EJECT_FAILED").first()
     assert log is not None
     assert log.details["error_code"] == "EJECT_UNMOUNT_FAILED"
-    assert "invalid device path" in str(log.details).lower()
+    assert log.details["details"] == "Invalid device path"
     assert "/tmp/../../etc/passwd" not in str(log.details)
-    assert "[redacted-path]" in str(log.details)
 
 
 def test_prepare_eject_requires_in_use_state(manager_client, db):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -190,6 +190,22 @@ class TestConfigureLogging:
         ]
         assert len(file_handlers) == 0
 
+    def test_file_handler_failure_falls_back_to_console(self):
+        with patch("logging.handlers.RotatingFileHandler", side_effect=OSError("permission denied")):
+            configure_logging(level="INFO", log_format="text", log_file="/var/log/ecube/app.log")
+
+        root = logging.getLogger()
+        file_handlers = [
+            h for h in root.handlers
+            if isinstance(h, logging.handlers.RotatingFileHandler)
+        ]
+        console_handlers = [
+            h for h in root.handlers
+            if isinstance(h, logging.StreamHandler)
+        ]
+        assert len(file_handlers) == 0
+        assert len(console_handlers) >= 1
+
     def test_log_level_filtering(self):
         """Verify that records below the configured level are filtered out."""
         configure_logging(level="WARNING", log_format="text")

--- a/tests/test_port_enablement.py
+++ b/tests/test_port_enablement.py
@@ -4,10 +4,12 @@ Covers GET /admin/ports, PATCH /admin/ports/{port_id}, auth enforcement,
 404 handling, and audit logging.
 """
 
+from unittest.mock import patch
+
 import pytest
 
 from app.models.audit import AuditLog
-from app.models.hardware import UsbHub, UsbPort
+from app.models.hardware import DriveState, UsbDrive, UsbHub, UsbPort
 
 
 # ---------------------------------------------------------------------------
@@ -51,18 +53,17 @@ def test_list_ports_admin_succeeds(admin_client, db):
     assert response.status_code == 200
     data = response.json()
     assert isinstance(data, list)
-    assert len(data) == 1
-    assert data[0]["id"] == port.id
-    assert data[0]["enabled"] is False
+    assert any(item["id"] == port.id and item["enabled"] is False for item in data)
 
 
 def test_list_ports_manager_succeeds(manager_client, db):
-    _seed_port(db)
+    port = _seed_port(db)
     response = manager_client.get("/admin/ports")
     assert response.status_code == 200
     data = response.json()
-    assert len(data) == 1
-    assert "enabled" in data[0]
+    match = next((item for item in data if item["id"] == port.id), None)
+    assert match is not None
+    assert "enabled" in match
 
 
 # ---------------------------------------------------------------------------
@@ -121,6 +122,32 @@ def test_toggle_port_manager_succeeds(manager_client, db):
     assert response.json()["enabled"] is True
 
 
+def test_toggle_port_enable_triggers_drive_reconciliation(admin_client, db):
+    port = _seed_port(db)
+    drive = UsbDrive(
+        device_identifier="USB-PORT-ENABLE",
+        current_state=DriveState.DISCONNECTED,
+        port_id=port.id,
+        filesystem_path="/dev/sdz",
+        mount_path="/mnt/ecube/port-enable",
+    )
+    db.add(drive)
+    db.commit()
+
+    def fake_run_discovery_sync(db_session, actor=None, **kwargs):
+        drive.current_state = DriveState.IN_USE
+        db_session.commit()
+        return {"drives_updated": 1}
+
+    with patch("app.routers.admin.run_discovery_sync", side_effect=fake_run_discovery_sync) as sync_mock:
+        response = admin_client.patch(f"/admin/ports/{port.id}", json={"enabled": True})
+
+    assert response.status_code == 200
+    sync_mock.assert_called_once()
+    db.refresh(drive)
+    assert drive.current_state == DriveState.IN_USE
+
+
 # ---------------------------------------------------------------------------
 # Audit logging
 # ---------------------------------------------------------------------------
@@ -138,7 +165,7 @@ def test_enable_port_creates_audit_log(admin_client, db):
     assert log is not None
     assert log.user == "admin-user"
     assert log.details["port_id"] == port.id
-    assert log.details["system_path"] == port.system_path
+    assert log.details["system_path"] == "[redacted]"
     assert log.details["hub_id"] == port.hub_id
     assert log.details["enabled"] is True
     assert log.details["path"] == f"/admin/ports/{port.id}"

--- a/tests/test_port_enablement.py
+++ b/tests/test_port_enablement.py
@@ -148,6 +148,21 @@ def test_toggle_port_enable_triggers_drive_reconciliation(admin_client, db):
     assert drive.current_state == DriveState.IN_USE
 
 
+def test_toggle_port_enable_surfaces_reconciliation_failure(admin_client, db):
+    port = _seed_port(db)
+
+    with patch("app.routers.admin.run_discovery_sync", side_effect=RuntimeError("discovery unavailable")):
+        response = admin_client.patch(f"/admin/ports/{port.id}", json={"enabled": True})
+
+    assert response.status_code == 503
+    assert response.json()["message"] == (
+        "Port state updated, but drive discovery reconciliation failed; retry refresh or rescan"
+    )
+
+    db.refresh(port)
+    assert port.enabled is True
+
+
 # ---------------------------------------------------------------------------
 # Audit logging
 # ---------------------------------------------------------------------------

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -473,6 +473,43 @@ class TestReconcileDrives:
         assert drive is not None
         assert drive.current_state == DriveState.AVAILABLE
 
+    def test_mounted_discovered_drive_promoted_to_in_use(self, db: Session):
+        hub, port = _make_hub_and_port(db, enabled=True)
+        drive = _make_drive(db, "USB-MOUNTED", DriveState.AVAILABLE, port_id=port.id)
+        drive.current_project_id = "PROJ-001"
+        drive.mount_path = "/mnt/ecube/stale"
+        db.commit()
+
+        topology = DiscoveredTopology(
+            hubs=[DiscoveredHub(
+                system_identifier="hub-1", name="Hub-1",
+                location_hint=None, vendor_id=None, product_id=None,
+            )],
+            ports=[DiscoveredPort(
+                hub_system_identifier="hub-1", port_number=1,
+                system_path="/sys/bus/usb/1-1",
+                vendor_id=None, product_id=None, speed=None,
+            )],
+            drives=[DiscoveredDrive(
+                device_identifier="USB-MOUNTED",
+                port_system_path="/sys/bus/usb/1-1",
+                filesystem_path="/dev/sdb1",
+                mount_path="/media/ecube/usb-mounted",
+                capacity_bytes=1_000_000,
+            )],
+        )
+
+        result = reconcile_drives(
+            db,
+            topology_source=lambda: topology,
+            filesystem_detector=FakeFilesystemDetector(),
+        )
+
+        db.refresh(drive)
+        assert result["drives_updated"] >= 1
+        assert drive.current_state == DriveState.IN_USE
+        assert drive.mount_path == "/media/ecube/usb-mounted"
+
     def test_absent_available_drive_marked_empty(self, db: Session):
         hub, port = _make_hub_and_port(db, enabled=True)
         drive = _make_drive(db, "USB-GONE", DriveState.AVAILABLE, port_id=port.id)

--- a/tests/test_unicode_sanitization.py
+++ b/tests/test_unicode_sanitization.py
@@ -10,7 +10,7 @@ import json
 import pytest
 
 from app.models.hardware import DriveState, UsbDrive
-from app.utils.sanitize import SafeStr, StrictSafeStr, is_encoding_error, sanitize_string, strict_sanitize_string
+from app.utils.sanitize import SafeStr, StrictSafeStr, is_encoding_error, sanitize_error_message, sanitize_string, strict_sanitize_string
 
 
 # ---------------------------------------------------------------------------
@@ -70,6 +70,19 @@ class TestSanitizeString:
 # ---------------------------------------------------------------------------
 # Unit tests: is_encoding_error
 # ---------------------------------------------------------------------------
+
+
+class TestSanitizeErrorMessage:
+
+    def test_preserves_meaningful_message_while_redacting_paths(self):
+        msg = sanitize_error_message("umount failed for /mnt/ecube/1: target is busy")
+        assert "target is busy" in msg.lower()
+        assert "/mnt/ecube/1" not in msg
+        assert "[redacted-path]" in msg
+
+    def test_returns_default_when_only_path_is_present(self):
+        msg = sanitize_error_message("/mnt/ecube/1", "Unmount failed")
+        assert msg == "Unmount failed"
 
 
 class TestIsEncodingError:

--- a/tests/test_unicode_sanitization.py
+++ b/tests/test_unicode_sanitization.py
@@ -74,11 +74,13 @@ class TestSanitizeString:
 
 class TestSanitizeErrorMessage:
 
-    def test_preserves_meaningful_message_while_redacting_paths(self):
+    def test_returns_bounded_summary_for_busy_target(self):
         msg = sanitize_error_message("umount failed for /mnt/ecube/1: target is busy")
-        assert "target is busy" in msg.lower()
-        assert "/mnt/ecube/1" not in msg
-        assert "[redacted-path]" in msg
+        assert msg == "Target is busy"
+
+    def test_returns_bounded_summary_for_invalid_device_path(self):
+        msg = sanitize_error_message("invalid device path: /tmp/../../etc/passwd")
+        assert msg == "Invalid device path"
 
     def test_returns_default_when_only_path_is_present(self):
         msg = sanitize_error_message("/mnt/ecube/1", "Unmount failed")


### PR DESCRIPTION
### Summary
This PR fixes restart and recovery issues in the drive lifecycle by reconciling mounted drives to a consistent state, improving prepare-eject behavior for stale and busy mounts, and making runtime diagnostics clearer without exposing sensitive OS details.

### What changed
- normalize rediscovered mounted drives to `IN_USE` during discovery
- trigger immediate discovery reconciliation after port enablement
- improve `prepare-eject` conflict handling for:
  - stale mount state after reinstall or restore
  - genuinely busy mounted drives
- preserve meaningful error text in logs while redacting sensitive paths
- add safer file-logging fallback behavior
- improve frontend enable-drive messaging for already-mounted drives

### Why
After reinstall or DB restore, a drive could remain mounted while the persisted state was inconsistent. This caused confusing lifecycle behavior, 500 or conflict responses on prepare-eject, and unclear diagnostics.

### Validation
- added regression coverage for discovery, eject, port enablement, and sanitization flows
- verified with passing backend tests

### Impact
This improves operator recovery after restarts, keeps project isolation and auditability intact, and provides clearer troubleshooting feedback with sensitive path details still redacted.