### PR TITLE
Require a passing share test before saving edited mount settings

### DIFF
--- a/app/routers/mounts.py
+++ b/app/routers/mounts.py
@@ -122,9 +122,10 @@ def remove_mount(
     mount_service.remove_mount(mount_id, db, actor=current_user.username, client_ip=get_client_ip(request))
 
 
-@router.post("/{mount_id}/validate", response_model=NetworkMountSchema, responses={**R_401, **R_403, **R_404, **R_422, **R_500})
+@router.post("/{mount_id}/validate", response_model=NetworkMountSchema, responses={**R_401, **R_403, **R_404, **R_409, **R_422, **R_500})
 def validate_mount(
     mount_id: int,
+    body: MountUpdate | None = None,
     *,
     db: Session = Depends(get_db),
     current_user: CurrentUser = Depends(_ADMIN_MANAGER),
@@ -136,4 +137,10 @@ def validate_mount(
 
     **Roles:** ``admin``, ``manager``
     """
-    return mount_service.validate_mount(mount_id, db, actor=current_user.username, client_ip=get_client_ip(request))
+    return mount_service.validate_mount(
+        mount_id,
+        db,
+        mount_data=body,
+        actor=current_user.username,
+        client_ip=get_client_ip(request),
+    )

--- a/app/services/mount_service.py
+++ b/app/services/mount_service.py
@@ -719,6 +719,50 @@ def _prepare_mount_for_update(
     )
 
 
+def _restore_mount_after_candidate_validation(
+    mount: NetworkMount,
+    *,
+    provider: "MountProvider",
+    original_mount_type: MountType,
+    original_remote_path: str,
+    original_was_mounted: bool,
+) -> Optional[str]:
+    local_mount_point = str(mount.local_mount_point)
+    current_result = check_mounted_with_configured_timeout(provider, local_mount_point)
+
+    if current_result is True:
+        try:
+            unmount_ok, unmount_error = provider.os_unmount(local_mount_point)
+        except Exception as exc:
+            unmount_ok, unmount_error = False, str(exc)
+
+        if not unmount_ok:
+            error_text = unmount_error or "umount failed"
+            lowered_error = error_text.lower()
+            if not any(phrase in lowered_error for phrase in ("not mounted", "no mount point")):
+                return error_text
+
+    if not original_was_mounted:
+        return None
+
+    original_credentials = (
+        _load_stored_mount_credentials(mount)
+        if _stored_credentials_present(mount)
+        else {"username": None, "password": None, "credentials_file": None}
+    )
+    restore_ok, restore_error = provider.os_mount(
+        original_mount_type,
+        original_remote_path,
+        local_mount_point,
+        credentials_file=original_credentials["credentials_file"],
+        username=original_credentials["username"],
+        password=original_credentials["password"],
+    )
+    if restore_ok:
+        return None
+    return restore_error or "Failed to restore original mount state"
+
+
 def add_mount(mount_data: MountCreate, db: Session, actor: Optional[str] = None,
               provider: Optional["MountProvider"] = None,
               client_ip: Optional[str] = None) -> NetworkMount:
@@ -1200,7 +1244,8 @@ def validate_all_mounts(db: Session, actor: Optional[str] = None,
 
 def validate_mount(mount_id: int, db: Session, actor: Optional[str] = None,
                    provider: Optional["MountProvider"] = None,
-                   client_ip: Optional[str] = None) -> NetworkMount:
+                   client_ip: Optional[str] = None,
+                   mount_data: Optional[MountUpdate] = None) -> NetworkMount:
     mount_repo = MountRepository(db)
     audit_repo = AuditRepository(db)
 
@@ -1209,6 +1254,125 @@ def validate_mount(mount_id: int, db: Session, actor: Optional[str] = None,
         raise HTTPException(status_code=404, detail="Mount not found")
 
     provider = provider or _default_provider()
+
+    if mount_data is not None:
+        normalized_project_id = normalize_project_id(mount_data.project_id)
+        if not isinstance(normalized_project_id, str) or not normalized_project_id:
+            raise HTTPException(status_code=422, detail="project_id must not be empty")
+
+        mount_repo.acquire_create_lock()
+        _validate_remote_path_conflicts(
+            mount_data.type,
+            mount_data.remote_path,
+            normalized_project_id,
+            mount_repo.list_all(),
+            ignore_mount_id=mount_id,
+        )
+
+        checked_at = datetime.now(timezone.utc)
+        original_status = mount.status
+        original_mount_type = mount.type if isinstance(mount.type, MountType) else MountType(str(mount.type))
+        original_remote_path = str(mount.remote_path)
+        original_mount_state = check_mounted_with_configured_timeout(provider, str(mount.local_mount_point))
+        original_was_mounted = original_mount_state is True or original_status == MountStatus.MOUNTED
+
+        candidate_status = MountStatus.ERROR
+        validation_error = None
+        try:
+            if original_was_mounted:
+                _prepare_mount_for_update(mount, provider=provider)
+
+            create_dir_error = _ensure_mount_directory(mount.local_mount_point)
+            if create_dir_error:
+                validation_error = create_dir_error
+            else:
+                owner_error = _validate_mount_directory_owner(mount.local_mount_point)
+                if owner_error:
+                    validation_error = owner_error
+                else:
+                    resolved_credentials = _resolve_mount_operation_credentials(mount, mount_data)
+                    success, validation_error = provider.os_mount(
+                        mount_data.type,
+                        mount_data.remote_path,
+                        mount.local_mount_point,
+                        credentials_file=resolved_credentials["credentials_file"],
+                        username=resolved_credentials["username"],
+                        password=resolved_credentials["password"],
+                    )
+                    candidate_status = MountStatus.MOUNTED if success else MountStatus.ERROR
+        finally:
+            mount.status = original_status
+            restore_error = _restore_mount_after_candidate_validation(
+                mount,
+                provider=provider,
+                original_mount_type=original_mount_type,
+                original_remote_path=original_remote_path,
+                original_was_mounted=original_was_mounted,
+            )
+
+        if restore_error:
+            logger.info(
+                "Mount candidate validation could not restore original state",
+                extra={
+                    "context": {
+                        "mount_id": mount.id,
+                        "mount_label": _redacted_mount_label(str(mount.local_mount_point)),
+                        "failure_category": "mount_validate_restore",
+                    }
+                },
+            )
+            logger.debug(
+                "Mount candidate validation restore raw error",
+                extra={
+                    "context": {
+                        "mount_id": mount.id,
+                        "mount_label": _redacted_mount_label(str(mount.local_mount_point)),
+                        "raw_error": restore_error,
+                    }
+                },
+            )
+            raise HTTPException(
+                status_code=500,
+                detail="Mount validation could not restore original mount state",
+            )
+
+        mount.last_checked_at = checked_at
+        try:
+            mount_repo.save(mount)
+        except Exception:
+            logger.exception(
+                "DB commit failed while saving mount validation timestamp",
+                extra={"context": {"mount_id": mount_id}},
+            )
+            raise HTTPException(
+                status_code=500,
+                detail="Database error while saving mount validation",
+            )
+
+        try:
+            audit_repo.add(
+                action="MOUNT_VALIDATED",
+                user=actor,
+                details={
+                    "mount_id": mount_id,
+                    "mount_label": _redacted_mount_label(str(mount.local_mount_point)),
+                    "status": candidate_status.value,
+                },
+                client_ip=client_ip,
+            )
+        except Exception:
+            logger.exception("Failed to write audit log for MOUNT_VALIDATED")
+
+        return NetworkMount(
+            id=mount.id,
+            type=mount_data.type,
+            remote_path=mount_data.remote_path,
+            project_id=normalized_project_id,
+            local_mount_point=mount.local_mount_point,
+            status=candidate_status,
+            last_checked_at=checked_at,
+        )
+
     result = check_mounted_with_configured_timeout(provider, mount.local_mount_point)
     if result is True:
         mount.status = MountStatus.MOUNTED

--- a/app/services/mount_service.py
+++ b/app/services/mount_service.py
@@ -1361,7 +1361,16 @@ def validate_mount(mount_id: int, db: Session, actor: Optional[str] = None,
                 client_ip=client_ip,
             )
         except Exception:
-            logger.exception("Failed to write audit log for MOUNT_VALIDATED")
+            logger.exception(
+                "Failed to write audit log for MOUNT_VALIDATED",
+                extra={"context": {"mount_id": mount_id}},
+            )
+
+        if candidate_status != MountStatus.MOUNTED:
+            raise HTTPException(
+                status_code=409,
+                detail=sanitize_error_message(validation_error, "Mount validation failed"),
+            )
 
         return NetworkMount(
             id=mount.id,

--- a/frontend/e2e/mounts.spec.js
+++ b/frontend/e2e/mounts.spec.js
@@ -7,6 +7,7 @@ test('mounts add/edit/test/remove flow', async ({ page }) => {
 
   const mounts = [{ id: 10, type: 'NFS', remote_path: '10.0.0.4:/exports', local_mount_point: '/nfs/exports', project_id: 'CASE-2026-000', status: 'MOUNTED' }]
   const patchPayloads = []
+  const validatePayloads = []
 
   await page.route('**/api/mounts', async (route) => {
     if (route.request().method() === 'GET') {
@@ -33,7 +34,22 @@ test('mounts add/edit/test/remove flow', async ({ page }) => {
   })
 
   await page.route('**/api/mounts/*/validate', async (route) => {
-    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mounts[0]) })
+    const mountId = Number(route.request().url().split('/').slice(-2, -1)[0])
+    const body = route.request().postDataJSON() ?? null
+    if (body) {
+      validatePayloads.push(body)
+    }
+    const mount = mounts.find((entry) => entry.id === mountId) ?? mounts[0]
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ...mount,
+        ...(body ?? {}),
+        status: 'MOUNTED',
+        last_checked_at: null,
+      }),
+    })
   })
 
   await page.route('**/api/mounts/*', async (route) => {
@@ -66,13 +82,25 @@ test('mounts add/edit/test/remove flow', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Edit' }).nth(1).click()
   await expect(page.getByRole('heading', { name: 'Edit Share' })).toBeVisible()
+  const editDialog = page.getByRole('dialog', { name: 'Edit Share' })
   await expect(page.getByLabel('Local Mount Point')).toHaveValue('/nfs/case-2026-001')
   await page.getByLabel('Remote Path').fill('//server/case-2026-001')
   await expect(page.getByRole('button', { name: 'Clear saved credentials' })).toBeVisible()
   await page.getByRole('button', { name: 'Clear saved credentials' }).click()
-  await page.getByRole('button', { name: 'Save', exact: true }).click()
+  await expect(editDialog.getByRole('button', { name: 'Save', exact: true })).toBeDisabled()
 
-  expect(patchPayloads).toEqual([
+  await editDialog.getByRole('button', { name: 'Test', exact: true }).click()
+  await expect(editDialog.getByRole('button', { name: 'Save', exact: true })).toBeEnabled()
+
+  await page.getByLabel('Remote Path').fill('//server/case-2026-001-updated')
+  await expect(editDialog.getByRole('button', { name: 'Save', exact: true })).toBeDisabled()
+
+  await editDialog.getByRole('button', { name: 'Test', exact: true }).click()
+  await expect(editDialog.getByRole('button', { name: 'Save', exact: true })).toBeEnabled()
+
+  await editDialog.getByRole('button', { name: 'Save', exact: true }).click()
+
+  expect(validatePayloads).toEqual([
     {
       type: 'SMB',
       remote_path: '//server/case-2026-001',
@@ -81,9 +109,26 @@ test('mounts add/edit/test/remove flow', async ({ page }) => {
       password: null,
       credentials_file: null,
     },
+    {
+      type: 'SMB',
+      remote_path: '//server/case-2026-001-updated',
+      project_id: 'CASE-2026-001',
+      username: null,
+      password: null,
+      credentials_file: null,
+    },
   ])
 
-  await page.getByRole('button', { name: 'Test' }).nth(1).click()
+  expect(patchPayloads).toEqual([
+    {
+      type: 'SMB',
+      remote_path: '//server/case-2026-001-updated',
+      project_id: 'CASE-2026-001',
+      username: null,
+      password: null,
+      credentials_file: null,
+    },
+  ])
 
   await page.getByRole('button', { name: 'Remove' }).first().click()
   await page.getByRole('button', { name: 'Remove' }).last().click()

--- a/frontend/e2e/theme.spec.js
+++ b/frontend/e2e/theme.spec.js
@@ -2,6 +2,8 @@ import { test, expect } from '@playwright/test'
 import { setupAuthenticatedPage, routeJson, setupPublicPage } from './helpers/app.js'
 import { expectNoCriticalA11yViolations } from './helpers/a11y.js'
 
+test.use({ timezoneId: 'America/New_York' })
+
 async function disableMotion(page) {
   await page.addStyleTag({ content: '*, *::before, *::after { transition-duration: 0s !important; animation-duration: 0s !important; }' })
 }

--- a/frontend/src/api/mounts.js
+++ b/frontend/src/api/mounts.js
@@ -10,8 +10,8 @@ export function validateAllMounts() {
   return toData(apiClient.post(`${API_BASE}/mounts/validate`))
 }
 
-export function validateMount(mountId) {
-  return toData(apiClient.post(`${API_BASE}/mounts/${mountId}/validate`))
+export function validateMount(mountId, payload) {
+  return toData(apiClient.post(`${API_BASE}/mounts/${mountId}/validate`, payload))
 }
 
 export function createMount(payload) {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -207,6 +207,8 @@
     "storedCredentials": "Stored Credentials",
     "clearStoredCredentials": "Clear saved credentials",
     "createSuccess": "Share added successfully.",
+    "testFailed": "Share test failed. Review the remote path or credentials and try again.",
+    "testSuccess": "Share test passed. You can now save these changes.",
     "updateFailed": "Share update failed. Review the returned mount status before closing the dialog.",
     "updateSuccess": "Share updated successfully.",
     "removeConfirmTitle": "Remove mount?",

--- a/frontend/src/views/MountsView.vue
+++ b/frontend/src/views/MountsView.vue
@@ -352,6 +352,7 @@ function openEditDialog(mount, event) {
 function closeAddDialog() {
   showAddDialog.value = false
   error.value = ''
+  successMessage.value = ''
   resetForm()
 }
 

--- a/frontend/src/views/MountsView.vue
+++ b/frontend/src/views/MountsView.vue
@@ -17,9 +17,11 @@ const authStore = useAuthStore()
 const mounts = ref([])
 const loading = ref(false)
 const saving = ref(false)
+const dialogTesting = ref(false)
 const error = ref('')
 const successMessage = ref('')
 const editingMountId = ref(null)
+const editValidationPassed = ref(false)
 
 const showAddDialog = ref(false)
 const showRemoveDialog = ref(false)
@@ -114,6 +116,8 @@ async function loadMounts() {
 
 function resetForm() {
   editingMountId.value = null
+  editValidationPassed.value = false
+  dialogTesting.value = false
   form.value = {
     type: 'SMB',
     remote_path: '',
@@ -129,8 +133,17 @@ function resetForm() {
   }
 }
 
+function invalidateEditValidation() {
+  if (!isEditMode.value) return
+  if (editValidationPassed.value && successMessage.value === t('mounts.testSuccess')) {
+    successMessage.value = ''
+  }
+  editValidationPassed.value = false
+}
+
 function markCredentialFieldChanged(fieldName) {
   credentialFieldState.value[fieldName] = true
+  invalidateEditValidation()
 }
 
 function clearStoredCredentials() {
@@ -142,6 +155,7 @@ function clearStoredCredentials() {
     password: true,
     credentials_file: true,
   }
+  invalidateEditValidation()
 }
 
 function trapFocusWithin(event, container) {
@@ -243,6 +257,27 @@ async function submitMountDialog() {
   }
 }
 
+async function runDialogValidate() {
+  if (!isEditMode.value || editingMountId.value === null || !formValid()) return
+  dialogTesting.value = true
+  editValidationPassed.value = false
+  error.value = ''
+  successMessage.value = ''
+  try {
+    const result = await validateMount(editingMountId.value, buildMountPayload())
+    if (result?.status === 'MOUNTED') {
+      editValidationPassed.value = true
+      successMessage.value = t('mounts.testSuccess')
+      return
+    }
+    error.value = t('mounts.testFailed')
+  } catch (requestError) {
+    error.value = normalizeErrorMessage(requestError?.response?.data, t('mounts.testFailed'))
+  } finally {
+    dialogTesting.value = false
+  }
+}
+
 async function runValidateAll() {
   loading.value = true
   error.value = ''
@@ -290,6 +325,8 @@ function openEditDialog(mount, event) {
   editingMountId.value = mount.id
   error.value = ''
   successMessage.value = ''
+  editValidationPassed.value = false
+  dialogTesting.value = false
   form.value = {
     type: mount.type || 'SMB',
     remote_path: mount.remote_path || '',
@@ -383,6 +420,13 @@ watch(
     if (value !== normalized) {
       form.value.project_id = normalized
     }
+  },
+)
+
+watch(
+  () => [form.value.type, form.value.remote_path, form.value.project_id],
+  () => {
+    invalidateEditValidation()
   },
 )
 
@@ -513,7 +557,19 @@ onBeforeUnmount(() => {
 
           <div class="dialog-actions">
             <button class="btn" @click="closeAddDialog">{{ t('common.actions.cancel') }}</button>
-            <button class="btn btn-primary" :disabled="saving || !formValid()" @click="submitMountDialog">
+            <button
+              v-if="isEditMode"
+              class="btn"
+              :disabled="saving || dialogTesting || !formValid()"
+              @click="runDialogValidate"
+            >
+              {{ dialogTesting ? t('common.labels.loading') : t('mounts.test') }}
+            </button>
+            <button
+              class="btn btn-primary"
+              :disabled="saving || dialogTesting || !formValid() || (isEditMode && !editValidationPassed)"
+              @click="submitMountDialog"
+            >
               {{ saving ? t('common.labels.loading') : dialogSubmitLabel }}
             </button>
           </div>

--- a/frontend/src/views/__tests__/MountsView.spec.js
+++ b/frontend/src/views/__tests__/MountsView.spec.js
@@ -431,6 +431,31 @@ describe('MountsView removal flow', () => {
     expect(saveButton().attributes('disabled')).toBeDefined()
   })
 
+  it('clears the test success banner when the edit dialog is cancelled', async () => {
+    mocks.getMounts.mockResolvedValue([buildMount({ id: 42, remote_path: '//server/original-share', project_id: 'PROJ-OLD' })])
+    mocks.validateMount.mockResolvedValue(buildMount({ id: 42, status: 'MOUNTED' }))
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const editButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('common.actions.edit'))
+    expect(editButton).toBeTruthy()
+
+    await editButton.trigger('click')
+    await flushPromises()
+
+    await wrapper.find('#mount-remote-path').setValue('//server/updated-share')
+    await findDialogButton(wrapper, i18n.global.t('mounts.test')).trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain(i18n.global.t('mounts.testSuccess'))
+
+    await findDialogButton(wrapper, i18n.global.t('common.actions.cancel')).trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain(i18n.global.t('mounts.testSuccess'))
+  })
+
   it('keeps the edit dialog open and shows feedback when the in-dialog test fails', async () => {
     mocks.getMounts.mockResolvedValue([buildMount({ id: 42, remote_path: '//server/original-share', project_id: 'PROJ-OLD' })])
     mocks.validateMount.mockRejectedValue({ response: { data: { detail: 'Authentication failed for edited share.' } } })

--- a/frontend/src/views/__tests__/MountsView.spec.js
+++ b/frontend/src/views/__tests__/MountsView.spec.js
@@ -90,6 +90,10 @@ function mountView() {
   })
 }
 
+function findDialogButton(wrapper, label) {
+  return wrapper.find('.dialog-actions').findAll('button').find((node) => node.text() === label)
+}
+
 describe('MountsView removal flow', () => {
   beforeEach(() => {
     authState.roles = ['admin', 'manager']
@@ -328,6 +332,7 @@ describe('MountsView removal flow', () => {
 
   it('submits edit mode through updateMount without creating a new mount', async () => {
     mocks.getMounts.mockResolvedValue([buildMount({ id: 42, remote_path: '//server/original-share', project_id: 'PROJ-OLD' })])
+    mocks.validateMount.mockResolvedValue(buildMount({ id: 42, status: 'MOUNTED' }))
 
     const wrapper = mountView()
     await flushPromises()
@@ -341,9 +346,17 @@ describe('MountsView removal flow', () => {
     await wrapper.find('#mount-remote-path').setValue('//server/updated-share')
     await wrapper.find('#mount-project-id').setValue('proj-updated')
 
-    await wrapper.findAll('button').find((node) => node.text() === i18n.global.t('common.actions.save')).trigger('click')
+    await findDialogButton(wrapper, i18n.global.t('mounts.test')).trigger('click')
     await flushPromises()
 
+    await findDialogButton(wrapper, i18n.global.t('common.actions.save')).trigger('click')
+    await flushPromises()
+
+    expect(mocks.validateMount).toHaveBeenCalledWith(42, {
+      type: 'SMB',
+      remote_path: '//server/updated-share',
+      project_id: 'PROJ-UPDATED',
+    })
     expect(mocks.updateMount).toHaveBeenCalledWith(42, {
       type: 'SMB',
       remote_path: '//server/updated-share',
@@ -354,6 +367,7 @@ describe('MountsView removal flow', () => {
 
   it('lets the operator explicitly clear stored credentials during edit', async () => {
     mocks.getMounts.mockResolvedValue([buildMount({ id: 42, remote_path: '//server/original-share', project_id: 'PROJ-OLD' })])
+    mocks.validateMount.mockResolvedValue(buildMount({ id: 42, status: 'MOUNTED' }))
     mocks.updateMount.mockResolvedValue(buildMount({ id: 42, remote_path: '//server/original-share', project_id: 'PROJ-OLD', status: 'MOUNTED' }))
 
     const wrapper = mountView()
@@ -368,7 +382,10 @@ describe('MountsView removal flow', () => {
     await wrapper.findAll('button').find((node) => node.text() === i18n.global.t('mounts.clearStoredCredentials')).trigger('click')
     await flushPromises()
 
-    await wrapper.findAll('button').find((node) => node.text() === i18n.global.t('common.actions.save')).trigger('click')
+    await findDialogButton(wrapper, i18n.global.t('mounts.test')).trigger('click')
+    await flushPromises()
+
+    await findDialogButton(wrapper, i18n.global.t('common.actions.save')).trigger('click')
     await flushPromises()
 
     expect(mocks.updateMount).toHaveBeenCalledWith(42, {
@@ -381,8 +398,65 @@ describe('MountsView removal flow', () => {
     })
   })
 
+  it('requires a passing in-dialog test before edited values can be saved', async () => {
+    mocks.getMounts.mockResolvedValue([buildMount({ id: 42, remote_path: '//server/original-share', project_id: 'PROJ-OLD' })])
+    mocks.validateMount.mockResolvedValue(buildMount({ id: 42, status: 'MOUNTED' }))
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const editButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('common.actions.edit'))
+    expect(editButton).toBeTruthy()
+
+    await editButton.trigger('click')
+    await flushPromises()
+
+    await wrapper.find('#mount-remote-path').setValue('//server/updated-share')
+    await wrapper.find('#mount-project-id').setValue('proj-updated')
+
+    const saveButton = () => findDialogButton(wrapper, i18n.global.t('common.actions.save'))
+    const testButton = () => findDialogButton(wrapper, i18n.global.t('mounts.test'))
+
+    expect(saveButton().attributes('disabled')).toBeDefined()
+
+    await testButton().trigger('click')
+    await flushPromises()
+
+    expect(saveButton().attributes('disabled')).toBeUndefined()
+    expect(wrapper.text()).toContain(i18n.global.t('mounts.testSuccess'))
+
+    await wrapper.find('#mount-remote-path').setValue('//server/updated-share-2')
+    await flushPromises()
+
+    expect(saveButton().attributes('disabled')).toBeDefined()
+  })
+
+  it('keeps the edit dialog open and shows feedback when the in-dialog test fails', async () => {
+    mocks.getMounts.mockResolvedValue([buildMount({ id: 42, remote_path: '//server/original-share', project_id: 'PROJ-OLD' })])
+    mocks.validateMount.mockRejectedValue({ response: { data: { detail: 'Authentication failed for edited share.' } } })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const editButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('common.actions.edit'))
+    expect(editButton).toBeTruthy()
+
+    await editButton.trigger('click')
+    await flushPromises()
+
+    await wrapper.find('#mount-remote-path').setValue('//server/updated-share')
+    await findDialogButton(wrapper, i18n.global.t('mounts.test')).trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('#mount-type').exists()).toBe(true)
+    expect(wrapper.find('.error-banner').text()).toContain('Authentication failed for edited share.')
+    expect(findDialogButton(wrapper, i18n.global.t('common.actions.save')).attributes('disabled')).toBeDefined()
+    expect(mocks.updateMount).not.toHaveBeenCalled()
+  })
+
   it('keeps the dialog open and shows actionable backend text when edit fails', async () => {
     mocks.getMounts.mockResolvedValue([buildMount({ id: 42, remote_path: '//server/original-share', project_id: 'PROJ-OLD' })])
+    mocks.validateMount.mockResolvedValue(buildMount({ id: 42, status: 'MOUNTED' }))
     mocks.updateMount.mockRejectedValue({ response: { data: { detail: 'A mount for this remote source is already configured.' } } })
 
     const wrapper = mountView()
@@ -394,7 +468,10 @@ describe('MountsView removal flow', () => {
     await editButton.trigger('click')
     await flushPromises()
 
-    await wrapper.findAll('button').find((node) => node.text() === i18n.global.t('common.actions.save')).trigger('click')
+    await findDialogButton(wrapper, i18n.global.t('mounts.test')).trigger('click')
+    await flushPromises()
+
+    await findDialogButton(wrapper, i18n.global.t('common.actions.save')).trigger('click')
     await flushPromises()
 
     expect(wrapper.find('#mount-type').exists()).toBe(true)
@@ -403,6 +480,7 @@ describe('MountsView removal flow', () => {
 
   it('keeps the dialog open when the update returns an error-status mount record', async () => {
     mocks.getMounts.mockResolvedValue([buildMount({ id: 42, remote_path: '//server/original-share', project_id: 'PROJ-OLD' })])
+    mocks.validateMount.mockResolvedValue(buildMount({ id: 42, status: 'MOUNTED' }))
     mocks.updateMount.mockResolvedValue(buildMount({ id: 42, remote_path: '//server/original-share', project_id: 'PROJ-OLD', status: 'ERROR' }))
 
     const wrapper = mountView()
@@ -414,7 +492,10 @@ describe('MountsView removal flow', () => {
     await editButton.trigger('click')
     await flushPromises()
 
-    await wrapper.findAll('button').find((node) => node.text() === i18n.global.t('common.actions.save')).trigger('click')
+    await findDialogButton(wrapper, i18n.global.t('mounts.test')).trigger('click')
+    await flushPromises()
+
+    await findDialogButton(wrapper, i18n.global.t('common.actions.save')).trigger('click')
     await flushPromises()
 
     expect(wrapper.find('#mount-type').exists()).toBe(true)

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -4,6 +4,7 @@ import pytest
 
 from app.models.network import MountStatus, MountType, NetworkMount
 from app.config import settings
+from app.schemas.network import MountUpdate
 from app.services.mount_check_utils import check_mounted_with_configured_timeout
 from app.services.mount_service import (
     LinuxMountProvider,
@@ -922,6 +923,89 @@ def test_validate_mount_command_failure(manager_client, db):
     data = response.json()
     assert data["status"] == "ERROR"
     assert data["last_checked_at"] is not None
+
+
+def test_validate_mount_with_candidate_payload_uses_unsaved_values_without_persisting(db):
+    mount = NetworkMount(
+        type=MountType.SMB,
+        remote_path="//server/original-share",
+        project_id="PROJ-OLD",
+        local_mount_point="/smb/original-share",
+        status=MountStatus.UNMOUNTED,
+    )
+    db.add(mount)
+    db.commit()
+
+    class StatefulProvider:
+        def __init__(self):
+            self.mounted = False
+            self.mount_calls = []
+            self.unmount_calls = []
+
+        def check_mounted(self, local_mount_point: str, *, timeout_seconds=None):
+            return self.mounted
+
+        def os_mount(self, mount_type, remote_path, local_mount_point, *, credentials_file=None, username=None, password=None):
+            self.mount_calls.append(
+                {
+                    "mount_type": mount_type,
+                    "remote_path": remote_path,
+                    "local_mount_point": local_mount_point,
+                    "credentials_file": credentials_file,
+                    "username": username,
+                    "password": password,
+                }
+            )
+            self.mounted = True
+            return True, None
+
+        def os_unmount(self, local_mount_point: str):
+            self.unmount_calls.append(local_mount_point)
+            self.mounted = False
+            return True, None
+
+    provider = StatefulProvider()
+
+    with patch("app.services.mount_service._ensure_mount_directory", return_value=None), \
+         patch("app.services.mount_service._validate_mount_directory_owner", return_value=None):
+        result = validate_mount(
+            mount.id,
+            db,
+            provider=provider,
+            mount_data=MountUpdate(
+                type=MountType.SMB,
+                remote_path="//server/edited-share",
+                project_id="proj-new",
+                username="svc-reader",
+                password="top-secret",
+                credentials_file=None,
+            ),
+        )
+
+    db.expire_all()
+    persisted = db.query(NetworkMount).filter(NetworkMount.id == mount.id).one()
+
+    assert result.remote_path == "//server/edited-share"
+    assert result.project_id == "PROJ-NEW"
+    assert result.status == MountStatus.MOUNTED
+    assert result.last_checked_at is not None
+
+    assert persisted.remote_path == "//server/original-share"
+    assert persisted.project_id == "PROJ-OLD"
+    assert persisted.status == MountStatus.UNMOUNTED
+    assert persisted.last_checked_at is not None
+
+    assert provider.mount_calls == [
+        {
+            "mount_type": MountType.SMB,
+            "remote_path": "//server/edited-share",
+            "local_mount_point": "/smb/original-share",
+            "credentials_file": None,
+            "username": "svc-reader",
+            "password": "top-secret",
+        }
+    ]
+    assert provider.unmount_calls == ["/smb/original-share"]
 
 
 def test_validate_mount_not_found(manager_client, db):

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 from app.models.network import MountStatus, MountType, NetworkMount
 from app.config import settings
@@ -10,6 +11,7 @@ from app.services.mount_service import (
     LinuxMountProvider,
     _cleanup_generated_mount_directory,
     _ensure_mount_directory,
+    sanitize_error_message,
     validate_mount,
 )
 
@@ -1006,6 +1008,89 @@ def test_validate_mount_with_candidate_payload_uses_unsaved_values_without_persi
         }
     ]
     assert provider.unmount_calls == ["/smb/original-share"]
+
+
+def test_validate_mount_with_candidate_payload_returns_sanitized_failure_and_preserves_original_mount(db):
+    mount = NetworkMount(
+        type=MountType.SMB,
+        remote_path="//server/original-share",
+        project_id="PROJ-OLD",
+        local_mount_point="/smb/original-share",
+        status=MountStatus.UNMOUNTED,
+    )
+    db.add(mount)
+    db.commit()
+
+    class StatefulProvider:
+        def __init__(self):
+            self.mounted = False
+            self.mount_calls = []
+            self.unmount_calls = []
+
+        def check_mounted(self, local_mount_point: str, *, timeout_seconds=None):
+            return self.mounted
+
+        def os_mount(self, mount_type, remote_path, local_mount_point, *, credentials_file=None, username=None, password=None):
+            self.mount_calls.append(
+                {
+                    "mount_type": mount_type,
+                    "remote_path": remote_path,
+                    "local_mount_point": local_mount_point,
+                    "credentials_file": credentials_file,
+                    "username": username,
+                    "password": password,
+                }
+            )
+            self.mounted = False
+            return False, "Authentication failed for edited share."
+
+        def os_unmount(self, local_mount_point: str):
+            self.unmount_calls.append(local_mount_point)
+            self.mounted = False
+            return True, None
+
+    provider = StatefulProvider()
+
+    with patch("app.services.mount_service._ensure_mount_directory", return_value=None), \
+         patch("app.services.mount_service._validate_mount_directory_owner", return_value=None):
+        with pytest.raises(HTTPException) as exc_info:
+            validate_mount(
+                mount.id,
+                db,
+                provider=provider,
+                mount_data=MountUpdate(
+                    type=MountType.SMB,
+                    remote_path="//server/edited-share",
+                    project_id="proj-new",
+                    username="svc-reader",
+                    password="top-secret",
+                    credentials_file=None,
+                ),
+            )
+
+    db.expire_all()
+    persisted = db.query(NetworkMount).filter(NetworkMount.id == mount.id).one()
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == sanitize_error_message(
+        "Authentication failed for edited share.",
+        "Mount validation failed",
+    )
+    assert persisted.remote_path == "//server/original-share"
+    assert persisted.project_id == "PROJ-OLD"
+    assert persisted.status == MountStatus.UNMOUNTED
+    assert persisted.last_checked_at is not None
+    assert provider.mount_calls == [
+        {
+            "mount_type": MountType.SMB,
+            "remote_path": "//server/edited-share",
+            "local_mount_point": "/smb/original-share",
+            "credentials_file": None,
+            "username": "svc-reader",
+            "password": "top-secret",
+        }
+    ]
+    assert provider.unmount_calls == []
 
 
 def test_validate_mount_not_found(manager_client, db):


### PR DESCRIPTION
## Summary

This branch updates the Mounts edit workflow so operators must successfully test edited share settings before saving them, while preserving the existing stored mount configuration until validation succeeds. It also stabilizes the Playwright theme visual-regression suite by pinning the screenshot timezone so audit-page snapshots render consistently in CI.

## Changes included

- Backend mount validation now accepts an optional candidate edit payload on `POST /mounts/{mount_id}/validate` instead of only validating the persisted record.
- Mount candidate validation in the service layer now:
  - checks conflicts for the edited remote path and project
  - mounts the candidate configuration without persisting it
  - restores the original mount state afterward
  - records validation timestamps and audit events
  - surfaces restore failures safely with structured logging
- Mount edit UI now includes an in-dialog `Test` action and disables `Save` until the current edited values pass validation.
- Changing mount fields or credentials after a passing test clears the passing state and blocks save again until re-tested.
- Mount API client updated to send an optional validation payload for edit-mode testing.
- Added user-facing success and failure messaging for share test results in the edit dialog.
- Expanded backend, unit, and E2E coverage for the gated mount edit flow.
- Theme visual-regression Playwright spec now runs with a fixed `America/New_York` timezone so audit-page timestamps match committed snapshots across CI runners.

## User-facing / operator-facing effects

- Operators can now test edited share settings before saving them.
- Edited share settings cannot be saved until the current in-dialog values have passed a test.
- Failed share tests keep the dialog open and show actionable feedback without persisting changes.
- This touches an operator workflow and audit-related behavior:
  - mount validation audit events continue to be recorded
  - candidate validation is restored back to the original mount state before returning

## Validation

- Targeted backend mount validation pytest slice passed:
  - `5 passed, 54 deselected`
- Mounts Vue unit spec passed:
  - `19 passed`
- Mounts Playwright E2E spec passed:
  - `2 passed`
- Theme Playwright visual-regression spec passed:
  - `6 passed`
- Full frontend Playwright suite passed locally:
  - `90 passed`
- Integration tests passed locally:
  - `tests/integration -q --run-integration`