### PR TITLE
Improve drive audit events and surface them in application logs/pr

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -93,6 +93,14 @@ Allowed (debug only):
   - absolute filesystem paths
   - device identifiers
   - sensitive OS details
+- Exception: application logs may mirror structured audit metadata for
+  operator-visible audit events when each mirrored field is already sanitized,
+  redacted, or otherwise safe for normal logs. This allows info/warning/error
+  log output to carry the same safe context as the persisted audit record for
+  events such as drive lifecycle or formatting actions.
+- Under this exception, paths must still be redacted rather than emitted as raw
+  host paths, and device identity must still be masked, summarized, or replaced
+  with a safe operator label rather than logged verbatim.
 
 Forbidden:
 - logger.info("Mount failed: " + str(err))
@@ -106,8 +114,15 @@ Forbidden:
   - raw provider errors
   - raw exception strings
   - absolute filesystem paths
-  - device identifiers
   - unredacted mount paths
+- Exception: audit records may include stable drive-identifying or USB-topology
+  metadata when the purpose of the event is chain-of-custody, discovery, or
+  hardware traceability. This includes fields such as a drive identifier,
+  port identifier, vendor/product identifiers, or other non-secret hardware
+  identity attributes needed to reconstruct which device was observed.
+- Under this exception, host filesystem paths and mount paths must still be
+  redacted, and provider/error text must still be sanitized rather than stored
+  verbatim.
 
 - Audit logs must use structured, sanitized, or redacted error information.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,8 +78,33 @@ Debug logs **may include**:
 - raw provider errors  
 - raw exception strings  
 
+### Info/warning/error logging (strict)
+These levels must **not** include:
+- raw provider errors
+- absolute filesystem paths
+- device identifiers
+- sensitive OS details
+
+Exception:
+- application logs may mirror structured audit metadata for operator-visible audit events when each mirrored field is already sanitized, redacted, or otherwise safe for normal logs. This allows info/warning/error log output to carry the same safe context as the persisted audit record for events such as drive lifecycle or formatting actions.
+- under this exception, paths must still be redacted rather than emitted as raw host paths, and device identity must still be masked, summarized, or replaced with a safe operator label rather than logged verbatim.
+
 Examples:
 ```python
 logger.debug("Provider error", {"raw_error": str(err)})
 logger.debug("Resolved mount path", {"path": mount_path})
 logger.debug("Device node", {"dev": "/dev/sdb1"})
+```
+
+## 5. Audit Log Redaction & Provider Error Safety
+
+- Audit logs must never contain:
+  - raw provider errors
+  - raw exception strings
+  - absolute filesystem paths
+  - unredacted mount paths
+- Exception:
+  - audit records may include stable drive-identifying or USB-topology metadata when the purpose of the event is chain-of-custody, discovery, or hardware traceability. This includes fields such as a drive identifier, port identifier, vendor/product identifiers, or other non-secret hardware identity attributes needed to reconstruct which device was observed.
+  - under this exception, host filesystem paths and mount paths must still be redacted, and provider/error text must still be sanitized rather than stored verbatim.
+
+- Audit logs must use structured, sanitized, or redacted error information.

--- a/app/config.py
+++ b/app/config.py
@@ -282,6 +282,9 @@ class Settings(BaseSettings):
     #: Path to the ``mkfs.exfat`` binary.
     mkfs_exfat_path: str = "/sbin/mkfs.exfat"
 
+    #: Path to the ``dumpe2fs`` binary used for best-effort ext4 free-space probing.
+    dumpe2fs_path: str = "/sbin/dumpe2fs"
+
     #: Base directory for USB drive mount points.  Each drive is mounted at
     #: ``<usb_mount_base_path>/<drive_db_id>``, e.g. ``/mnt/ecube/7``.
     usb_mount_base_path: str = "/mnt/ecube"

--- a/app/infrastructure/drive_format.py
+++ b/app/infrastructure/drive_format.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import subprocess
-from typing import Protocol
+from typing import Optional, Protocol
 
 from app.config import settings
 from app.infrastructure.device_path import validate_device_path
@@ -35,6 +36,10 @@ class DriveFormatter(Protocol):
 
     def is_mounted(self, device_path: str) -> bool:
         """Return ``True`` if the device (or any partition) is currently mounted."""
+        ...
+
+    def probe_free_bytes(self, device_path: str, filesystem_type: str) -> Optional[int]:
+        """Return best-effort free bytes available after formatting."""
         ...
 
 
@@ -87,6 +92,47 @@ class LinuxDriveFormatter:
         except OSError:
             logger.exception("Could not read %s for mount check", settings.procfs_mounts_path)
         return False
+
+    def probe_free_bytes(self, device_path: str, filesystem_type: str) -> Optional[int]:
+        if not validate_device_path(device_path):
+            return None
+        if filesystem_type != "ext4":
+            return None
+
+        try:
+            proc = subprocess.run(
+                _with_sudo([settings.dumpe2fs_path, "-h", device_path]),
+                check=True,
+                capture_output=True,
+                timeout=settings.subprocess_timeout_seconds,
+            )
+        except (subprocess.TimeoutExpired, subprocess.CalledProcessError, OSError) as exc:
+            logger.debug(
+                "dumpe2fs free-space probe failed",
+                extra={"filesystem_path": device_path, "raw_error": str(exc)},
+            )
+            return None
+
+        output = proc.stdout.decode(errors="replace")
+        free_blocks = _extract_ext4_header_int(output, "Free blocks")
+        block_size = _extract_ext4_header_int(output, "Block size")
+        if free_blocks is None or block_size is None:
+            return None
+        return free_blocks * block_size
+
+
+_EXT4_HEADER_FIELD_RE = re.compile(r"^(?P<key>[^:]+):\s*(?P<value>[0-9,]+)\s*$", re.MULTILINE)
+
+
+def _extract_ext4_header_int(output: str, field_name: str) -> Optional[int]:
+    for match in _EXT4_HEADER_FIELD_RE.finditer(output):
+        if match.group("key").strip() != field_name:
+            continue
+        try:
+            return int(match.group("value").replace(",", ""))
+        except ValueError:
+            return None
+    return None
 
 
 def _with_sudo(cmd: list[str]) -> list[str]:

--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -83,6 +83,14 @@ from app.config import settings
 _BUILTIN_ATTRS = frozenset(logging.LogRecord("", 0, "", 0, "", (), None).__dict__.keys())
 
 
+def _record_extra_fields(record: logging.LogRecord) -> dict[str, object]:
+    return {
+        k: v
+        for k, v in record.__dict__.items()
+        if k not in _BUILTIN_ATTRS and k not in ("message", "trace_id", "user_id", "asctime")
+    }
+
+
 class JsonFormatter(logging.Formatter):
     """Emit each log record as a single-line JSON object.
 
@@ -99,11 +107,7 @@ class JsonFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         # Build the extra dict from anything the caller passed that is not a
         # standard LogRecord attribute.
-        extra = {
-            k: v
-            for k, v in record.__dict__.items()
-            if k not in _BUILTIN_ATTRS and k not in ("message", "trace_id", "user_id")
-        }
+        extra = _record_extra_fields(record)
 
         obj = {
             "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
@@ -135,6 +139,24 @@ class TextFormatter(logging.Formatter):
 
     def __init__(self) -> None:
         super().__init__(fmt=_TEXT_FORMAT, datefmt="%Y-%m-%dT%H:%M:%S%z")
+
+    def format(self, record: logging.LogRecord) -> str:
+        base = super().format(record)
+
+        context: dict[str, object] = {}
+        if getattr(record, "trace_id", None) is not None:
+            context["trace_id"] = record.trace_id  # type: ignore[attr-defined]
+        if getattr(record, "user_id", None) is not None:
+            context["user_id"] = record.user_id  # type: ignore[attr-defined]
+
+        extra = _record_extra_fields(record)
+        if extra:
+            context["extra"] = extra
+
+        if not context:
+            return base
+
+        return f"{base} {json.dumps(context, default=str, sort_keys=True)}"
 
 
 # ---------------------------------------------------------------------------

--- a/app/routers/drives.py
+++ b/app/routers/drives.py
@@ -168,5 +168,6 @@ def format_drive(
     formatter = get_drive_formatter()
     return drive_service.format_drive(
         drive_id, body.filesystem_type, db, formatter=formatter, actor=current_user.username,
+        filesystem_detector=get_filesystem_detector(),
         client_ip=get_client_ip(request),
     )

--- a/app/services/audit_service.py
+++ b/app/services/audit_service.py
@@ -24,6 +24,7 @@ from app.schemas.audit import (
 logger = logging.getLogger(__name__)
 
 _COC_DRIVE_ACTIONS = {
+    "DRIVE_DISCOVERED",
     "DRIVE_INITIALIZED",
     "DRIVE_EJECT_PREPARED",
     "DRIVE_EJECT_FAILED",
@@ -40,6 +41,7 @@ _COC_JOB_ACTIONS = {
 }
 
 _ACTION_LABELS = {
+    "DRIVE_DISCOVERED": "Drive discovered",
     "DRIVE_INITIALIZED": "Drive initialized",
     "JOB_CREATED": "Job created",
     "JOB_STARTED": "Copy operation started",

--- a/app/services/discovery_service.py
+++ b/app/services/discovery_service.py
@@ -37,6 +37,7 @@ Hub auto-creation:
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import logging
 from typing import Callable, List, Optional
 
@@ -96,6 +97,31 @@ def _build_persisted_drive_metadata(drive: UsbDrive) -> dict:
         "speed": drive.speed,
         "serial_number_present": bool(drive.serial_number),
         "serial_number_masked": mask_serial_number(drive.serial_number),
+    }
+
+
+def _build_drive_discovered_audit_details(drive: UsbDrive, *, actor: Optional[str] = None) -> dict:
+    port = drive.port
+    hub = port.hub if port else None
+    return {
+        "drive_id": drive.id,
+        "device_identifier": drive.device_identifier,
+        "device_label": drive.display_device_label,
+        "manufacturer": drive.manufacturer,
+        "product_name": drive.product_name,
+        "filesystem_path": drive.filesystem_path,
+        "filesystem_type": drive.filesystem_type,
+        "capacity_bytes": drive.capacity_bytes,
+        "port_id": port.id if port else None,
+        "port_number": port.port_number if port else None,
+        "port_system_path": port.system_path if port else None,
+        "hub_id": hub.id if hub else None,
+        "vendor_id": (port.vendor_id if port and port.vendor_id else (hub.vendor_id if hub else None)),
+        "product_id": (port.product_id if port and port.product_id else (hub.product_id if hub else None)),
+        "speed": drive.speed,
+        "serial_number_masked": mask_serial_number(drive.serial_number),
+        "discovery_actor": actor or "system",
+        "discovered_at": datetime.now(timezone.utc).isoformat(),
     }
 
 
@@ -275,6 +301,16 @@ def run_discovery_sync(
             metadata = _build_discovered_drive_metadata(discovered_drive, discovered_port, drive_id=drive.id)
             observed_drive_metadata.append({"action": "inserted", **metadata})
             logger.info("USB discovery inserted drive", extra=metadata)
+            try:
+                audit_repo.add(
+                    action="DRIVE_DISCOVERED",
+                    user=actor,
+                    drive_id=drive.id,
+                    details=_build_drive_discovered_audit_details(drive, actor=actor),
+                    client_ip=client_ip,
+                )
+            except Exception:
+                logger.exception("Failed to write audit log for DRIVE_DISCOVERED")
 
         else:
             # Existing drive — update mutable fields.

--- a/app/services/drive_service.py
+++ b/app/services/drive_service.py
@@ -10,11 +10,12 @@ from app.exceptions import ConflictError
 from app.infrastructure.drive_eject import DriveEjectProvider
 from app.infrastructure.drive_format import DriveFormatter
 from app.infrastructure.drive_mount import DriveMountProvider
-from app.infrastructure import validate_device_path
+from app.infrastructure import FilesystemDetector, validate_device_path
 from app.models.hardware import DriveState, UsbDrive
 from app.repositories.audit_repository import AuditRepository
 from app.repositories.drive_repository import DriveRepository
 from app.repositories.mount_repository import MountRepository
+from app.services.audit_service import log_and_audit
 from app.utils.drive_identity import mask_serial_number
 from app.utils.sanitize import normalize_project_id, sanitize_error_message
 
@@ -788,6 +789,7 @@ def format_drive(
     db: Session,
     *,
     formatter: DriveFormatter,
+    filesystem_detector: FilesystemDetector,
     actor: Optional[str] = None,
     client_ip: Optional[str] = None,
 ) -> UsbDrive:
@@ -848,6 +850,34 @@ def format_drive(
             detail=f"Drive format failed: {exc}",
         )
 
+    detected_filesystem_type: Optional[str] = None
+    try:
+        detected = filesystem_detector.detect(drive.filesystem_path)
+        if detected not in {None, "unknown", "unformatted"}:
+            detected_filesystem_type = detected
+    except Exception as exc:
+        logger.debug(
+            "Post-format filesystem detection failed",
+            extra={
+                "drive_id": drive_id,
+                "filesystem_path": drive.filesystem_path,
+                "raw_error": str(exc),
+            },
+        )
+
+    free_bytes: Optional[int] = None
+    try:
+        free_bytes = formatter.probe_free_bytes(drive.filesystem_path, filesystem_type)
+    except Exception as exc:
+        logger.debug(
+            "Post-format free-space probe failed",
+            extra={
+                "drive_id": drive_id,
+                "filesystem_path": drive.filesystem_path,
+                "raw_error": str(exc),
+            },
+        )
+
     drive.filesystem_type = filesystem_type
     # Formatting wipes all previous data, so the project binding is cleared.
     # The drive is now clean and can be initialized for any project.
@@ -879,15 +909,18 @@ def format_drive(
         )
 
     try:
-        audit_repo.add(
+        log_and_audit(
+            db,
             action="DRIVE_FORMATTED",
-            user=actor,
+            actor_id=actor,
             project_id=prior_project_id,
             drive_id=drive_id,
-            details={
-                "drive_id": drive_id,
+            metadata={
                 "filesystem_path": drive.filesystem_path,
                 "filesystem_type": filesystem_type,
+                "detected_filesystem_type": detected_filesystem_type,
+                "free_bytes": free_bytes,
+                "capacity_bytes": drive.capacity_bytes,
                 "actor": actor,
             },
             client_ip=client_ip,

--- a/docs/operations/09-administration-automation-guide.md
+++ b/docs/operations/09-administration-automation-guide.md
@@ -1478,8 +1478,9 @@ Every audit entry contains:
 
 | Action | Trigger |
 |--------|---------|
+| `DRIVE_DISCOVERED` | New drive inserted and recorded during discovery sync |
 | `DRIVE_INITIALIZED` | Drive bound to a project |
-| `DRIVE_FORMATTED` | Drive filesystem formatted |
+| `DRIVE_FORMATTED` | Drive filesystem formatted, with best-effort post-format filesystem and free-space details |
 | `DRIVE_FORMAT_FAILED` | Drive format operation failed |
 | `DRIVE_FORMAT_DB_UPDATE_FAILED` | Format succeeded but DB update failed |
 | `DRIVE_EJECT_PREPARED` | Drive flushed and unmounted for removal |

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -51,11 +51,14 @@ def _simple_topology(
     port_path: str = "1-1",
     drive_id: str = "SN-ABC123",
 ) -> DiscoveredTopology:
-    hub = DiscoveredHub(system_identifier=hub_id, name="Test Hub")
+    hub = DiscoveredHub(system_identifier=hub_id, name="Test Hub", vendor_id="1d6b", product_id="0002")
     port = DiscoveredPort(
         hub_system_identifier=hub_id,
         port_number=1,
         system_path=port_path,
+        vendor_id="0781",
+        product_id="5583",
+        speed="5000",
     )
     drive = DiscoveredDrive(
         device_identifier=drive_id,
@@ -138,6 +141,80 @@ def test_initial_sync_audit_includes_safe_drive_metadata_shape(db):
     assert observed[0]["serial_number_present"] is True
     assert observed[0]["serial_number_masked"].endswith("C123")
     assert "filesystem_path" not in observed[0]
+
+
+def test_initial_sync_emits_drive_discovered_audit_log(db):
+    run_discovery_sync(db, actor="admin-user", topology_source=_simple_topology, filesystem_detector=_NULL_DETECTOR)
+
+    log = db.query(AuditLog).filter(AuditLog.action == "DRIVE_DISCOVERED").one()
+    drive = db.query(UsbDrive).one()
+    assert log.user == "admin-user"
+    assert log.drive_id == drive.id
+    assert log.details["drive_id"] == drive.id
+    assert log.details["device_identifier"] == drive.device_identifier
+    assert log.details["device_label"] == "SanDisk Ultra - Port 1"
+    assert log.details["filesystem_path"] == "[redacted]"
+    assert log.details["filesystem_type"] == "unformatted"
+    assert log.details["capacity_bytes"] == 64_000_000_000
+    assert log.details["port_number"] == 1
+    assert log.details["vendor_id"] == "0781"
+    assert log.details["product_id"] == "5583"
+    assert log.details["speed"] == "5000"
+    assert log.details["discovery_actor"] == "admin-user"
+    assert log.details["serial_number_masked"].endswith("C123")
+    assert log.details["discovered_at"]
+
+
+def test_initial_sync_drive_discovered_audit_handles_missing_optional_fields(db):
+    topology = DiscoveredTopology(
+        hubs=[DiscoveredHub(system_identifier="usb1", name="Test Hub")],
+        ports=[DiscoveredPort(hub_system_identifier="usb1", port_number=1, system_path="1-1")],
+        drives=[DiscoveredDrive(device_identifier="SN-NOMETA", port_system_path="1-1")],
+    )
+
+    run_discovery_sync(db, actor="admin-user", topology_source=lambda: topology, filesystem_detector=_NULL_DETECTOR)
+
+    log = db.query(AuditLog).filter(AuditLog.action == "DRIVE_DISCOVERED").one()
+    assert log.details["manufacturer"] is None
+    assert log.details["product_name"] is None
+    assert log.details["filesystem_path"] is None
+    assert log.details["filesystem_type"] is None
+    assert log.details["capacity_bytes"] is None
+    assert log.details["vendor_id"] is None
+    assert log.details["product_id"] is None
+    assert log.details["speed"] is None
+
+
+def test_sync_does_not_duplicate_drive_discovered_audit_for_unchanged_drive(db):
+    topology = _simple_topology()
+    run_discovery_sync(db, actor="admin-user", topology_source=lambda: topology, filesystem_detector=_NULL_DETECTOR)
+    run_discovery_sync(db, actor="admin-user", topology_source=lambda: topology, filesystem_detector=_NULL_DETECTOR)
+
+    assert db.query(AuditLog).filter(AuditLog.action == "DRIVE_DISCOVERED").count() == 1
+
+
+def test_initial_sync_continues_when_drive_discovered_audit_write_fails(db, monkeypatch):
+    from app.repositories.audit_repository import AuditRepository
+
+    original_add = AuditRepository.add
+
+    def flaky_add(self, action, *args, **kwargs):
+        if action == "DRIVE_DISCOVERED":
+            raise RuntimeError("audit unavailable")
+        return original_add(self, action, *args, **kwargs)
+
+    monkeypatch.setattr(AuditRepository, "add", flaky_add)
+
+    summary = run_discovery_sync(
+        db,
+        actor="admin-user",
+        topology_source=_simple_topology,
+        filesystem_detector=_NULL_DETECTOR,
+    )
+
+    assert summary["drives_inserted"] == 1
+    assert db.query(UsbDrive).count() == 1
+    assert db.query(AuditLog).filter(AuditLog.action == "USB_DISCOVERY_SYNC").count() == 1
 
 
 def test_initial_sync_emits_app_log_lines(db, caplog):

--- a/tests/test_filesystem_format.py
+++ b/tests/test_filesystem_format.py
@@ -6,12 +6,14 @@ conftest.py.
 """
 from __future__ import annotations
 
+import logging
 from unittest.mock import patch
 
 import pytest
 
 from app.infrastructure.filesystem_detection import FilesystemDetector
 from app.infrastructure.drive_format import DriveFormatter, LinuxDriveFormatter
+from app.logging_config import TextFormatter
 from app.infrastructure.usb_discovery import (
     DiscoveredDrive,
     DiscoveredHub,
@@ -43,11 +45,21 @@ class FakeFilesystemDetector:
 class FakeFormatter:
     """Fake formatter that records calls and optionally raises."""
 
-    def __init__(self, *, fail: bool = False, mounted: bool = False):
+    def __init__(
+        self,
+        *,
+        fail: bool = False,
+        mounted: bool = False,
+        free_bytes_result: int | None = None,
+        free_bytes_error: Exception | None = None,
+    ):
         self._fail = fail
         self._mounted = mounted
+        self._free_bytes_result = free_bytes_result
+        self._free_bytes_error = free_bytes_error
         self.format_calls: list[tuple[str, str]] = []
         self.mounted_calls: list[str] = []
+        self.free_bytes_calls: list[tuple[str, str]] = []
 
     def format(self, device_path: str, filesystem_type: str) -> None:
         self.format_calls.append((device_path, filesystem_type))
@@ -57,6 +69,12 @@ class FakeFormatter:
     def is_mounted(self, device_path: str) -> bool:
         self.mounted_calls.append(device_path)
         return self._mounted
+
+    def probe_free_bytes(self, device_path: str, filesystem_type: str) -> int | None:
+        self.free_bytes_calls.append((device_path, filesystem_type))
+        if self._free_bytes_error is not None:
+            raise self._free_bytes_error
+        return self._free_bytes_result
 
 
 def test_linux_drive_formatter_uses_sudo_when_configured(monkeypatch):
@@ -356,8 +374,12 @@ class TestFormatDriveEndpoint:
 
     def test_format_success_ext4(self, admin_client, db):
         drive = _make_drive(db, filesystem_type="unformatted")
-        fake = FakeFormatter()
-        with patch("app.routers.drives.get_drive_formatter", return_value=fake):
+        fake = FakeFormatter(free_bytes_result=31_000_000_000)
+        detector = FakeFilesystemDetector("ext4")
+        with (
+            patch("app.routers.drives.get_drive_formatter", return_value=fake),
+            patch("app.routers.drives.get_filesystem_detector", return_value=detector),
+        ):
             resp = admin_client.post(
                 f"/drives/{drive.id}/format",
                 json={"filesystem_type": "ext4"},
@@ -373,17 +395,114 @@ class TestFormatDriveEndpoint:
         assert log.project_id is None
         assert log.details["drive_id"] == drive.id
         assert log.details["filesystem_type"] == "ext4"
+        assert log.details["detected_filesystem_type"] == "ext4"
+        assert log.details["free_bytes"] == 31_000_000_000
+        assert log.details["capacity_bytes"] is None
+        assert log.details["filesystem_path"] == "[redacted]"
+        assert fake.free_bytes_calls == [("/dev/sdb", "ext4")]
+        assert detector.calls == ["/dev/sdb"]
+
+    def test_format_success_emits_application_log_event(self, admin_client, db, caplog):
+        drive = _make_drive(db, filesystem_type="unformatted")
+        fake = FakeFormatter(free_bytes_result=31_000_000_000)
+        detector = FakeFilesystemDetector("ext4")
+        caplog.set_level("INFO", logger="app.services.audit_service")
+
+        with (
+            patch("app.routers.drives.get_drive_formatter", return_value=fake),
+            patch("app.routers.drives.get_filesystem_detector", return_value=detector),
+        ):
+            resp = admin_client.post(
+                f"/drives/{drive.id}/format",
+                json={"filesystem_type": "ext4"},
+            )
+
+        assert resp.status_code == 200
+        log_record = next(
+            record
+            for record in caplog.records
+            if record.name == "app.services.audit_service" and record.getMessage() == "DRIVE_FORMATTED"
+        )
+        assert log_record.drive_id == drive.id
+        assert log_record.filesystem_type == "ext4"
+
+    def test_format_success_text_formatter_includes_audit_context(self, admin_client, db):
+        import io
+
+        drive = _make_drive(db, filesystem_type="unformatted")
+        fake = FakeFormatter(free_bytes_result=31_000_000_000)
+        detector = FakeFilesystemDetector("ext4")
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(TextFormatter())
+        audit_logger = logging.getLogger("app.services.audit_service")
+        previous_handlers = audit_logger.handlers[:]
+        previous_propagate = audit_logger.propagate
+        previous_level = audit_logger.level
+        audit_logger.handlers = [handler]
+        audit_logger.propagate = False
+        audit_logger.setLevel(logging.INFO)
+
+        try:
+            with (
+                patch("app.routers.drives.get_drive_formatter", return_value=fake),
+                patch("app.routers.drives.get_filesystem_detector", return_value=detector),
+            ):
+                resp = admin_client.post(
+                    f"/drives/{drive.id}/format",
+                    json={"filesystem_type": "ext4"},
+                )
+        finally:
+            handler.flush()
+            audit_logger.handlers = previous_handlers
+            audit_logger.propagate = previous_propagate
+            audit_logger.setLevel(previous_level)
+
+        assert resp.status_code == 200
+        output = stream.getvalue()
+        assert "DRIVE_FORMATTED" in output
+        assert '"drive_id": ' in output
+        assert '"filesystem_type": "ext4"' in output
+        assert '"detected_filesystem_type": "ext4"' in output
 
     def test_format_success_exfat(self, manager_client, db):
         drive = _make_drive(db, filesystem_type="unformatted")
         fake = FakeFormatter()
-        with patch("app.routers.drives.get_drive_formatter", return_value=fake):
+        detector = FakeFilesystemDetector("exfat")
+        with (
+            patch("app.routers.drives.get_drive_formatter", return_value=fake),
+            patch("app.routers.drives.get_filesystem_detector", return_value=detector),
+        ):
             resp = manager_client.post(
                 f"/drives/{drive.id}/format",
                 json={"filesystem_type": "exfat"},
             )
         assert resp.status_code == 200
         assert resp.json()["filesystem_type"] == "exfat"
+
+    def test_format_audit_enrichment_is_null_safe_when_probes_fail(self, admin_client, db):
+        drive = _make_drive(db, filesystem_type="unformatted", capacity_bytes=64_000_000_000)
+        fake = FakeFormatter(free_bytes_result=None, free_bytes_error=RuntimeError("probe failed"))
+
+        class FailingDetector:
+            def detect(self, device_path: str) -> str:
+                raise RuntimeError("detect failed")
+
+        with (
+            patch("app.routers.drives.get_drive_formatter", return_value=fake),
+            patch("app.routers.drives.get_filesystem_detector", return_value=FailingDetector()),
+        ):
+            resp = admin_client.post(
+                f"/drives/{drive.id}/format",
+                json={"filesystem_type": "ext4"},
+            )
+
+        assert resp.status_code == 200
+        log = db.query(AuditLog).filter(AuditLog.action == "DRIVE_FORMATTED").first()
+        assert log is not None
+        assert log.details["detected_filesystem_type"] is None
+        assert log.details["free_bytes"] is None
+        assert log.details["capacity_bytes"] == 64_000_000_000
 
     def test_format_unsupported_type_rejected(self, admin_client, db):
         drive = _make_drive(db)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -139,6 +139,36 @@ class TestTextFormatter:
         assert "app.services.drive_service" in output
         assert "drive not found" in output
 
+    def test_includes_structured_context_fields(self):
+        formatter = TextFormatter()
+        logger = logging.getLogger("test.text.extra")
+        logger.handlers.clear()
+        handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        record = logger.makeRecord(
+            name="test.text.extra",
+            level=logging.INFO,
+            fn="",
+            lno=0,
+            msg="DRIVE_FORMATTED",
+            args=(),
+            exc_info=None,
+            extra={
+                "drive_id": 7,
+                "filesystem_type": "ext4",
+                "user_id": "manager",
+            },
+        )
+
+        output = formatter.format(record)
+        assert "DRIVE_FORMATTED" in output
+        assert '"user_id": "manager"' in output
+        assert '"drive_id": 7' in output
+        assert '"filesystem_type": "ext4"' in output
+
 
 # ---------------------------------------------------------------------------
 # configure_logging tests


### PR DESCRIPTION
Summary

This change improves ECUBE’s drive auditability and operator observability around USB discovery and drive formatting. It adds a dedicated per-drive discovery audit event, enriches successful format records with best-effort post-format confirmation details, and updates application text logs so the same structured context written to the audit trail is also visible in the log file.

Changes included

- Add a new DRIVE_DISCOVERED audit event during USB discovery with persisted drive, port, and hub metadata, while keeping discovery resilient if the audit write fails.
- Enrich DRIVE_FORMATTED with detected_filesystem_type, free_bytes, and capacity_bytes using injected filesystem detection and a new best-effort ext4 free-space probe via dumpe2fs.
- Extend the drive formatting infrastructure and config to support post-format free-space probing in the trusted system layer.
- Route successful drive format auditing through the shared log-and-audit bridge so the event is emitted to both the audit table and the application logger.
- Update text log formatting so structured log context is rendered into human-readable log files instead of being dropped outside JSON mode.
- Add audit action labeling and operations documentation for the new discovery event and the richer format event payload.

User-facing or operator-facing effects

- Operators now get a dedicated audit record when a drive is first discovered, improving chain-of-custody traceability at insertion time.
- Successful format events now show richer evidence in both the audit trail and the application log file, including confirmed filesystem type and best-effort free-space details when available.
- Text-mode log files now surface the same structured context that previously only appeared in the audit table or JSON logs.

Validation

- Focused discovery audit tests passed:
  - pytest tests/test_discovery.py -q -k "drive_discovered"
- Focused format audit/logging tests passed:
  - pytest tests/test_filesystem_format.py -q -k "format_success_ext4 or format_success_emits_application_log_event"
  - pytest tests/test_filesystem_format.py -q -k "format_success_text_formatter_includes_audit_context or format_success_emits_application_log_event"
- Focused logging formatter test passed:
  - pytest tests/test_logging.py -q -k "includes_structured_context_fields"
- Broader full-module verification is still needed if you want a clean end-to-end test signal for the entire filesystem-format module; earlier broader runs exposed unrelated pre-existing failures outside this change slice.