### PR TITLE
Normalize project IDs to uppercase on entry and display

### DIFF
--- a/frontend/src/utils/projectId.js
+++ b/frontend/src/utils/projectId.js
@@ -1,0 +1,17 @@
+export function normalizeProjectId(value) {
+  if (typeof value !== 'string') return ''
+  return value.trim().toUpperCase()
+}
+
+export function normalizeProjectRecord(record, keys = ['project_id', 'current_project_id']) {
+  if (!record || typeof record !== 'object') return record
+
+  const next = { ...record }
+  for (const key of keys) {
+    if (typeof next[key] === 'string') {
+      const normalized = normalizeProjectId(next[key])
+      next[key] = normalized || null
+    }
+  }
+  return next
+}

--- a/frontend/src/views/AuditView.vue
+++ b/frontend/src/views/AuditView.vue
@@ -11,6 +11,7 @@ import DataTable from '@/components/common/DataTable.vue'
 import Pagination from '@/components/common/Pagination.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
+import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -71,9 +72,8 @@ function _toDriveOption(drive) {
 function _toProjectList(drives) {
   return [...new Set(
     drives
-      .map((drive) => drive.current_project_id)
+      .map((drive) => normalizeProjectId(drive.current_project_id))
       .filter((value) => typeof value === 'string' && value.trim())
-      .map((value) => value.trim())
   )].sort((a, b) => a.localeCompare(b))
 }
 
@@ -200,7 +200,7 @@ async function loadAudit() {
 async function loadDriveOptions() {
   try {
     const drives = await getDrives({ state: ['IN_USE', 'AVAILABLE'] })
-    allActiveDrives.value = drives
+    allActiveDrives.value = (drives || []).map((item) => normalizeProjectRecord(item, ['current_project_id']))
   } catch {
     allActiveDrives.value = []
     cocError.value = t('common.errors.networkError')
@@ -217,7 +217,7 @@ function buildCocParams() {
     params.drive_sn = cocFilters.value.drive_sn.trim()
   }
   if (cocFilters.value.project_id.trim()) {
-    params.project_id = cocFilters.value.project_id.trim()
+    params.project_id = normalizeProjectId(cocFilters.value.project_id)
   }
   return params
 }
@@ -286,7 +286,7 @@ async function loadChainOfCustody() {
 function prepareHandoff(report) {
   handoffForm.value = {
     drive_id: String(report.drive_id),
-    project_id: report.project_id || '',
+    project_id: normalizeProjectId(report.project_id),
     possessor: '',
     delivery_time: '',
     received_by: '',
@@ -316,7 +316,7 @@ async function confirmHandoffSubmission() {
   try {
     const handoffResult = await confirmChainOfCustodyHandoff({
       drive_id: driveId,
-      project_id: handoffForm.value.project_id.trim() || undefined,
+      project_id: normalizeProjectId(handoffForm.value.project_id) || undefined,
       possessor: handoffForm.value.possessor.trim(),
       delivery_time: localDateTimeAsUtcIso(handoffForm.value.delivery_time),
       received_by: handoffForm.value.received_by.trim() || undefined,
@@ -402,7 +402,9 @@ function printCocReport() {
 function initCocFromRoute() {
   cocFilters.value.drive_id = typeof route.query.drive_id === 'string' ? route.query.drive_id : ''
   cocFilters.value.drive_sn = typeof route.query.drive_sn === 'string' ? route.query.drive_sn : ''
-  cocFilters.value.project_id = typeof route.query.project_id === 'string' ? route.query.project_id : ''
+  cocFilters.value.project_id = typeof route.query.project_id === 'string'
+    ? normalizeProjectId(route.query.project_id)
+    : ''
   if (route.query.coc === '1' && (cocFilters.value.drive_id || cocFilters.value.drive_sn || cocFilters.value.project_id)) {
     loadChainOfCustody()
   }
@@ -494,7 +496,7 @@ onMounted(() => {
             <StatusBadge :status="report.custody_complete ? 'COMPLETED' : 'PENDING'" :label="report.custody_complete ? t('audit.custodyComplete') : t('audit.custodyIncomplete')" />
           </header>
           <p class="muted">
-            {{ t('dashboard.project') }}: {{ report.project_id || '-' }}
+            {{ t('dashboard.project') }}: {{ normalizeProjectId(report.project_id) || '-' }}
             | {{ t('audit.deliveryTime') }}: {{ asUtcDate(report.delivery_time) }}
           </p>
 

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -8,6 +8,7 @@ import { usePolling } from '@/composables/usePolling.js'
 import DataTable from '@/components/common/DataTable.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import ProgressBar from '@/components/common/ProgressBar.vue'
+import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
 
 const { t } = useI18n()
 
@@ -37,18 +38,26 @@ const healthColumns = computed(() => [
   { key: 'progress', label: t('dashboard.progress') },
 ])
 
+function formatProjectId(value) {
+  return normalizeProjectId(value) || '-'
+}
+
 async function refreshSnapshot() {
   const warnings = []
   const results = await Promise.allSettled([getDrives({ include_disconnected: true }), listJobs({ limit: 200 })])
 
   if (results[0].status === 'fulfilled') {
-    drives.value = Array.isArray(results[0].value) ? results[0].value : []
+    drives.value = Array.isArray(results[0].value)
+      ? results[0].value.map((item) => normalizeProjectRecord(item, ['current_project_id']))
+      : []
   } else {
     warnings.push(t('dashboard.loadDrivesError'))
   }
 
   if (results[1].status === 'fulfilled') {
-    jobs.value = Array.isArray(results[1].value) ? results[1].value : []
+    jobs.value = Array.isArray(results[1].value)
+      ? results[1].value.map((item) => normalizeProjectRecord(item, ['project_id']))
+      : []
   } else {
     // Backward compatibility for servers that do not yet expose GET /jobs.
     jobs.value = []
@@ -119,6 +128,7 @@ onUnmounted(() => {
     <article class="panel">
       <h2>{{ t('jobs.activeJobs') }}</h2>
       <DataTable :columns="healthColumns" :rows="activeJobs" row-key="id" :empty-text="t('dashboard.noActiveJobs')">
+        <template #cell-project_id="{ row }">{{ formatProjectId(row.project_id) }}</template>
         <template #cell-status="{ row }">
           <StatusBadge :status="row.status" />
         </template>

--- a/frontend/src/views/DriveDetailView.vue
+++ b/frontend/src/views/DriveDetailView.vue
@@ -11,6 +11,7 @@ import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useStatusLabels } from '@/composables/useStatusLabels.js'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import DirectoryBrowser from '@/components/browse/DirectoryBrowser.vue'
+import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -116,7 +117,8 @@ async function loadDrive() {
   clearBanners()
   try {
     const drives = await getDrives({ include_disconnected: true })
-    drive.value = drives.find((item) => item.id === driveId.value) || null
+    const next = drives.find((item) => item.id === driveId.value) || null
+    drive.value = next ? normalizeProjectRecord(next, ['current_project_id']) : null
     if (!drive.value) {
       error.value = t('drives.notFound')
     }
@@ -132,7 +134,10 @@ async function runFormat() {
   saving.value = true
   clearBanners()
   try {
-    drive.value = await formatDrive(drive.value.id, { filesystem_type: filesystemType.value })
+    drive.value = normalizeProjectRecord(
+      await formatDrive(drive.value.id, { filesystem_type: filesystemType.value }),
+      ['current_project_id'],
+    )
     infoMessage.value = t('drives.formatSuccess')
     showFormatDialog.value = false
   } catch {
@@ -146,7 +151,7 @@ function normalizeMountedProjectOptions(mounts) {
   return [...new Set(
     (mounts || [])
       .filter((mount) => mount?.status === 'MOUNTED')
-      .map((mount) => (typeof mount?.project_id === 'string' ? mount.project_id.trim() : ''))
+      .map((mount) => normalizeProjectId(mount?.project_id))
       .filter((value) => value && value.toUpperCase() !== 'UNASSIGNED'),
   )].sort((left, right) => left.localeCompare(right))
 }
@@ -157,7 +162,7 @@ async function loadMountedProjects() {
     const mounts = await getMounts()
     mountedProjectOptions.value = normalizeMountedProjectOptions(mounts)
     const currentProject = typeof drive.value?.current_project_id === 'string'
-      ? drive.value.current_project_id.trim()
+      ? normalizeProjectId(drive.value.current_project_id)
       : ''
 
     if (currentProject && mountedProjectOptions.value.includes(currentProject)) {
@@ -186,7 +191,10 @@ async function runInitialize() {
   saving.value = true
   clearBanners()
   try {
-    drive.value = await initializeDrive(drive.value.id, { project_id: projectId.value.trim() })
+    drive.value = normalizeProjectRecord(
+      await initializeDrive(drive.value.id, { project_id: normalizeProjectId(projectId.value) }),
+      ['current_project_id'],
+    )
     infoMessage.value = t('drives.initializeSuccess')
     showInitializeDialog.value = false
     projectId.value = ''
@@ -288,7 +296,7 @@ async function runMount() {
   saving.value = true
   clearBanners()
   try {
-    drive.value = await mountDrive(drive.value.id)
+    drive.value = normalizeProjectRecord(await mountDrive(drive.value.id), ['current_project_id'])
     infoMessage.value = t('drives.mountSuccess')
   } catch (err) {
     const status = err?.response?.status

--- a/frontend/src/views/DrivesView.vue
+++ b/frontend/src/views/DrivesView.vue
@@ -8,6 +8,7 @@ import Pagination from '@/components/common/Pagination.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import DirectoryBrowser from '@/components/browse/DirectoryBrowser.vue'
 import { useStatusLabels } from '@/composables/useStatusLabels.js'
+import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
 
 const { t } = useI18n()
 const { driveStateLabel } = useStatusLabels()
@@ -55,6 +56,27 @@ function formatBytes(value) {
     unit += 1
   }
   return `${next.toFixed(next >= 10 ? 0 : 1)} ${units[unit]}`
+}
+
+function formatProjectId(value) {
+  return normalizeProjectId(value) || '-'
+}
+
+async function loadDrives() {
+  loading.value = true
+  error.value = ''
+  try {
+    const params = {}
+    if (stateFilter.value === 'ALL' || stateFilter.value === 'DISCONNECTED') {
+      params.include_disconnected = true
+    }
+    const response = await getDrives(params)
+    drives.value = (response || []).map((item) => normalizeProjectRecord(item, ['current_project_id']))
+  } catch {
+    error.value = t('common.errors.networkError')
+  } finally {
+    loading.value = false
+  }
 }
 
 const filtered = computed(() => {
@@ -106,22 +128,6 @@ function setSort(key) {
   } else {
     sortKey.value = key
     sortDir.value = 'asc'
-  }
-}
-
-async function loadDrives() {
-  loading.value = true
-  error.value = ''
-  try {
-    const params = {}
-    if (stateFilter.value === 'ALL' || stateFilter.value === 'DISCONNECTED') {
-      params.include_disconnected = true
-    }
-    drives.value = await getDrives(params)
-  } catch {
-    error.value = t('common.errors.networkError')
-  } finally {
-    loading.value = false
   }
 }
 
@@ -223,6 +229,9 @@ onMounted(loadDrives)
     </div>
 
     <DataTable :columns="columns" :rows="paged" :empty-text="t('drives.empty')">
+      <template #cell-current_project_id="{ row }">
+        {{ formatProjectId(row.current_project_id) }}
+      </template>
       <template #cell-current_state="{ row }">
         <StatusBadge :status="row.current_state" :label="driveStateLabel(row.current_state)" />
       </template>

--- a/frontend/src/views/JobDetailView.vue
+++ b/frontend/src/views/JobDetailView.vue
@@ -10,6 +10,7 @@ import { usePolling } from '@/composables/usePolling.js'
 import DataTable from '@/components/common/DataTable.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import ProgressBar from '@/components/common/ProgressBar.vue'
+import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
 import { useStatusLabels } from '@/composables/useStatusLabels.js'
 
 const route = useRoute()
@@ -68,7 +69,7 @@ async function loadDebug() {
 const jobPoller = usePolling(
   async () => {
     const next = await getJob(jobId.value)
-    job.value = next
+    job.value = normalizeProjectRecord(next, ['project_id'])
     await loadDebug()
     return next
   },
@@ -157,7 +158,7 @@ onUnmounted(() => {
     <article v-if="job" class="panel">
       <div class="job-header">
         <StatusBadge :status="job.status" />
-        <span>{{ t('dashboard.project') }}: {{ job.project_id }}</span>
+        <span>{{ t('dashboard.project') }}: {{ normalizeProjectId(job.project_id) || '-' }}</span>
         <span>{{ t('jobs.evidence') }}: {{ job.evidence_number }}</span>
       </div>
 

--- a/frontend/src/views/JobsView.vue
+++ b/frontend/src/views/JobsView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth.js'
@@ -10,6 +10,7 @@ import DataTable from '@/components/common/DataTable.vue'
 import Pagination from '@/components/common/Pagination.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useStatusLabels } from '@/composables/useStatusLabels.js'
+import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
 
 const router = useRouter()
 const { t } = useI18n()
@@ -57,6 +58,10 @@ function progressPercent(job) {
   return Math.min(100, Math.round((job.copied_bytes / job.total_bytes) * 100))
 }
 
+function formatProjectId(value) {
+  return normalizeProjectId(value) || '-'
+}
+
 const filtered = computed(() => {
   const query = search.value.trim().toLowerCase()
   return jobs.value.filter((job) => {
@@ -79,7 +84,9 @@ const paged = computed(() => {
 async function loadSupportingData() {
   const [driveResult, mountResult] = await Promise.allSettled([getDrives(), getMounts()])
   drives.value = driveResult.status === 'fulfilled' ? driveResult.value : []
-  mounts.value = mountResult.status === 'fulfilled' ? mountResult.value : []
+  mounts.value = mountResult.status === 'fulfilled'
+    ? (mountResult.value || []).map((item) => normalizeProjectRecord(item, ['project_id']))
+    : []
 }
 
 async function loadJobs() {
@@ -87,7 +94,8 @@ async function loadJobs() {
   error.value = ''
   compatibilityNote.value = ''
   try {
-    jobs.value = await listJobs({ limit: 200 })
+    const response = await listJobs({ limit: 200 })
+    jobs.value = (response || []).map((item) => normalizeProjectRecord(item, ['project_id']))
   } catch {
     jobs.value = []
     compatibilityNote.value = t('jobs.listUnavailable')
@@ -109,13 +117,13 @@ async function submitCreateJob() {
   error.value = ''
   try {
     const payload = {
-      project_id: form.value.project_id.trim(),
+      project_id: normalizeProjectId(form.value.project_id),
       evidence_number: form.value.evidence_number.trim(),
       source_path: resolveSourcePath(),
       drive_id: form.value.drive_id ? Number(form.value.drive_id) : undefined,
       thread_count: Number(form.value.thread_count),
     }
-    const created = await createJob(payload)
+    const created = normalizeProjectRecord(await createJob(payload), ['project_id'])
     jobs.value = [created, ...jobs.value]
     showWizard.value = false
     wizardStep.value = 1
@@ -146,6 +154,16 @@ function canMoveNext() {
   if (wizardStep.value === 3) return !!form.value.project_id.trim() && !!form.value.evidence_number.trim() && !!form.value.source_path.trim()
   return true
 }
+
+watch(
+  () => form.value.project_id,
+  (value) => {
+    const normalized = normalizeProjectId(value)
+    if (value !== normalized) {
+      form.value.project_id = normalized
+    }
+  },
+)
 
 onMounted(async () => {
   await Promise.all([loadJobs(), loadSupportingData()])
@@ -181,6 +199,7 @@ onMounted(async () => {
     </div>
 
     <DataTable :columns="columns" :rows="paged" :empty-text="t('jobs.empty')">
+      <template #cell-project_id="{ row }">{{ formatProjectId(row.project_id) }}</template>
       <template #cell-status="{ row }">
         <StatusBadge :status="row.status" :label="jobStatusLabel(row.status)" />
       </template>

--- a/frontend/src/views/MountsView.vue
+++ b/frontend/src/views/MountsView.vue
@@ -7,6 +7,7 @@ import Pagination from '@/components/common/Pagination.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import DirectoryBrowser from '@/components/browse/DirectoryBrowser.vue'
+import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
 
 const { t } = useI18n()
 
@@ -82,7 +83,8 @@ async function loadMounts() {
   loading.value = true
   error.value = ''
   try {
-    mounts.value = await getMounts()
+    const response = await getMounts()
+    mounts.value = (response || []).map((item) => normalizeProjectRecord(item, ['project_id']))
   } catch {
     error.value = t('common.errors.networkError')
   } finally {
@@ -126,9 +128,13 @@ function protectedValue(value) {
   return value ? t('common.labels.protected') : '-'
 }
 
+function formatProjectId(value) {
+  return normalizeProjectId(value) || '-'
+}
+
 function browseLabel(mount) {
   return mount?.project_id
-    ? `${t('mounts.browse')} ${mount.project_id}`
+    ? `${t('mounts.browse')} ${formatProjectId(mount.project_id)}`
     : t('mounts.browse')
 }
 
@@ -144,7 +150,7 @@ async function submitAddMount() {
     const payload = {
       type: form.value.type,
       remote_path: form.value.remote_path.trim(),
-      project_id: form.value.project_id.trim(),
+      project_id: normalizeProjectId(form.value.project_id),
       username: form.value.username.trim() || null,
       password: form.value.password || null,
       credentials_file: form.value.credentials_file.trim() || null,
@@ -164,7 +170,8 @@ async function runValidateAll() {
   loading.value = true
   error.value = ''
   try {
-    mounts.value = await validateAllMounts()
+    const response = await validateAllMounts()
+    mounts.value = (response || []).map((item) => normalizeProjectRecord(item, ['project_id']))
   } catch {
     error.value = t('common.errors.requestConflict')
   } finally {
@@ -175,7 +182,7 @@ async function runValidateAll() {
 async function runValidateOne(mountId) {
   error.value = ''
   try {
-    const next = await validateMount(mountId)
+    const next = normalizeProjectRecord(await validateMount(mountId), ['project_id'])
     const index = mounts.value.findIndex((item) => item.id === mountId)
     if (index >= 0) mounts.value[index] = next
   } catch {
@@ -186,6 +193,12 @@ async function runValidateOne(mountId) {
 function openAddDialog(event) {
   addDialogTriggerRef.value = event?.currentTarget instanceof HTMLElement ? event.currentTarget : document.activeElement
   showAddDialog.value = true
+  void nextTick(() => {
+    const target = addDialogRef.value?.querySelector('#mount-type')
+    if (target instanceof HTMLElement) {
+      target.focus()
+    }
+  })
 }
 
 function closeAddDialog() {
@@ -251,6 +264,16 @@ async function toggleBrowse(mountId) {
 
 onMounted(loadMounts)
 
+watch(
+  () => form.value.project_id,
+  (value) => {
+    const normalized = normalizeProjectId(value)
+    if (value !== normalized) {
+      form.value.project_id = normalized
+    }
+  },
+)
+
 watch(showAddDialog, async (open) => {
   if (open) {
     document.addEventListener('keydown', handleAddDialogKeydown)
@@ -293,6 +316,7 @@ onBeforeUnmount(() => {
     <input v-model="search" type="text" :placeholder="t('mounts.searchPlaceholder')" :aria-label="t('mounts.searchPlaceholder')" />
 
     <DataTable :columns="columns" :rows="paged" :empty-text="t('mounts.empty')">
+      <template #cell-project_id="{ row }">{{ formatProjectId(row.project_id) }}</template>
       <template #cell-remote_path="{ row }">{{ protectedValue(row.remote_path) }}</template>
       <template #cell-local_mount_point="{ row }">{{ protectedValue(row.local_mount_point) }}</template>
       <template #cell-status="{ row }"><StatusBadge :status="row.status" /></template>
@@ -323,7 +347,7 @@ onBeforeUnmount(() => {
       :aria-label="browseLabel(activeBrowsedMount)"
     >
       <h3 class="browse-panel-title">
-        {{ t('browse.browseMountContents') }}: {{ activeBrowsedMount.project_id || t('common.labels.protected') }}
+        {{ t('browse.browseMountContents') }}: {{ formatProjectId(activeBrowsedMount.project_id) }}
       </h3>
       <DirectoryBrowser
         :mount-path="activeBrowsedMount.local_mount_point"

--- a/frontend/src/views/SystemView.vue
+++ b/frontend/src/views/SystemView.vue
@@ -14,6 +14,7 @@ import DataTable from '@/components/common/DataTable.vue'
 import Pagination from '@/components/common/Pagination.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useAuthStore } from '@/stores/auth.js'
+import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
 
 const { t } = useI18n()
 const authStore = useAuthStore()
@@ -150,6 +151,10 @@ const workerQueueDisplay = computed(() => {
   return q
 })
 
+function formatProjectId(value) {
+  return normalizeProjectId(value) || t('dashboard.project')
+}
+
 function extractApiMessage(err) {
   const data = err?.response?.data || {}
   return String(data.message || data.detail || '').trim()
@@ -222,7 +227,7 @@ async function loadJobDebug() {
   loading.value = true
   error.value = ''
   try {
-    jobDebug.value = await getJobDebug(Number(jobDebugId.value))
+    jobDebug.value = normalizeProjectRecord(await getJobDebug(Number(jobDebugId.value)), ['project_id'])
   } catch (err) {
     const status = err?.response?.status
     if (status === 404) {
@@ -242,7 +247,9 @@ async function loadJobOptions() {
   jobsListUnavailable.value = false
   try {
     const response = await listJobs({ limit: 200 })
-    jobs.value = Array.isArray(response) ? response : []
+    jobs.value = Array.isArray(response)
+      ? response.map((item) => normalizeProjectRecord(item, ['project_id']))
+      : []
   } catch {
     jobs.value = []
     jobsListUnavailable.value = true
@@ -350,7 +357,7 @@ onMounted(loadTabData)
         <select id="job-picker" class="job-picker" :value="jobDebugId" @change="onJobPickerChange">
           <option value="">{{ t('system.jobPickerPlaceholder') }}</option>
           <option v-for="job in jobs" :key="job.id" :value="String(job.id)">
-            #{{ job.id }} - {{ job.project_id || t('dashboard.project') }} - {{ job.status || t('common.labels.unknown') }}
+            #{{ job.id }} - {{ formatProjectId(job.project_id) }} - {{ job.status || t('common.labels.unknown') }}
           </option>
         </select>
         <input v-model="jobDebugId" type="number" min="1" :placeholder="t('jobs.jobId')" />
@@ -361,7 +368,7 @@ onMounted(loadTabData)
       <div v-if="jobDebug" class="health-grid">
         <span>{{ t('jobs.jobId') }}</span><strong>{{ jobDebug.job_id }}</strong>
         <span>{{ t('common.labels.status') }}</span><StatusBadge :status="jobDebug.status" />
-        <span>{{ t('dashboard.project') }}</span><strong>{{ jobDebug.project_id }}</strong>
+        <span>{{ t('dashboard.project') }}</span><strong>{{ formatProjectId(jobDebug.project_id) }}</strong>
         <span>{{ t('dashboard.progress') }}</span><strong>{{ jobDebug.copied_bytes || 0 }} / {{ jobDebug.total_bytes || 0 }}</strong>
       </div>
 

--- a/frontend/src/views/__tests__/DrivesView.spec.js
+++ b/frontend/src/views/__tests__/DrivesView.spec.js
@@ -38,7 +38,15 @@ function mountView() {
       stubs: {
         DataTable: {
           props: ['rows', 'emptyText'],
-          template: '<div><slot v-for="row in rows" name="cell-actions" :row="row" /><div class="rows-count">{{ rows.length }}</div></div>',
+          template: `
+            <div>
+              <div v-for="row in rows" :key="row.id" class="row-stub">
+                <slot name="cell-current_project_id" :row="row" />
+                <slot name="cell-actions" :row="row" />
+              </div>
+              <div class="rows-count">{{ rows.length }}</div>
+            </div>
+          `,
         },
         Pagination: true,
         StatusBadge: {
@@ -110,6 +118,16 @@ describe('DrivesView rescan and filter loading', () => {
 
     expect(wrapper.find('select').element.value).toBe('ALL')
     expect(mocks.getDrives).toHaveBeenLastCalledWith({ include_disconnected: true })
+  })
+
+  it('renders project IDs in uppercase even when the data arrives mixed-case', async () => {
+    mocks.getDrives.mockResolvedValue([buildDrive({ current_project_id: 'proj-123' })])
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('PROJ-123')
+    expect(wrapper.text()).not.toContain('proj-123')
   })
 
   it('shows the Browse action for a mounted available drive', async () => {

--- a/frontend/src/views/__tests__/MountsView.spec.js
+++ b/frontend/src/views/__tests__/MountsView.spec.js
@@ -124,7 +124,7 @@ describe('MountsView removal flow', () => {
     expect(wrapper.text()).toContain(i18n.global.t('mounts.removeConfirmTitle'))
   })
 
-  it('submits the selected project when adding a mount', async () => {
+  it('uppercases the project ID as the operator types and submits it normalized', async () => {
     mocks.getMounts.mockResolvedValue([])
 
     const wrapper = mountView()
@@ -137,7 +137,10 @@ describe('MountsView removal flow', () => {
     await flushPromises()
 
     await wrapper.find('#mount-remote-path').setValue('//server/new-share')
-    await wrapper.find('#mount-project-id').setValue('PROJ-NEW')
+    await wrapper.find('#mount-project-id').setValue('proj-new')
+
+    expect(wrapper.find('#mount-project-id').element.value).toBe('PROJ-NEW')
+
     await wrapper.findAll('button').find((node) => node.text() === i18n.global.t('common.actions.create')).trigger('click')
     await flushPromises()
 


### PR DESCRIPTION
Fixes Issue 216

### What changed
- normalized project IDs to uppercase across the frontend
- uppercased project input values live as operators type in job and mount workflows
- ensured mixed-case project values returned from APIs render consistently in uppercase in key views
- added shared frontend normalization helpers to avoid duplicated logic

### Affected areas
- job creation wizard
- add mount dialog
- drives list and drive detail views
- dashboard, audit, system, and job detail displays

### Why
This keeps project identifiers in a single canonical format throughout the product, reduces operator confusion, and avoids casing-related inconsistencies in project-based workflows.

### Verification
- added regression coverage for uppercase entry and display behavior
- verified with targeted frontend unit tests: **30 passed**