### PR TITLE
Add active job checks for drive eject functionality and update translations

### DIFF
--- a/frontend/src/api/__tests__/jobs.spec.js
+++ b/frontend/src/api/__tests__/jobs.spec.js
@@ -66,4 +66,13 @@ describe('jobs api helpers', () => {
     )
     expect(toData).toHaveBeenCalled()
   })
+
+  it('forwards an optional timeout override for list requests', async () => {
+    const { listJobs } = await import('@/api/jobs.js')
+
+    await listJobs({ drive_id: 7, statuses: ['RUNNING'] }, { timeout: 5000 })
+
+    expect(get).toHaveBeenCalledTimes(1)
+    expect(get).toHaveBeenCalledWith('/api/jobs', expect.objectContaining({ timeout: 5000 }))
+  })
 })

--- a/frontend/src/api/jobs.js
+++ b/frontend/src/api/jobs.js
@@ -29,8 +29,12 @@ function normalizeJobId(jobId) {
   return normalized
 }
 
-export function listJobs(params = {}) {
-  return toData(apiClient.get(`${API_BASE}/jobs`, { params: buildQueryParams(params) }))
+export function listJobs(params = {}, { timeout } = {}) {
+  const config = { params: buildQueryParams(params) }
+  if (timeout != null) {
+    config.timeout = timeout
+  }
+  return toData(apiClient.get(`${API_BASE}/jobs`, config))
 }
 
 export function createJob(payload) {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -75,6 +75,8 @@
     "formatConfirmBody": "Formatting destroys all data on this drive.",
     "ejectConfirmTitle": "Prepare drive eject?",
     "ejectConfirmBody": "Ensure no active copy operation is running before eject.",
+    "ejectBlockedActiveJob": "Cannot eject: copy job {jobId} is currently running on this drive.",
+    "ejectBlockedUnknownJob": "Cannot eject: an active copy operation is running on this drive.",
     "cocPrompt": "Drive is ready for safe removal. Generate a chain-of-custody report and confirm handoff details.",
     "openCocReport": "Open CoC Report",
     "browse": "Browse",

--- a/frontend/src/views/DriveDetailView.vue
+++ b/frontend/src/views/DriveDetailView.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth.js'
 import { getDrives, formatDrive, initializeDrive, mountDrive, prepareEjectDrive, refreshDrives } from '@/api/drives.js'
+import { listJobs } from '@/api/jobs.js'
 import { getMounts } from '@/api/mounts.js'
 import { enablePort } from '@/api/admin.js'
 import { normalizeErrorMessage } from '@/api/client.js'
@@ -69,6 +70,9 @@ const showEjectDialog = ref(false)
 const showInitializeDialog = ref(false)
 const browseExpanded = ref(false)
 const showCocPrompt = ref(false)
+const showActiveJobWarning = ref(false)
+const activeJobId = ref(null)
+const activeJobWarningMessage = ref('')
 
 const filesystemType = ref('ext4')
 const projectId = ref('')
@@ -342,12 +346,62 @@ async function runMount() {
   }
 }
 
+async function openPrepareEjectDialog() {
+  if (!drive.value) return
+  saving.value = true
+  clearBanners()
+  showActiveJobWarning.value = false
+  activeJobId.value = null
+  activeJobWarningMessage.value = ''
+  try {
+    const jobs = await listJobs({
+      drive_id: drive.value.id,
+      statuses: ['RUNNING', 'VERIFYING'],
+      limit: 1,
+    })
+    const activeJob = Array.isArray(jobs) ? jobs[0] : null
+
+    if (activeJob) {
+      activeJobId.value = activeJob.id ?? null
+      activeJobWarningMessage.value = activeJobId.value != null
+        ? t('drives.ejectBlockedActiveJob', { jobId: activeJobId.value })
+        : t('drives.ejectBlockedUnknownJob')
+      showActiveJobWarning.value = true
+      showEjectDialog.value = false
+      return
+    }
+
+    showEjectDialog.value = true
+  } catch (err) {
+    const status = err?.response?.status
+    const detail = normalizeErrorMessage(err?.response?.data, null)
+    if (!status) {
+      error.value = t('common.errors.networkError')
+    } else if (status === 403) {
+      error.value = detail || t('common.errors.insufficientPermissions')
+    } else if (status === 404) {
+      error.value = detail || t('common.errors.notFound')
+    } else if (status === 422) {
+      error.value = detail || t('common.errors.validationFailed')
+    } else if (status >= 500) {
+      error.value = t('common.errors.serverError', { status })
+    } else {
+      error.value = detail || t('common.errors.serverErrorGeneric')
+    }
+  } finally {
+    saving.value = false
+  }
+}
+
 async function runPrepareEject() {
   if (!drive.value) return
   saving.value = true
   clearBanners()
   showEjectDialog.value = false
   showCocPrompt.value = false
+  showActiveJobWarning.value = false
+  activeJobId.value = null
+  activeJobWarningMessage.value = ''
   try {
     drive.value = normalizeProjectRecord(
       await prepareEjectDrive(drive.value.id),
@@ -456,7 +510,7 @@ onBeforeUnmount(() => {
         <button v-if="canBrowse" class="btn" @click="browseExpanded = !browseExpanded">{{ t('drives.browse') }}</button>
         <button class="btn" :disabled="!canFormat || saving" @click="showFormatDialog = true">{{ t('drives.format') }}</button>
         <button class="btn" :disabled="!canInitialize || saving" @click="openInitializeDialog">{{ t('drives.initialize') }}</button>
-        <button class="btn btn-danger" :disabled="!canEject || saving" @click="showEjectDialog = true">{{ t('drives.prepareEject') }}</button>
+        <button class="btn btn-danger" :disabled="!canEject || saving" @click="openPrepareEjectDialog">{{ t('drives.prepareEject') }}</button>
       </div>
 
       <p v-if="!canManage" class="muted">{{ t('auth.insufficientPermissions') }}</p>
@@ -488,6 +542,13 @@ onBeforeUnmount(() => {
       </header>
       <DirectoryBrowser :mount-path="drive.mount_path" />
     </section>
+
+    <div v-if="showActiveJobWarning" class="warn-banner active-job-warning" role="alert" aria-live="assertive">
+      <p>{{ activeJobWarningMessage }}</p>
+      <div class="actions">
+        <button class="btn" :disabled="saving" @click="showActiveJobWarning = false; activeJobWarningMessage = ''">{{ t('common.actions.cancel') }}</button>
+      </div>
+    </div>
 
     <ConfirmDialog
       v-model="showEjectDialog"

--- a/frontend/src/views/DriveDetailView.vue
+++ b/frontend/src/views/DriveDetailView.vue
@@ -85,6 +85,7 @@ const initializeTriggerRef = ref(null)
 const initializeDialogTitleId = 'drive-initialize-dialog-title'
 const initializeDialogHelpId = 'drive-initialize-dialog-help'
 const initializeDialogStatusId = 'drive-initialize-dialog-status'
+const EJECT_PREFLIGHT_TIMEOUT_MS = 5000
 
 const { driveStateLabel } = useStatusLabels()
 
@@ -358,7 +359,7 @@ async function openPrepareEjectDialog() {
       drive_id: drive.value.id,
       statuses: ['RUNNING', 'VERIFYING'],
       limit: 1,
-    })
+    }, { timeout: EJECT_PREFLIGHT_TIMEOUT_MS })
     const activeJob = Array.isArray(jobs) ? jobs[0] : null
 
     if (activeJob) {

--- a/frontend/src/views/__tests__/DriveDetailView.spec.js
+++ b/frontend/src/views/__tests__/DriveDetailView.spec.js
@@ -335,6 +335,8 @@ describe('DriveDetailView mount workflow', () => {
       drive_id: 7,
       statuses: ['RUNNING', 'VERIFYING'],
       limit: 1,
+    }, {
+      timeout: 5000,
     })
     expect(wrapper.find('.confirm-dialog-stub').exists()).toBe(true)
 

--- a/frontend/src/views/__tests__/DriveDetailView.spec.js
+++ b/frontend/src/views/__tests__/DriveDetailView.spec.js
@@ -375,6 +375,24 @@ describe('DriveDetailView mount workflow', () => {
     expect(wrapper.text()).not.toContain(i18n.global.t('drives.ejectBlockedActiveJob', { jobId: 44 }))
   })
 
+  it('blocks prepare eject when the drive has an active verifying job', async () => {
+    mocks.getDrives.mockResolvedValue([buildDrive({ current_state: 'IN_USE' })])
+    mocks.listJobs.mockResolvedValue([{ id: 45, status: 'VERIFYING' }])
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const ejectButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('drives.prepareEject'))
+    expect(ejectButton).toBeTruthy()
+
+    await ejectButton.trigger('click')
+    await flushPromises()
+
+    expect(mocks.prepareEjectDrive).not.toHaveBeenCalled()
+    expect(wrapper.find('.confirm-dialog-stub').exists()).toBe(false)
+    expect(wrapper.text()).toContain(i18n.global.t('drives.ejectBlockedActiveJob', { jobId: 45 }))
+  })
+
   it('surfaces a preflight error and does not open the eject dialog when the jobs request fails', async () => {
     mocks.getDrives.mockResolvedValue([buildDrive({ current_state: 'IN_USE' })])
     mocks.listJobs.mockRejectedValue({})

--- a/frontend/src/views/__tests__/DriveDetailView.spec.js
+++ b/frontend/src/views/__tests__/DriveDetailView.spec.js
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   hasAnyRole: vi.fn(),
   push: vi.fn(),
   getDrives: vi.fn(),
+  listJobs: vi.fn(),
   getMounts: vi.fn(),
   formatDrive: vi.fn(),
   initializeDrive: vi.fn(),
@@ -34,6 +35,10 @@ vi.mock('@/api/drives.js', () => ({
   mountDrive: (...args) => mocks.mountDrive(...args),
   prepareEjectDrive: (...args) => mocks.prepareEjectDrive(...args),
   refreshDrives: (...args) => mocks.refreshDrives(...args),
+}))
+
+vi.mock('@/api/jobs.js', () => ({
+  listJobs: (...args) => mocks.listJobs(...args),
 }))
 
 vi.mock('@/api/mounts.js', () => ({
@@ -94,6 +99,7 @@ describe('DriveDetailView mount workflow', () => {
     mocks.hasAnyRole.mockReset()
     mocks.push.mockReset()
     mocks.getDrives.mockReset()
+    mocks.listJobs.mockReset()
     mocks.getMounts.mockReset()
     mocks.formatDrive.mockReset()
     mocks.initializeDrive.mockReset()
@@ -104,6 +110,7 @@ describe('DriveDetailView mount workflow', () => {
 
     mocks.hasAnyRole.mockReturnValue(true)
     mocks.getDrives.mockResolvedValue([buildDrive()])
+    mocks.listJobs.mockResolvedValue([])
     mocks.getMounts.mockResolvedValue([
       { id: 1, status: 'MOUNTED', project_id: 'PROJ-007' },
       { id: 2, status: 'MOUNTED', project_id: 'PROJ-999' },
@@ -324,6 +331,11 @@ describe('DriveDetailView mount workflow', () => {
 
     await ejectButton.trigger('click')
     await flushPromises()
+    expect(mocks.listJobs).toHaveBeenCalledWith({
+      drive_id: 7,
+      statuses: ['RUNNING', 'VERIFYING'],
+      limit: 1,
+    })
     expect(wrapper.find('.confirm-dialog-stub').exists()).toBe(true)
 
     await wrapper.find('.confirm-dialog-confirm').trigger('click')
@@ -332,5 +344,50 @@ describe('DriveDetailView mount workflow', () => {
     expect(mocks.prepareEjectDrive).toHaveBeenCalledWith(7)
     expect(wrapper.find('.confirm-dialog-stub').exists()).toBe(false)
     expect(wrapper.text()).toContain('Drive is busy; close any shell, file browser, or process using the mounted drive and retry prepare-eject')
+  })
+
+  it('blocks prepare eject when the drive has an active running job', async () => {
+    mocks.getDrives.mockResolvedValue([buildDrive({ current_state: 'IN_USE' })])
+    mocks.listJobs.mockResolvedValue([{ id: 44, status: 'RUNNING' }])
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const ejectButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('drives.prepareEject'))
+    expect(ejectButton).toBeTruthy()
+
+    await ejectButton.trigger('click')
+    await flushPromises()
+
+    expect(mocks.prepareEjectDrive).not.toHaveBeenCalled()
+    expect(wrapper.find('.confirm-dialog-stub').exists()).toBe(false)
+    expect(wrapper.text()).toContain(i18n.global.t('drives.ejectBlockedActiveJob', { jobId: 44 }))
+
+    const cancelButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('common.actions.cancel'))
+    expect(cancelButton).toBeTruthy()
+
+    await cancelButton.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.confirm-dialog-stub').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain(i18n.global.t('drives.ejectBlockedActiveJob', { jobId: 44 }))
+  })
+
+  it('surfaces a preflight error and does not open the eject dialog when the jobs request fails', async () => {
+    mocks.getDrives.mockResolvedValue([buildDrive({ current_state: 'IN_USE' })])
+    mocks.listJobs.mockRejectedValue({})
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const ejectButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('drives.prepareEject'))
+    expect(ejectButton).toBeTruthy()
+
+    await ejectButton.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.confirm-dialog-stub').exists()).toBe(false)
+    expect(mocks.prepareEjectDrive).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain(i18n.global.t('common.errors.networkError'))
   })
 })


### PR DESCRIPTION
## Summary

This change adds a frontend pre-flight guard to the drive eject workflow so operators get immediate guidance when a drive is still being used by an active copy job. Instead of opening the Prepare Eject confirmation unconditionally, the drive detail view now checks for `RUNNING` or `VERIFYING` jobs first and only continues to the confirmation dialog when the drive is clear.

## Changes included

- Updated `DriveDetailView` to replace the direct `showEjectDialog = true` path with an async pre-flight job lookup using the existing jobs API.
- Added blocking warning state in the drive detail view so an active job prevents the eject confirmation dialog from opening.
- Included job-aware warning copy for:
  - active job with a known job ID
  - active job where no job ID is available
- Preserved the existing backend-enforced eject behavior and conflict handling after pre-flight passes.
- Added focused unit coverage for:
  - normal pre-flight pass through to the existing eject confirmation flow
  - active `RUNNING` job blocking the eject flow
  - pre-flight API failure surfacing an error without opening the eject dialog

## User-facing / operator-facing effects

- Operators now get a clear blocking warning before attempting eject when a copy operation is still active on the drive.
- The warning includes the conflicting job ID when available, which makes the workflow easier to triage.
- The existing Prepare Eject confirmation still appears when no active job is found.
- If the jobs pre-flight request fails, the UI now shows an error banner and does not proceed to the eject confirmation step.
- This change improves the operator workflow around removable media safety without changing backend hardware enforcement.

## Validation

- Verified with targeted frontend unit tests:
  - `npm exec vitest run src/views/__tests__/DriveDetailView.spec.js`
  - Result: `14/14` tests passed
- Verified with the full frontend unit suite:
  - `npm run test:unit`
  - Result: `25/25` test files passed, `209/209` tests passed
- Coverage run completed successfully as part of the full frontend test command.