### PR TITLE
Fix issue where progress bar starts at 100

### DIFF
--- a/frontend/src/utils/jobProgress.js
+++ b/frontend/src/utils/jobProgress.js
@@ -1,0 +1,62 @@
+function clampPercent(value) {
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+function isActiveStatus(status) {
+  return ['RUNNING', 'PAUSING', 'VERIFYING'].includes(String(status || '').toUpperCase())
+}
+
+export function calculateJobProgress(job) {
+  if (!job) {
+    return {
+      percent: 0,
+      totalBytes: 0,
+      copiedBytes: 0,
+      totalFiles: 0,
+      finishedFiles: 0,
+      bytePercent: null,
+      filePercent: null,
+      active: false,
+    }
+  }
+
+  const status = String(job.status || '').toUpperCase()
+  const totalBytes = Number(job.total_bytes || 0)
+  const copiedBytes = Number(job.copied_bytes || 0)
+  const totalFiles = Number(job.file_count || 0)
+  const filesSucceeded = Number(job.files_succeeded || 0)
+  const filesFailed = Number(job.files_failed || 0)
+  const finishedFiles = Math.min(totalFiles, filesSucceeded + filesFailed)
+  const active = isActiveStatus(status)
+
+  const bytePercent = totalBytes > 0
+    ? clampPercent((copiedBytes / totalBytes) * 100)
+    : null
+  const filePercent = totalFiles > 0
+    ? clampPercent((finishedFiles / totalFiles) * 100)
+    : null
+
+  const knownPercents = [bytePercent, filePercent].filter((value) => value != null)
+  const percent = active
+    ? (knownPercents.length ? Math.min(...knownPercents) : 0)
+    : (bytePercent ?? filePercent ?? 0)
+
+  const displayCopiedBytes = active && totalBytes > 0 && bytePercent != null && bytePercent > percent
+    ? Math.min(copiedBytes, Math.floor((percent / 100) * totalBytes))
+    : copiedBytes
+
+  return {
+    percent,
+    totalBytes,
+    copiedBytes: displayCopiedBytes,
+    totalFiles,
+    finishedFiles,
+    bytePercent,
+    filePercent,
+    active,
+  }
+}
+
+export function isJobProgressActive(job) {
+  return isActiveStatus(job?.status)
+}

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -8,6 +8,7 @@ import { usePolling } from '@/composables/usePolling.js'
 import DataTable from '@/components/common/DataTable.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import ProgressBar from '@/components/common/ProgressBar.vue'
+import { calculateJobProgress, isJobProgressActive } from '@/utils/jobProgress.js'
 import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
 
 const { t } = useI18n()
@@ -43,33 +44,11 @@ function formatProjectId(value) {
 }
 
 function progressPercent(job) {
-  if (!job) return 0
-
-  const status = String(job.status || '').toUpperCase()
-  const totalBytes = Number(job.total_bytes || 0)
-  const copiedBytes = Number(job.copied_bytes || 0)
-  const totalFiles = Number(job.file_count || 0)
-  const filesSucceeded = Number(job.files_succeeded || 0)
-  const filesFailed = Number(job.files_failed || 0)
-  const finishedFiles = Math.min(totalFiles, filesSucceeded + filesFailed)
-
-  const bytePercent = totalBytes > 0
-    ? Math.max(0, Math.min(100, Math.round((copiedBytes / totalBytes) * 100)))
-    : 0
-  const filePercent = totalFiles > 0
-    ? Math.max(0, Math.min(100, Math.round((finishedFiles / totalFiles) * 100)))
-    : bytePercent
-
-  if (status === 'RUNNING' || status === 'VERIFYING') {
-    return Math.min(bytePercent || 100, filePercent || 100)
-  }
-
-  return totalBytes > 0 ? bytePercent : filePercent
+  return calculateJobProgress(job).percent
 }
 
 function progressActive(job) {
-  const status = String(job?.status || '').toUpperCase()
-  return status === 'RUNNING' || status === 'VERIFYING'
+  return isJobProgressActive(job)
 }
 
 async function refreshSnapshot() {

--- a/frontend/src/views/JobDetailView.vue
+++ b/frontend/src/views/JobDetailView.vue
@@ -13,6 +13,7 @@ import DataTable from '@/components/common/DataTable.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import ProgressBar from '@/components/common/ProgressBar.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
+import { calculateJobProgress, isJobProgressActive } from '@/utils/jobProgress.js'
 import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
 
 const route = useRoute()
@@ -103,38 +104,16 @@ const selectedCompareFile = computed(() => (
 ))
 
 const progressMetrics = computed(() => {
-  const currentJob = job.value || {}
-  const status = String(currentJob.status || '').toUpperCase()
-  const totalBytes = Number(currentJob.total_bytes || 0)
-  const copiedBytes = Number(currentJob.copied_bytes || 0)
-  const totalFiles = Number(currentJob.file_count || 0)
-  const filesSucceeded = Number(currentJob.files_succeeded || 0)
-  const filesFailed = Number(currentJob.files_failed || 0)
-  const finishedFiles = Math.min(totalFiles, filesSucceeded + filesFailed)
-
-  const bytePercent = totalBytes > 0
-    ? Math.max(0, Math.min(100, Math.round((copiedBytes / totalBytes) * 100)))
-    : 0
-  const filePercent = totalFiles > 0
-    ? Math.max(0, Math.min(100, Math.round((finishedFiles / totalFiles) * 100)))
-    : bytePercent
-
-  const percent = (status === 'RUNNING' || status === 'PAUSING' || status === 'VERIFYING')
-    ? Math.min(bytePercent || 100, filePercent || 100)
-    : (totalBytes > 0 ? bytePercent : filePercent)
-
-  const displayCopiedBytes = (status === 'RUNNING' || status === 'PAUSING' || status === 'VERIFYING') && totalBytes > 0 && bytePercent > percent
-    ? Math.min(copiedBytes, Math.floor((percent / 100) * totalBytes))
-    : copiedBytes
+  const metrics = calculateJobProgress(job.value)
 
   return {
     total: 100,
-    value: percent,
-    percent,
-    totalBytes,
-    copiedBytes: displayCopiedBytes,
-    totalFiles,
-    finishedFiles,
+    value: metrics.percent,
+    percent: metrics.percent,
+    totalBytes: metrics.totalBytes,
+    copiedBytes: metrics.copiedBytes,
+    totalFiles: metrics.totalFiles,
+    finishedFiles: metrics.finishedFiles,
   }
 })
 
@@ -147,8 +126,7 @@ const progressLabel = computed(() => {
 })
 
 const progressActive = computed(() => {
-  const status = String(job.value?.status || '').toUpperCase()
-  return status === 'RUNNING' || status === 'PAUSING' || status === 'VERIFYING'
+  return isJobProgressActive(job.value)
 })
 
 const canStart = computed(() => {

--- a/frontend/src/views/JobsView.vue
+++ b/frontend/src/views/JobsView.vue
@@ -11,6 +11,7 @@ import DataTable from '@/components/common/DataTable.vue'
 import Pagination from '@/components/common/Pagination.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useStatusLabels } from '@/composables/useStatusLabels.js'
+import { calculateJobProgress } from '@/utils/jobProgress.js'
 import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
 
 const router = useRouter()
@@ -117,28 +118,7 @@ async function runJobAction(job, action) {
 }
 
 function progressPercent(job) {
-  if (!job) return 0
-
-  const status = String(job.status || '').toUpperCase()
-  const totalBytes = Number(job.total_bytes || 0)
-  const copiedBytes = Number(job.copied_bytes || 0)
-  const totalFiles = Number(job.file_count || 0)
-  const filesSucceeded = Number(job.files_succeeded || 0)
-  const filesFailed = Number(job.files_failed || 0)
-  const finishedFiles = Math.min(totalFiles, filesSucceeded + filesFailed)
-
-  const bytePercent = totalBytes > 0
-    ? Math.max(0, Math.min(100, Math.round((copiedBytes / totalBytes) * 100)))
-    : 0
-  const filePercent = totalFiles > 0
-    ? Math.max(0, Math.min(100, Math.round((finishedFiles / totalFiles) * 100)))
-    : bytePercent
-
-  if (status === 'RUNNING' || status === 'PAUSING' || status === 'VERIFYING') {
-    return Math.min(bytePercent || 100, filePercent || 100)
-  }
-
-  return totalBytes > 0 ? bytePercent : filePercent
+  return calculateJobProgress(job).percent
 }
 
 function formatProjectId(value) {

--- a/frontend/src/views/__tests__/DashboardView.spec.js
+++ b/frontend/src/views/__tests__/DashboardView.spec.js
@@ -83,4 +83,24 @@ describe('DashboardView active jobs', () => {
 
     expect(wrapper.find('.progress-stub').text()).toBe('40/100')
   })
+
+  it('does not show 100% when a running job is still below 1%', async () => {
+    mocks.listJobs.mockResolvedValue([
+      {
+        id: 16,
+        project_id: 'PROJ-001',
+        status: 'RUNNING',
+        copied_bytes: 136 * 1024 * 1024,
+        total_bytes: 27 * 1024 * 1024 * 1024,
+        file_count: 5000,
+        files_succeeded: 0,
+        files_failed: 0,
+      },
+    ])
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.find('.progress-stub').text()).toBe('0/100')
+  })
 })

--- a/frontend/src/views/__tests__/JobDetailView.spec.js
+++ b/frontend/src/views/__tests__/JobDetailView.spec.js
@@ -281,6 +281,31 @@ describe('JobDetailView start action', () => {
     expect(wrapper.text()).toContain('1.5 KB / 483 MB')
   })
 
+  it('does not show 100% while a running job is still below 1%', async () => {
+    mocks.getJob.mockResolvedValue({
+      id: 6,
+      status: 'RUNNING',
+      project_id: 'PROJ-001',
+      evidence_number: 'EV-006',
+      source_path: '/nfs/project-001/evidence',
+      target_mount_path: '/mnt/ecube/1',
+      thread_count: 4,
+      copied_bytes: 136 * 1024 * 1024,
+      total_bytes: 27 * 1024 * 1024 * 1024,
+      file_count: 5000,
+      files_succeeded: 0,
+      files_failed: 0,
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const progress = wrapper.find('.progressbar-stub').text()
+    expect(progress).toContain('0|100|')
+    expect(progress).not.toContain('100|100|')
+    expect(wrapper.text()).toContain('136 MB / 27 GB')
+  })
+
   it('keeps verify and manifest disabled until the job reaches 100%', async () => {
     mocks.getJob.mockResolvedValue({
       id: 6,

--- a/frontend/src/views/__tests__/JobsView.spec.js
+++ b/frontend/src/views/__tests__/JobsView.spec.js
@@ -323,6 +323,29 @@ describe('JobsView grouped create dialog', () => {
     expect(wrapper.find('.row-progress-stub').text()).not.toContain('100%')
   })
 
+  it('does not show 100% when running progress rounds down to 0%', async () => {
+    mocks.listJobs.mockResolvedValue([
+      {
+        id: 16,
+        project_id: 'PROJ-001',
+        evidence_number: 'EV-016',
+        status: 'RUNNING',
+        source_path: '/nfs/project-001',
+        total_bytes: 27 * 1024 * 1024 * 1024,
+        copied_bytes: 136 * 1024 * 1024,
+        file_count: 5000,
+        files_succeeded: 0,
+        files_failed: 0,
+      },
+    ])
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.find('.row-progress-stub').text()).toContain('0%')
+    expect(wrapper.find('.row-progress-stub').text()).not.toContain('100%')
+  })
+
   it('uses Details as the row action label', async () => {
     mocks.listJobs.mockResolvedValue([
       {


### PR DESCRIPTION
This change fixes a frontend job-progress regression where active jobs could briefly render as `100%` even when the copy had only just started and the true rounded percentage was still `0%`. The progress calculation is now centralized and reused across the dashboard, jobs list, and job detail views so all three surfaces show consistent, conservative progress.

**Changes Included**

- Added a shared frontend progress helper in jobProgress.js.
- Replaced duplicated per-view progress math in:
  - DashboardView.vue
  - JobsView.vue
  - JobDetailView.vue
- Fixed the root cause of the false `100%` display:
  - previous logic treated a real `0` percentage as falsy and fell back to `100`
  - new logic distinguishes unknown progress from a valid `0%`
- Preserved existing conservative behavior for active jobs by continuing to use the lower of byte-based and file-based progress when both are available.
- Added targeted regression coverage for the low-progress case in:
  - DashboardView.spec.js
  - JobsView.spec.js
  - JobDetailView.spec.js

**User-Facing Effects**

- Running jobs no longer flash `100%` when they are still below `1%` complete.
- Dashboard, jobs list, and job detail now report progress consistently.
- Byte display remains accurate for early-copy states such as `136 MB / 27 GB` while the visible percent remains `0%` until it legitimately rounds up.

**Validation**

- Focused frontend regression tests passed:
  - `npx vitest run src/views/__tests__/JobsView.spec.js src/views/__tests__/JobDetailView.spec.js src/views/__tests__/DashboardView.spec.js`
- Result: `3` test files passed, `31` tests passed.
- The coverage-enforced `npm run test:unit` script was not used as the final validation artifact for this change because targeted runs trip unrelated global coverage thresholds when only a subset of specs is executed. Full-suite coverage validation is still needed if required for merge gating.