### PR TITLE
Capture safe USB metadata and show readable drive labels

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -258,6 +258,18 @@ Forbidden:
 - JSON fields use SQLAlchemy JSON in models; PostgreSQL JSONB in migrations.
 - Index tables by project, status, and timestamps.
 - Background copy tasks must not starve the system.
+
+# Alembic release workflow (issue 280)
+- While ECUBE is pre-release, the current unreleased application version may
+  intentionally accumulate schema changes inside the baseline or current
+  release-scoped Alembic migration instead of creating a new forward migration
+  for every schema edit.
+- PR review must not flag this pattern by itself as a migration-history defect
+  when it is clearly part of the accepted release-scoped migration workflow
+  tracked by issue 280.
+- Reviewers must still verify that fresh databases migrate to the expected
+  schema and that the chosen workflow is documented in the change or linked
+  issue when a migration file is edited in place.
 - Drive lifecycle transitions must be atomic.
 
 ###############################################################################

--- a/alembic/versions/0001_initial.py
+++ b/alembic/versions/0001_initial.py
@@ -72,6 +72,8 @@ def upgrade() -> None:
         sa.Column("id", sa.Integer, primary_key=True),
         sa.Column("port_id", sa.Integer, sa.ForeignKey("usb_ports.id"), nullable=True),
         sa.Column("device_identifier", sa.String, unique=True, nullable=False),
+        sa.Column("manufacturer", sa.String(), nullable=True),
+        sa.Column("product_name", sa.String(), nullable=True),
         sa.Column("filesystem_path", sa.String, nullable=True),
         sa.Column("filesystem_type", sa.String(), nullable=True),
         sa.Column("capacity_bytes", sa.BigInteger, nullable=True),

--- a/app/infrastructure/usb_discovery.py
+++ b/app/infrastructure/usb_discovery.py
@@ -67,6 +67,12 @@ class DiscoveredDrive:
     mount_path: Optional[str] = None
     """Active mount point from ``/proc/mounts``, e.g. ``"/mnt/ecube/7"``.
     ``None`` when the device is not currently mounted."""
+    manufacturer: Optional[str] = None
+    """USB manufacturer string when available."""
+    product_name: Optional[str] = None
+    """USB product string when available."""
+    speed: Optional[str] = None
+    """Port speed in Mbps when available."""
 
 
 @dataclass
@@ -253,6 +259,8 @@ def discover_usb_topology() -> DiscoveredTopology:
                 # Check for a mass-storage drive at this port
                 interface_class = _read_sysfs_attr(dev_path, "bDeviceClass") or ""
                 serial = _read_sysfs_attr(dev_path, "serial")
+                manufacturer = _read_sysfs_attr(dev_path, "manufacturer")
+                product_name = _read_sysfs_attr(dev_path, "product")
                 device_id = serial if serial else dev
                 block_node = _block_device_for_sysfs_path(dev_path)
                 if block_node or interface_class == "00":
@@ -271,6 +279,9 @@ def discover_usb_topology() -> DiscoveredTopology:
                             filesystem_path=block_node,
                             capacity_bytes=capacity,
                             mount_path=_find_mount_point(block_node, mount_map) if block_node else None,
+                            manufacturer=manufacturer,
+                            product_name=product_name,
+                            speed=port_speed,
                         )
                     )
 

--- a/app/models/hardware.py
+++ b/app/models/hardware.py
@@ -2,6 +2,7 @@ from sqlalchemy import Boolean, Column, Integer, String, BigInteger, Enum, Forei
 from sqlalchemy.orm import relationship, validates
 from sqlalchemy.sql import func
 from app.database import Base
+from app.utils.drive_identity import build_readable_device_label
 from app.utils.sanitize import normalize_project_id
 import enum
 
@@ -49,6 +50,8 @@ class UsbDrive(Base):
     id = Column(Integer, primary_key=True)
     port_id = Column(Integer, ForeignKey("usb_ports.id"), nullable=True)
     device_identifier = Column(String, unique=True, nullable=False)
+    manufacturer = Column(String, nullable=True)
+    product_name = Column(String, nullable=True)
     filesystem_path = Column(String)
     capacity_bytes = Column(BigInteger)
     encryption_status = Column(String)
@@ -69,11 +72,28 @@ class UsbDrive(Base):
         return self.port.system_path if self.port else None
 
     @property
+    def port_number(self):
+        return self.port.port_number if self.port else None
+
+    @property
+    def speed(self):
+        return self.port.speed if self.port else None
+
+    @property
     def serial_number(self):
         port_system_path = self.port_system_path
         if port_system_path and self.device_identifier == port_system_path:
             return None
         return self.device_identifier or None
+
+    @property
+    def display_device_label(self):
+        return build_readable_device_label(
+            self.manufacturer,
+            self.product_name,
+            self.port_number,
+            fallback_label=self.port_system_path or self.device_identifier,
+        )
 
     @validates("current_project_id")
     def _normalize_current_project_id(self, _key, value):

--- a/app/schemas/hardware.py
+++ b/app/schemas/hardware.py
@@ -32,10 +32,15 @@ class UsbPortSchema(BaseModel):
 class UsbDriveSchema(BaseModel):
     id: int = Field(..., description="Unique identifier for the drive")
     port_id: Optional[int] = Field(default=None, description="ID of the port the drive is connected to")
+    port_number: Optional[int] = Field(default=None, description="Port number on the parent USB hub when available")
+    speed: Optional[str] = Field(default=None, description="Port speed in Mbps when available")
     port_system_path: Optional[str] = Field(
         default=None,
         description="Port-based USB identifier for the parent port (for example '2-1')",
     )
+    manufacturer: Optional[str] = Field(default=None, description="USB manufacturer string when available")
+    product_name: Optional[str] = Field(default=None, description="USB product string when available")
+    display_device_label: str = Field(..., description="Operator-friendly drive label built from safe USB metadata")
     device_identifier: str = Field(
         ...,
         description=(

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -140,7 +140,12 @@ class DriveInfoSchema(BaseModel):
     """Subset of drive metadata embedded in job responses."""
 
     id: int = Field(..., description="Unique identifier for the drive")
+    port_number: Optional[int] = Field(default=None, description="Port number on the parent USB hub when available")
+    speed: Optional[str] = Field(default=None, description="Port speed in Mbps when available")
     port_system_path: Optional[str] = Field(default=None, description="Port-based USB identifier (for example '2-1')")
+    manufacturer: Optional[str] = Field(default=None, description="USB manufacturer string when available")
+    product_name: Optional[str] = Field(default=None, description="USB product string when available")
+    display_device_label: str = Field(..., description="Operator-friendly drive label built from safe USB metadata")
     device_identifier: str = Field(..., description="Stable hardware identifier for the drive")
     filesystem_path: Optional[str] = Field(default=None, description="Current OS block device node (e.g. /dev/sdb)")
     capacity_bytes: Optional[int] = Field(default=None, description="Total storage capacity in bytes")

--- a/app/services/discovery_service.py
+++ b/app/services/discovery_service.py
@@ -48,8 +48,55 @@ from app.models.hardware import DriveState, UsbDrive, UsbPort
 from app.repositories.audit_repository import AuditRepository
 from app.repositories.drive_repository import DriveRepository
 from app.repositories.hardware_repository import HubRepository, PortRepository
+from app.utils.drive_identity import build_readable_device_label, mask_serial_number
 
 logger = logging.getLogger(__name__)
+
+
+def _serial_number_from_identifier(device_identifier: Optional[str], port_system_path: Optional[str]) -> Optional[str]:
+    identifier = str(device_identifier or "").strip()
+    if not identifier:
+        return None
+    if port_system_path and identifier == port_system_path:
+        return None
+    return identifier
+
+
+def _build_discovered_drive_metadata(discovered_drive, discovered_port=None, *, drive_id: Optional[int] = None) -> dict:
+    port_number = discovered_port.port_number if discovered_port else None
+    speed = discovered_drive.speed or (discovered_port.speed if discovered_port else None)
+    serial_number = _serial_number_from_identifier(
+        discovered_drive.device_identifier,
+        discovered_drive.port_system_path,
+    )
+    return {
+        "drive_id": drive_id,
+        "device_label": build_readable_device_label(
+            discovered_drive.manufacturer,
+            discovered_drive.product_name,
+            port_number,
+            fallback_label=discovered_drive.port_system_path or "USB Drive",
+        ),
+        "manufacturer": discovered_drive.manufacturer,
+        "product_name": discovered_drive.product_name,
+        "port_number": port_number,
+        "speed": speed,
+        "serial_number_present": bool(serial_number),
+        "serial_number_masked": mask_serial_number(serial_number),
+    }
+
+
+def _build_persisted_drive_metadata(drive: UsbDrive) -> dict:
+    return {
+        "drive_id": drive.id,
+        "device_label": drive.display_device_label,
+        "manufacturer": drive.manufacturer,
+        "product_name": drive.product_name,
+        "port_number": drive.port_number,
+        "speed": drive.speed,
+        "serial_number_present": bool(drive.serial_number),
+        "serial_number_masked": mask_serial_number(drive.serial_number),
+    }
 
 
 def discover_usb_topology() -> DiscoveredTopology:
@@ -101,7 +148,7 @@ def run_discovery_sync(
     dict
         Summary with counts of hubs, ports, drives inserted/updated/removed.
     """
-    logger.info("USB_DISCOVERY_SYNC_STARTED actor=%s", actor or "system")
+    logger.info("USB discovery sync started", {"actor": actor or "system"})
     topology = topology_source()
 
     hub_repo = HubRepository(db)
@@ -127,6 +174,7 @@ def run_discovery_sync(
     # ----------------------------------------------------------------- ports
     ports_upserted: List[str] = []
     port_id_by_system_path: dict[str, int] = {}
+    discovered_port_by_system_path: dict[str, object] = {}
 
     for discovered_port in topology.ports:
         hub_id = hub_id_by_system_id.get(discovered_port.hub_system_identifier)
@@ -148,6 +196,7 @@ def run_discovery_sync(
             speed=discovered_port.speed,
         )
         port_id_by_system_path[discovered_port.system_path] = port.id
+        discovered_port_by_system_path[discovered_port.system_path] = discovered_port
         ports_upserted.append(discovered_port.system_path)
 
     # ---------------------------------------------------------------- drives
@@ -155,6 +204,8 @@ def run_discovery_sync(
     drives_inserted: List[str] = []
     drives_updated: List[str] = []
     drives_removed: List[str] = []
+    observed_drive_metadata: List[dict] = []
+    removed_drive_metadata: List[dict] = []
 
     # Build set of enabled port IDs for port-enablement filtering.
     enabled_port_ids: set[int] = {
@@ -167,6 +218,7 @@ def run_discovery_sync(
 
     # Upsert each discovered drive.
     for discovered_drive in topology.drives:
+        discovered_port = discovered_port_by_system_path.get(discovered_drive.port_system_path)
         existing: Optional[UsbDrive] = (
             db.query(UsbDrive)
             .filter(UsbDrive.device_identifier == discovered_drive.device_identifier)
@@ -188,6 +240,8 @@ def run_discovery_sync(
                 initial_state = DriveState.DISCONNECTED
             drive = UsbDrive(
                 device_identifier=discovered_drive.device_identifier,
+                manufacturer=discovered_drive.manufacturer,
+                product_name=discovered_drive.product_name,
                 port_id=port_id,
                 filesystem_path=discovered_drive.filesystem_path,
                 capacity_bytes=discovered_drive.capacity_bytes,
@@ -218,6 +272,9 @@ def run_discovery_sync(
                 continue
             db.refresh(drive)
             drives_inserted.append(discovered_drive.device_identifier)
+            metadata = _build_discovered_drive_metadata(discovered_drive, discovered_port, drive_id=drive.id)
+            observed_drive_metadata.append({"action": "inserted", **metadata})
+            logger.info("USB discovery inserted drive", metadata)
 
         else:
             # Existing drive — update mutable fields.
@@ -230,6 +287,12 @@ def run_discovery_sync(
                 changed = True
             if discovered_drive.capacity_bytes is not None and existing.capacity_bytes != discovered_drive.capacity_bytes:
                 existing.capacity_bytes = discovered_drive.capacity_bytes
+                changed = True
+            if discovered_drive.manufacturer is not None and existing.manufacturer != discovered_drive.manufacturer:
+                existing.manufacturer = discovered_drive.manufacturer
+                changed = True
+            if discovered_drive.product_name is not None and existing.product_name != discovered_drive.product_name:
+                existing.product_name = discovered_drive.product_name
                 changed = True
             if existing.mount_path != discovered_drive.mount_path:
                 existing.mount_path = discovered_drive.mount_path
@@ -281,6 +344,14 @@ def run_discovery_sync(
                     continue
                 db.refresh(existing)
                 drives_updated.append(discovered_drive.device_identifier)
+                metadata = _build_persisted_drive_metadata(existing)
+                observed_drive_metadata.append({"action": "updated", **metadata})
+                logger.info("USB discovery updated drive", metadata)
+            else:
+                observed_drive_metadata.append({
+                    "action": "observed",
+                    **_build_discovered_drive_metadata(discovered_drive, discovered_port, drive_id=existing.id),
+                })
 
     # Mark drives absent from hardware as DISCONNECTED (unless IN_USE — project
     # isolation must not be broken). Also clear stale device-path evidence and
@@ -313,6 +384,9 @@ def run_discovery_sync(
                 db.refresh(drive)
                 if was_available:
                     drives_removed.append(drive.device_identifier)
+                    removed_metadata = _build_persisted_drive_metadata(drive)
+                    removed_drive_metadata.append(removed_metadata)
+                    logger.info("USB discovery removed drive", removed_metadata)
                     try:
                         audit_repo.add(
                             action="DRIVE_REMOVED",
@@ -335,6 +409,8 @@ def run_discovery_sync(
         "drives_inserted": len(drives_inserted),
         "drives_updated": len(drives_updated),
         "drives_removed": len(drives_removed),
+        "observed_drives": observed_drive_metadata,
+        "removed_drives": removed_drive_metadata,
     }
 
     try:
@@ -348,13 +424,15 @@ def run_discovery_sync(
         logger.exception("Failed to write audit log for USB_DISCOVERY_SYNC")
 
     logger.info(
-        "USB_DISCOVERY_SYNC_COMPLETED actor=%s hubs_upserted=%d ports_upserted=%d drives_inserted=%d drives_updated=%d drives_removed=%d",
-        actor or "system",
-        summary["hubs_upserted"],
-        summary["ports_upserted"],
-        summary["drives_inserted"],
-        summary["drives_updated"],
-        summary["drives_removed"],
+        "USB discovery sync completed",
+        {
+            "actor": actor or "system",
+            "hubs_upserted": summary["hubs_upserted"],
+            "ports_upserted": summary["ports_upserted"],
+            "drives_inserted": summary["drives_inserted"],
+            "drives_updated": summary["drives_updated"],
+            "drives_removed": summary["drives_removed"],
+        },
     )
 
     return summary

--- a/app/services/discovery_service.py
+++ b/app/services/discovery_service.py
@@ -148,7 +148,7 @@ def run_discovery_sync(
     dict
         Summary with counts of hubs, ports, drives inserted/updated/removed.
     """
-    logger.info("USB discovery sync started", {"actor": actor or "system"})
+    logger.info("USB discovery sync started", extra={"actor": actor or "system"})
     topology = topology_source()
 
     hub_repo = HubRepository(db)
@@ -274,7 +274,7 @@ def run_discovery_sync(
             drives_inserted.append(discovered_drive.device_identifier)
             metadata = _build_discovered_drive_metadata(discovered_drive, discovered_port, drive_id=drive.id)
             observed_drive_metadata.append({"action": "inserted", **metadata})
-            logger.info("USB discovery inserted drive", metadata)
+            logger.info("USB discovery inserted drive", extra=metadata)
 
         else:
             # Existing drive — update mutable fields.
@@ -346,7 +346,7 @@ def run_discovery_sync(
                 drives_updated.append(discovered_drive.device_identifier)
                 metadata = _build_persisted_drive_metadata(existing)
                 observed_drive_metadata.append({"action": "updated", **metadata})
-                logger.info("USB discovery updated drive", metadata)
+                logger.info("USB discovery updated drive", extra=metadata)
             else:
                 observed_drive_metadata.append({
                     "action": "observed",
@@ -386,7 +386,7 @@ def run_discovery_sync(
                     drives_removed.append(drive.device_identifier)
                     removed_metadata = _build_persisted_drive_metadata(drive)
                     removed_drive_metadata.append(removed_metadata)
-                    logger.info("USB discovery removed drive", removed_metadata)
+                    logger.info("USB discovery removed drive", extra=removed_metadata)
                     try:
                         audit_repo.add(
                             action="DRIVE_REMOVED",
@@ -425,7 +425,7 @@ def run_discovery_sync(
 
     logger.info(
         "USB discovery sync completed",
-        {
+        extra={
             "actor": actor or "system",
             "hubs_upserted": summary["hubs_upserted"],
             "ports_upserted": summary["ports_upserted"],

--- a/app/services/drive_service.py
+++ b/app/services/drive_service.py
@@ -15,9 +15,27 @@ from app.models.hardware import DriveState, UsbDrive
 from app.repositories.audit_repository import AuditRepository
 from app.repositories.drive_repository import DriveRepository
 from app.repositories.mount_repository import MountRepository
+from app.utils.drive_identity import mask_serial_number
 from app.utils.sanitize import normalize_project_id, sanitize_error_message
 
 logger = logging.getLogger(__name__)
+
+
+def _safe_drive_log_context(drive: UsbDrive, *, reason: Optional[str] = None) -> dict:
+    context = {
+        "drive_id": drive.id,
+        "device_label": getattr(drive, "display_device_label", drive.device_identifier),
+        "manufacturer": getattr(drive, "manufacturer", None),
+        "product_name": getattr(drive, "product_name", None),
+        "port_number": getattr(drive, "port_number", None),
+        "speed": getattr(drive, "speed", None),
+        "serial_number_present": bool(getattr(drive, "serial_number", None)),
+        "serial_number_masked": mask_serial_number(getattr(drive, "serial_number", None)),
+        "current_state": drive.current_state.value if drive.current_state else None,
+    }
+    if reason:
+        context["reason"] = reason
+    return context
 
 
 def _redacted_device_name(path: Optional[str]) -> Optional[str]:
@@ -434,12 +452,11 @@ def mount_drive(
     success, error = provider.mount_drive(initial_filesystem_path, mount_point)
     if not success:
         logger.warning(
-            "Drive mount failed: drive_id=%s device_name=%s filesystem_type=%s mount_slot=%s reason=%s",
-            drive_id,
-            _redacted_device_name(initial_filesystem_path),
-            drive.filesystem_type,
-            _redacted_device_name(mount_point),
-            sanitize_error_message(error, "Mount provider reported failure"),
+            "Drive mount failed",
+            {
+                **_safe_drive_log_context(drive, reason=sanitize_error_message(error, "Mount provider reported failure")),
+                "filesystem_type": drive.filesystem_type,
+            },
         )
         try:
             audit_repo.add(
@@ -587,6 +604,15 @@ def mount_drive(
         )
     except Exception:
         logger.exception("Failed to write audit log for DRIVE_MOUNTED")
+
+    logger.info(
+        "Drive mounted",
+        {
+            **_safe_drive_log_context(drive),
+            "filesystem_type": drive.filesystem_type,
+            "project_id": drive.current_project_id,
+        },
+    )
 
     return drive
 

--- a/app/services/drive_service.py
+++ b/app/services/drive_service.py
@@ -453,7 +453,7 @@ def mount_drive(
     if not success:
         logger.warning(
             "Drive mount failed",
-            {
+            extra={
                 **_safe_drive_log_context(drive, reason=sanitize_error_message(error, "Mount provider reported failure")),
                 "filesystem_type": drive.filesystem_type,
             },
@@ -607,7 +607,7 @@ def mount_drive(
 
     logger.info(
         "Drive mounted",
-        {
+        extra={
             **_safe_drive_log_context(drive),
             "filesystem_type": drive.filesystem_type,
             "project_id": drive.current_project_id,

--- a/app/utils/drive_identity.py
+++ b/app/utils/drive_identity.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Optional
+
+
+def build_readable_device_label(
+    manufacturer: Optional[str],
+    product_name: Optional[str],
+    port_number: Optional[int],
+    *,
+    fallback_label: Optional[str] = None,
+) -> str:
+    parts: list[str] = []
+    for value in (manufacturer, product_name):
+        normalized = str(value or "").strip()
+        if normalized and normalized not in parts:
+            parts.append(normalized)
+
+    base_label = " ".join(parts).strip()
+    if port_number is not None:
+        if base_label:
+            return f"{base_label} - Port {port_number}"
+        return f"USB Drive - Port {port_number}"
+
+    if base_label:
+        return base_label
+
+    fallback = str(fallback_label or "").strip()
+    return fallback or "-"
+
+
+def mask_serial_number(serial_number: Optional[str]) -> Optional[str]:
+    serial = str(serial_number or "").strip()
+    if not serial:
+        return None
+    if len(serial) <= 4:
+        return "[redacted]"
+    return f"[redacted]-{serial[-4:]}"

--- a/frontend/e2e/drives.spec.js
+++ b/frontend/e2e/drives.spec.js
@@ -10,6 +10,10 @@ function makeEmptyDrive(overrides = {}) {
   return {
     id: 2,
     device_identifier: '/dev/sdc',
+    display_device_label: 'SanDisk Ultra - Port 7',
+    manufacturer: 'SanDisk',
+    product_name: 'Ultra',
+    port_number: 7,
     port_system_path: '2-7',
     serial_number: 'SER-002',
     filesystem_path: null,
@@ -197,6 +201,10 @@ test('prepare eject surfaces busy-drive detail without trapping the dialog', asy
   const drive = {
     id: 7,
     device_identifier: '/dev/sdg',
+    display_device_label: 'Kingston DataTraveler - Port 8',
+    manufacturer: 'Kingston',
+    product_name: 'DataTraveler',
+    port_number: 8,
     port_system_path: '2-8',
     serial_number: 'SER-007',
     filesystem_path: '/mnt/usb7',
@@ -230,6 +238,10 @@ test('drives list and drive detail admin flows', async ({ page }) => {
   const drive = {
     id: 1,
     device_identifier: '/dev/sdb',
+    display_device_label: 'SanDisk Ultra - Port 1',
+    manufacturer: 'SanDisk',
+    product_name: 'Ultra',
+    port_number: 1,
     port_system_path: '2-1',
     serial_number: 'SER-001',
     filesystem_path: '/mnt/usb1',
@@ -272,7 +284,7 @@ test('drives list and drive detail admin flows', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Drives' })).toBeVisible()
   await expect(page.getByRole('table').getByText('Device')).toBeVisible()
   await expect(page.getByRole('table').getByText('Serial Number')).toBeVisible()
-  await expect(page.getByText('2-1')).toBeVisible()
+  await expect(page.getByText('SanDisk Ultra - Port 1')).toBeVisible()
   await expect(page.getByText('SER-001')).toBeVisible()
   await page.getByRole('button', { name: 'Details' }).click()
 

--- a/frontend/src/utils/driveIdentity.js
+++ b/frontend/src/utils/driveIdentity.js
@@ -1,0 +1,26 @@
+export function formatDriveIdentity(drive) {
+  const explicitLabel = String(drive?.display_device_label || '').trim()
+  if (explicitLabel) {
+    return explicitLabel
+  }
+
+  const manufacturer = String(drive?.manufacturer || '').trim()
+  const productName = String(drive?.product_name || drive?.product || '').trim()
+  const portNumber = drive?.port_number
+  const parts = []
+
+  if (manufacturer) {
+    parts.push(manufacturer)
+  }
+  if (productName && !parts.includes(productName)) {
+    parts.push(productName)
+  }
+
+  if (parts.length > 0 && portNumber != null && portNumber !== '') {
+    return `${parts.join(' ')} - Port ${portNumber}`
+  }
+  if (parts.length > 0) {
+    return parts.join(' ')
+  }
+  return drive?.port_system_path || '-'
+}

--- a/frontend/src/views/DriveDetailView.vue
+++ b/frontend/src/views/DriveDetailView.vue
@@ -11,6 +11,7 @@ import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useStatusLabels } from '@/composables/useStatusLabels.js'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import DirectoryBrowser from '@/components/browse/DirectoryBrowser.vue'
+import { formatDriveIdentity } from '@/utils/driveIdentity.js'
 import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
 
 const route = useRoute()
@@ -440,7 +441,7 @@ onBeforeUnmount(() => {
     <article v-if="drive" class="detail-card">
       <div class="detail-grid">
         <div><strong>{{ t('common.labels.id') }}</strong><span>{{ drive.id }}</span></div>
-        <div><strong>{{ t('drives.device') }}</strong><span>{{ protectedValue(drive.device_identifier) }}</span></div>
+        <div><strong>{{ t('drives.device') }}</strong><span>{{ formatDriveIdentity(drive) }}</span></div>
         <div><strong>{{ t('drives.filesystemPath') }}</strong><span>{{ protectedValue(drive.filesystem_path) }}</span></div>
         <!-- Mount Point field removed -->
         <div><strong>{{ t('drives.filesystem') }}</strong><span>{{ drive.filesystem_type || '-' }}</span></div>

--- a/frontend/src/views/DrivesView.vue
+++ b/frontend/src/views/DrivesView.vue
@@ -8,6 +8,7 @@ import Pagination from '@/components/common/Pagination.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import DirectoryBrowser from '@/components/browse/DirectoryBrowser.vue'
 import { useStatusLabels } from '@/composables/useStatusLabels.js'
+import { formatDriveIdentity } from '@/utils/driveIdentity.js'
 import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
 
 const { t } = useI18n()
@@ -37,7 +38,7 @@ const activeBrowsedDrive = computed(() =>
 
 const columns = computed(() => [
   { key: 'id', label: t('common.labels.id'), align: 'right' },
-  { key: 'port_system_path', label: t('drives.device') },
+  { key: 'display_device_label', label: t('drives.device') },
   { key: 'serial_number', label: t('drives.serialNumber') },
   { key: 'filesystem_type', label: t('drives.filesystem') },
   { key: 'capacity_bytes', label: t('common.labels.size'), align: 'right' },
@@ -85,6 +86,9 @@ const filtered = computed(() => {
     const state = String(drive.current_state || '').toUpperCase()
     const stateMatch = stateFilter.value === 'ALL' || state === stateFilter.value
     const text = [
+      drive.display_device_label,
+      drive.manufacturer,
+      drive.product_name,
       drive.port_system_path,
       drive.serial_number,
       drive.filesystem_type,
@@ -219,7 +223,7 @@ onMounted(loadDrives)
       </select>
       <select v-model="sortKey" :aria-label="t('drives.sortBy')">
         <option value="id">{{ t('common.labels.id') }}</option>
-        <option value="port_system_path">{{ t('drives.device') }}</option>
+        <option value="display_device_label">{{ t('drives.device') }}</option>
         <option value="serial_number">{{ t('drives.serialNumber') }}</option>
         <option value="filesystem_type">{{ t('drives.filesystem') }}</option>
         <option value="current_state">{{ t('common.labels.status') }}</option>
@@ -231,8 +235,8 @@ onMounted(loadDrives)
     </div>
 
     <DataTable :columns="columns" :rows="paged" :empty-text="t('drives.empty')">
-      <template #cell-port_system_path="{ row }">
-        {{ row.port_system_path || '-' }}
+      <template #cell-display_device_label="{ row }">
+        {{ formatDriveIdentity(row) }}
       </template>
       <template #cell-serial_number="{ row }">
         {{ row.serial_number || '-' }}

--- a/frontend/src/views/JobDetailView.vue
+++ b/frontend/src/views/JobDetailView.vue
@@ -13,6 +13,7 @@ import DataTable from '@/components/common/DataTable.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import ProgressBar from '@/components/common/ProgressBar.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
+import { formatDriveIdentity } from '@/utils/driveIdentity.js'
 import { calculateJobProgress, isJobProgressActive } from '@/utils/jobProgress.js'
 import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
 
@@ -256,7 +257,7 @@ function formatCopyRate(bytesValue, totalSeconds) {
 }
 
 function formatDriveLabel(drive) {
-  return drive.port_system_path || '-'
+  return formatDriveIdentity(drive)
 }
 
 function formatMountLabel(mount) {

--- a/frontend/src/views/JobsView.vue
+++ b/frontend/src/views/JobsView.vue
@@ -11,6 +11,7 @@ import DataTable from '@/components/common/DataTable.vue'
 import Pagination from '@/components/common/Pagination.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useStatusLabels } from '@/composables/useStatusLabels.js'
+import { formatDriveIdentity } from '@/utils/driveIdentity.js'
 import { calculateJobProgress } from '@/utils/jobProgress.js'
 import { classifySourcePathOverlap, resolveMountedSourcePath } from '@/utils/pathOverlap.js'
 import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
@@ -134,11 +135,11 @@ function formatProjectId(value) {
 }
 
 function formatDriveLabel(drive) {
-  return drive.port_system_path || '-'
+  return formatDriveIdentity(drive)
 }
 
 function formatJobDevice(job) {
-  return job?.drive?.port_system_path || '-'
+  return formatDriveIdentity(job?.drive)
 }
 
 function formatMountLabel(mount) {

--- a/frontend/src/views/__tests__/DrivesView.spec.js
+++ b/frontend/src/views/__tests__/DrivesView.spec.js
@@ -22,6 +22,10 @@ function buildDrive(overrides = {}) {
   return {
     id: 1,
     device_identifier: 'USB-001',
+    display_device_label: 'SanDisk Ultra - Port 1',
+    manufacturer: 'SanDisk',
+    product_name: 'Ultra',
+    port_number: 1,
     port_system_path: '2-1',
     serial_number: 'SN-001',
     filesystem_type: 'ext4',
@@ -44,7 +48,7 @@ function mountView() {
             <div>
               <div class="column-labels">{{ (columns || []).map((column) => column.label).join(' ') }}</div>
               <div v-for="row in rows" :key="row.id" class="row-stub">
-                <span class="row-device">{{ row.port_system_path || '-' }}</span>
+                <span class="row-device">{{ row.display_device_label || row.port_system_path || '-' }}</span>
                 <span class="row-serial">{{ row.serial_number || '-' }}</span>
                 <slot name="cell-current_project_id" :row="row" />
                 <slot name="cell-actions" :row="row" />
@@ -135,10 +139,14 @@ describe('DrivesView rescan and filter loading', () => {
     expect(wrapper.text()).not.toContain('proj-123')
   })
 
-  it('shows port-based device and serial number in separate columns', async () => {
+  it('shows the readable device label and serial number in separate columns', async () => {
     mocks.getDrives.mockResolvedValue([
       buildDrive({
         device_identifier: 'SER-ONLY',
+        display_device_label: 'Kingston DataTraveler - Port 4',
+        manufacturer: 'Kingston',
+        product_name: 'DataTraveler',
+        port_number: 4,
         port_system_path: '2-4',
         serial_number: 'SER-ONLY',
       }),
@@ -149,7 +157,7 @@ describe('DrivesView rescan and filter loading', () => {
 
     expect(wrapper.text()).toContain(i18n.global.t('drives.device'))
     expect(wrapper.text()).toContain(i18n.global.t('drives.serialNumber'))
-    expect(wrapper.text()).toContain('2-4')
+    expect(wrapper.text()).toContain('Kingston DataTraveler - Port 4')
     expect(wrapper.text()).toContain('SER-ONLY')
   })
 
@@ -166,14 +174,14 @@ describe('DrivesView rescan and filter loading', () => {
   it('sorts by project in ascending and descending order and keeps that sort after refresh', async () => {
     mocks.getDrives
       .mockResolvedValueOnce([
-        buildDrive({ id: 1, current_project_id: 'proj-200', port_system_path: '2-1' }),
-        buildDrive({ id: 2, current_project_id: 'PROJ-050', port_system_path: '2-2' }),
-        buildDrive({ id: 3, current_project_id: 'PROJ-100', port_system_path: '2-3' }),
+        buildDrive({ id: 1, current_project_id: 'proj-200', display_device_label: 'Drive C - Port 1', port_system_path: '2-1' }),
+        buildDrive({ id: 2, current_project_id: 'PROJ-050', display_device_label: 'Drive A - Port 2', port_system_path: '2-2' }),
+        buildDrive({ id: 3, current_project_id: 'PROJ-100', display_device_label: 'Drive B - Port 3', port_system_path: '2-3' }),
       ])
       .mockResolvedValueOnce([
-        buildDrive({ id: 4, current_project_id: 'proj-300', port_system_path: '2-4' }),
-        buildDrive({ id: 5, current_project_id: 'PROJ-150', port_system_path: '2-5' }),
-        buildDrive({ id: 6, current_project_id: 'PROJ-250', port_system_path: '2-6' }),
+        buildDrive({ id: 4, current_project_id: 'proj-300', display_device_label: 'Drive C - Port 4', port_system_path: '2-4' }),
+        buildDrive({ id: 5, current_project_id: 'PROJ-150', display_device_label: 'Drive A - Port 5', port_system_path: '2-5' }),
+        buildDrive({ id: 6, current_project_id: 'PROJ-250', display_device_label: 'Drive B - Port 6', port_system_path: '2-6' }),
       ])
 
     const wrapper = mountView()
@@ -184,17 +192,14 @@ describe('DrivesView rescan and filter loading', () => {
     await flushPromises()
 
     let rows = wrapper.findAll('.row-stub')
-    expect(rows.map((row) => row.find('.row-device').text())).toEqual(['2-2', '2-3', '2-1'])
-    expect(rows.map((row) => row.text())).toEqual(
-      expect.arrayContaining(['2-2SN-001PROJ-050Details', '2-3SN-001PROJ-100Details', '2-1SN-001PROJ-200Details']),
-    )
+    expect(rows.map((row) => row.find('.row-device').text())).toEqual(['Drive A - Port 2', 'Drive B - Port 3', 'Drive C - Port 1'])
 
     const sortButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('drives.sortAsc'))
     await sortButton.trigger('click')
     await flushPromises()
 
     rows = wrapper.findAll('.row-stub')
-    expect(rows.map((row) => row.find('.row-device').text())).toEqual(['2-1', '2-3', '2-2'])
+    expect(rows.map((row) => row.find('.row-device').text())).toEqual(['Drive C - Port 1', 'Drive B - Port 3', 'Drive A - Port 2'])
 
     const refreshButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('common.actions.refresh'))
     await refreshButton.trigger('click')
@@ -202,6 +207,24 @@ describe('DrivesView rescan and filter loading', () => {
 
     expect(wrapper.findAll('select')[1].element.value).toBe('current_project_id')
     rows = wrapper.findAll('.row-stub')
-    expect(rows.map((row) => row.find('.row-device').text())).toEqual(['2-4', '2-6', '2-5'])
+    expect(rows.map((row) => row.find('.row-device').text())).toEqual(['Drive C - Port 4', 'Drive B - Port 6', 'Drive A - Port 5'])
+  })
+
+  it('renders the readable device label instead of the raw port path when available', async () => {
+    mocks.getDrives.mockResolvedValue([
+      buildDrive({
+        display_device_label: 'Kingston DataTraveler - Port 7',
+        manufacturer: 'Kingston',
+        product_name: 'DataTraveler',
+        port_number: 7,
+        port_system_path: '2-7',
+      }),
+    ])
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.find('.row-device').text()).toBe('Kingston DataTraveler - Port 7')
+    expect(wrapper.text()).not.toContain('2-7')
   })
 })

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -149,6 +149,11 @@ def test_initial_sync_emits_app_log_lines(db, caplog):
     assert any("USB discovery sync started" in message for message in messages)
     assert any("USB discovery sync completed" in message for message in messages)
 
+    start_record = next(record for record in caplog.records if record.getMessage() == "USB discovery sync started")
+    completed_record = next(record for record in caplog.records if record.getMessage() == "USB discovery sync completed")
+    assert start_record.actor == "admin-user"
+    assert completed_record.actor == "admin-user"
+
 
 # ---------------------------------------------------------------------------
 # Idempotency — running sync twice should not produce duplicate rows

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -62,6 +62,9 @@ def _simple_topology(
         port_system_path=port_path,
         filesystem_path="/dev/sdb",
         capacity_bytes=64_000_000_000,
+        manufacturer="SanDisk",
+        product_name="Ultra",
+        speed="5000",
     )
     return DiscoveredTopology(hubs=[hub], ports=[port], drives=[drive])
 
@@ -120,14 +123,31 @@ def test_initial_sync_emits_audit_log(db):
     assert logs[0].details["drives_inserted"] == 0
 
 
+def test_initial_sync_audit_includes_safe_drive_metadata_shape(db):
+    run_discovery_sync(db, actor="admin-user", topology_source=_simple_topology, filesystem_detector=_NULL_DETECTOR)
+
+    log = db.query(AuditLog).filter(AuditLog.action == "USB_DISCOVERY_SYNC").order_by(AuditLog.id.desc()).first()
+    assert log is not None
+    observed = log.details["observed_drives"]
+    assert len(observed) == 1
+    assert observed[0]["device_label"] == "SanDisk Ultra - Port 1"
+    assert observed[0]["manufacturer"] == "SanDisk"
+    assert observed[0]["product_name"] == "Ultra"
+    assert observed[0]["port_number"] == 1
+    assert observed[0]["speed"] == "5000"
+    assert observed[0]["serial_number_present"] is True
+    assert observed[0]["serial_number_masked"].endswith("C123")
+    assert "filesystem_path" not in observed[0]
+
+
 def test_initial_sync_emits_app_log_lines(db, caplog):
     caplog.set_level("INFO")
 
     run_discovery_sync(db, actor="admin-user", topology_source=_empty_topology, filesystem_detector=_NULL_DETECTOR)
 
     messages = [record.getMessage() for record in caplog.records]
-    assert any("USB_DISCOVERY_SYNC_STARTED actor=admin-user" in message for message in messages)
-    assert any("USB_DISCOVERY_SYNC_COMPLETED actor=admin-user" in message for message in messages)
+    assert any("USB discovery sync started" in message for message in messages)
+    assert any("USB discovery sync completed" in message for message in messages)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_drives.py
+++ b/tests/test_drives.py
@@ -61,6 +61,36 @@ def test_list_drives_exposes_port_and_serial_identifiers(client, db):
     assert match["serial_number"] == "SER-001"
 
 
+def test_list_drives_exposes_safe_usb_metadata_and_readable_label(client, db):
+    hub = UsbHub(name="Hub Ticket217", system_identifier="hub-ticket217-drives")
+    db.add(hub)
+    db.flush()
+
+    port = UsbPort(hub_id=hub.id, port_number=7, system_path="9-7", enabled=True, speed="5000")
+    db.add(port)
+    db.flush()
+
+    drive = UsbDrive(
+        device_identifier="SER-7777",
+        manufacturer="Kingston",
+        product_name="DataTraveler",
+        port_id=port.id,
+        current_state=DriveState.AVAILABLE,
+    )
+    db.add(drive)
+    db.commit()
+
+    response = client.get("/drives")
+    assert response.status_code == 200
+    payload = response.json()
+    match = next(item for item in payload if item["id"] == drive.id)
+    assert match["manufacturer"] == "Kingston"
+    assert match["product_name"] == "DataTraveler"
+    assert match["port_number"] == 7
+    assert match["speed"] == "5000"
+    assert match["display_device_label"] == "Kingston DataTraveler - Port 7"
+
+
 def test_list_drives_filter_by_project(client, db):
     """GET /drives?project_id= returns only matching drives."""
     d1 = UsbDrive(device_identifier="USB-A", current_state=DriveState.IN_USE, current_project_id="PROJ-001")


### PR DESCRIPTION
Summary

This branch adds safe USB metadata capture and readable drive identity labels across the discovery pipeline, API responses, audit/logging surfaces, and drive-facing UI. The goal is to make hardware information more useful to operators without exposing unsafe raw host details, while keeping discovery, mount handling, and schema behavior aligned end to end.

Changes included

- Backend discovery and data model
  - Capture USB manufacturer, product name, and port speed during hardware discovery.
  - Persist manufacturer and product name on `usb_drives`.
  - Add derived readable device labels plus port/speed accessors on the drive model.
  - Fold the new drive metadata columns into the baseline Alembic schema.

- API and schema contracts
  - Expose `manufacturer`, `product_name`, `port_number`, `speed`, and `display_device_label` on drive responses.
  - Extend embedded job drive metadata with the same safe fields so job-related views can render readable device identities consistently.

- Auditability and operator-safe logging
  - Enrich USB discovery audit details with safe per-drive metadata, including readable labels and masked serial presence.
  - Add structured discovery log lines for inserted, updated, observed, and removed drives.
  - Improve drive mount logging with safe per-drive context instead of path-heavy failure strings.

- Frontend behavior
  - Add a shared drive identity formatter for readable labels.
  - Update Drives, Drive Detail, Jobs, and Job Detail views to prefer readable device labels over raw port paths when available.
  - Update drives list search and sorting to use the readable device label field.

- Test coverage
  - Add backend coverage for safe USB metadata exposure and discovery audit payload shape.
  - Update drives view unit coverage for readable labels and sorting behavior.
  - Update drives E2E expectations to reflect readable device labels in the operator UI.

User-facing or operator-facing effects

- Operators now see labels like `SanDisk Ultra - Port 1` instead of only raw identifiers such as `2-1` where metadata is available.
- Discovery and mount-related logs carry more actionable hardware context while keeping serial data masked and avoiding unsafe filesystem detail in audit payloads.
- Drive and job screens present a more consistent hardware identity across list and detail views.

Validation

- `pytest tests/test_discovery.py::test_initial_sync_emits_app_log_lines tests/test_discovery.py::test_initial_sync_audit_includes_safe_drive_metadata_shape tests/test_drives.py::test_list_drives_exposes_safe_usb_metadata_and_readable_label -q`
- `pytest tests/test_migrations.py -q`
- `cd frontend && npx vitest run src/views/__tests__/DrivesView.spec.js`
- `cd frontend && npx playwright test frontend/e2e/drives.spec.js -g "drives list and drive detail admin flows"`
