### PR TITLE
Adopt release-scoped Alembic revision workflow

### DIFF
--- a/alembic/versions/v0_2_0.py
+++ b/alembic/versions/v0_2_0.py
@@ -1,6 +1,6 @@
 """Initial schema
 
-This is the canonical baseline migration for ECUBE v1.0.
+This is the canonical release-scoped migration for ECUBE v0.2.0.
 
 Fresh install
 -------------
@@ -22,11 +22,12 @@ scratch and then run ``alembic upgrade head``.
 
 Mutability notice
 -----------------
-This migration may be edited in-place while ECUBE is pre-release (no
-production deployments exist). All dev/test environments are rebuilt from
+This migration may be edited in-place while ECUBE v0.2.0 remains unreleased
+(no production deployments exist). All dev/test environments are rebuilt from
 scratch (``drop → create → alembic upgrade head``), so columns or indexes
-added here will always be applied. Once v1.0 ships, this file becomes
-immutable and all schema changes must use new sequential migrations.
+added here will always be applied. Once v0.2.0 ships, this file becomes
+immutable and the next unreleased ECUBE version must use its own single
+release-scoped migration module.
 
 Revision ID: 0001
 Revises:

--- a/app/utils/release_migration.py
+++ b/app/utils/release_migration.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 import argparse
 import re
+import shutil
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
 
 
 _SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
@@ -105,14 +110,47 @@ def create_release_migration(repo_root: Path) -> ReleaseMigrationResult:
     )
 
 
+def autogenerate_release_migration(repo_root: Path) -> ReleaseMigrationResult:
+    current = ensure_release_migration(repo_root)
+    if not current.path.exists():
+        raise ReleaseMigrationError(
+            f"Release migration {current.path.name} does not exist for ECUBE {current.version}. Run 'ecube-release-migration create' first."
+        )
+
+    backup_path = current.path.with_suffix(".py.bak")
+    if backup_path.exists():
+        raise ReleaseMigrationError(
+            f"Temporary backup file already exists at {backup_path}. Remove it before re-running the release migration workflow."
+        )
+
+    current.path.replace(backup_path)
+    temp_dir: Path | None = None
+    try:
+        generated_path, temp_dir = _run_autogenerate_revision(repo_root, current)
+        if generated_path != current.path:
+            generated_path.replace(current.path)
+    except Exception:
+        if backup_path.exists():
+            backup_path.replace(current.path)
+        raise
+    finally:
+        if temp_dir is not None and temp_dir.exists():
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    if backup_path.exists():
+        backup_path.unlink()
+
+    return ensure_release_migration(repo_root)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Locate or create the single unreleased ECUBE Alembic migration for the current project.version."
     )
     parser.add_argument(
         "command",
-        choices=("ensure", "create"),
-        help="'ensure' prints the current release migration path; 'create' scaffolds it if missing and otherwise fails clearly.",
+        choices=("ensure", "create", "autogenerate"),
+        help="'ensure' prints the current release migration path; 'create' scaffolds it if missing; 'autogenerate' refreshes the current release migration from model metadata.",
     )
     parser.add_argument(
         "--repo-root",
@@ -123,7 +161,12 @@ def main(argv: list[str] | None = None) -> int:
 
     repo_root = Path(args.repo_root).resolve()
     try:
-        result = ensure_release_migration(repo_root) if args.command == "ensure" else create_release_migration(repo_root)
+        if args.command == "ensure":
+            result = ensure_release_migration(repo_root)
+        elif args.command == "create":
+            result = create_release_migration(repo_root)
+        else:
+            result = autogenerate_release_migration(repo_root)
     except ReleaseMigrationError as exc:
         parser.exit(1, f"error: {exc}\n")
 
@@ -199,3 +242,30 @@ def upgrade() -> None:
 def downgrade() -> None:
     pass
 '''
+
+
+def _run_autogenerate_revision(repo_root: Path, current: ReleaseMigrationResult) -> tuple[Path, Path]:
+    versions_dir = _versions_dir(repo_root)
+    temp_dir = Path(tempfile.mkdtemp(prefix="ecube-release-migration-", dir=versions_dir))
+    try:
+        config = Config(str(repo_root / "alembic.ini"))
+        config.set_main_option("script_location", str(repo_root / "alembic"))
+        config.set_main_option("version_locations", str(temp_dir))
+        script = command.revision(
+            config,
+            message=f"release {current.version}",
+            autogenerate=True,
+            rev_id=current.revision,
+            head=current.down_revision or "base",
+            version_path=str(temp_dir),
+        )
+        if script is None:
+            raise ReleaseMigrationError("Alembic did not return a generated release migration path.")
+        script_path = Path(script.path)
+        if not script_path.exists():
+            raise ReleaseMigrationError(f"Alembic generated release migration path does not exist: {script_path}")
+        return script_path, temp_dir
+    except ReleaseMigrationError:
+        raise
+    except Exception as exc:
+        raise ReleaseMigrationError(f"Failed to autogenerate release migration for ECUBE {current.version}: {exc}") from exc

--- a/app/utils/release_migration.py
+++ b/app/utils/release_migration.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+_SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+_REVISION_RE = re.compile(r'^revision\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
+_DOWN_REVISION_RE = re.compile(r'^down_revision\s*=\s*(None|["\']([^"\']+)["\'])', re.MULTILINE)
+
+
+class ReleaseMigrationError(RuntimeError):
+    """Raised when the release-scoped migration workflow cannot continue."""
+
+
+@dataclass(frozen=True)
+class ReleaseMigrationResult:
+    version: str
+    path: Path
+    revision: str
+    down_revision: str | None
+    created: bool
+
+
+@dataclass(frozen=True)
+class _MigrationFile:
+    path: Path
+    revision: str
+    down_revision: str | None
+
+
+def release_migration_revision_id(version: str) -> str:
+    match = _SEMVER_RE.fullmatch(version.strip())
+    if not match:
+        raise ReleaseMigrationError(
+            f"Unsupported project.version '{version}'. Release migrations must use major.minor.patch format."
+        )
+    return f"v{match.group(1)}_{match.group(2)}_{match.group(3)}"
+
+
+def release_migration_module_name(version: str) -> str:
+    return f"{release_migration_revision_id(version)}.py"
+
+
+def resolve_project_version(pyproject_path: Path) -> str:
+    text = pyproject_path.read_text(encoding="utf-8")
+    in_project_section = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("[") and line.endswith("]"):
+            in_project_section = line == "[project]"
+            continue
+        if in_project_section and line.startswith("version"):
+            _, value = line.split("=", 1)
+            return value.strip().strip('"\'')
+    raise ReleaseMigrationError(f"Could not resolve [project].version from {pyproject_path}")
+
+
+def ensure_release_migration(repo_root: Path) -> ReleaseMigrationResult:
+    version = resolve_project_version(repo_root / "pyproject.toml")
+    path = _versions_dir(repo_root) / release_migration_module_name(version)
+    revision = release_migration_revision_id(version)
+    if not path.exists():
+        return ReleaseMigrationResult(
+            version=version,
+            path=path,
+            revision=revision,
+            down_revision=_current_head_revision(repo_root),
+            created=False,
+        )
+
+    metadata = _read_migration_file(path)
+    return ReleaseMigrationResult(
+        version=version,
+        path=path,
+        revision=metadata.revision,
+        down_revision=metadata.down_revision,
+        created=False,
+    )
+
+
+def create_release_migration(repo_root: Path) -> ReleaseMigrationResult:
+    pending = ensure_release_migration(repo_root)
+    if pending.path.exists():
+        raise ReleaseMigrationError(
+            f"Release migration {pending.path.name} already exists for ECUBE {pending.version}; update it in place instead of creating a second unreleased migration."
+        )
+
+    pending.path.write_text(
+        _render_migration_template(
+            version=pending.version,
+            revision=pending.revision,
+            down_revision=pending.down_revision,
+        ),
+        encoding="utf-8",
+    )
+    return ReleaseMigrationResult(
+        version=pending.version,
+        path=pending.path,
+        revision=pending.revision,
+        down_revision=pending.down_revision,
+        created=True,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Locate or create the single unreleased ECUBE Alembic migration for the current project.version."
+    )
+    parser.add_argument(
+        "command",
+        choices=("ensure", "create"),
+        help="'ensure' prints the current release migration path; 'create' scaffolds it if missing and otherwise fails clearly.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root that contains pyproject.toml and alembic/versions (default: current directory).",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    try:
+        result = ensure_release_migration(repo_root) if args.command == "ensure" else create_release_migration(repo_root)
+    except ReleaseMigrationError as exc:
+        parser.exit(1, f"error: {exc}\n")
+
+    status = "created" if result.created else "ready"
+    print(f"{status}: {result.path}")
+    return 0
+
+
+def _versions_dir(repo_root: Path) -> Path:
+    versions_dir = repo_root / "alembic" / "versions"
+    if not versions_dir.is_dir():
+        raise ReleaseMigrationError(f"Alembic versions directory not found at {versions_dir}")
+    return versions_dir
+
+
+def _migration_files(repo_root: Path) -> list[_MigrationFile]:
+    versions_dir = _versions_dir(repo_root)
+    migrations: list[_MigrationFile] = []
+    for path in sorted(versions_dir.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        migrations.append(_read_migration_file(path))
+    return migrations
+
+
+def _read_migration_file(path: Path) -> _MigrationFile:
+    text = path.read_text(encoding="utf-8")
+    revision_match = _REVISION_RE.search(text)
+    down_revision_match = _DOWN_REVISION_RE.search(text)
+    if not revision_match or not down_revision_match:
+        raise ReleaseMigrationError(f"Could not parse Alembic revision metadata from {path}")
+    down_revision = down_revision_match.group(2) if down_revision_match.group(1) != "None" else None
+    return _MigrationFile(path=path, revision=revision_match.group(1), down_revision=down_revision)
+
+
+def _current_head_revision(repo_root: Path) -> str | None:
+    migrations = _migration_files(repo_root)
+    if not migrations:
+        return None
+
+    referenced = {migration.down_revision for migration in migrations if migration.down_revision is not None}
+    heads = [migration for migration in migrations if migration.revision not in referenced]
+    if len(heads) != 1:
+        raise ReleaseMigrationError(
+            "Expected exactly one Alembic head revision before creating a new release migration."
+        )
+    return heads[0].revision
+
+
+def _render_migration_template(*, version: str, revision: str, down_revision: str | None) -> str:
+    rendered_down_revision = f'"{down_revision}"' if down_revision is not None else "None"
+    return f'''"""ECUBE release-scoped migration for v{version}.
+
+This module is the single unreleased Alembic migration for ECUBE v{version}.
+Accumulate all schema changes for this unreleased version here until the release ships.
+
+Revision ID: {revision}
+Revises: {down_revision or ''}
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "{revision}"
+down_revision = {rendered_down_revision}
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass
+'''

--- a/app/utils/release_migration.py
+++ b/app/utils/release_migration.py
@@ -4,12 +4,11 @@ import argparse
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
 
 
 _SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
-_REVISION_RE = re.compile(r'^revision\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
-_DOWN_REVISION_RE = re.compile(r'^down_revision\s*=\s*(None|["\']([^"\']+)["\'])', re.MULTILINE)
+_REVISION_RE = re.compile(r'^revision(?:\s*:[^=]+)?\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
+_DOWN_REVISION_RE = re.compile(r'^down_revision(?:\s*:[^=]+)?\s*=\s*(None|["\']([^"\']+)["\'])', re.MULTILINE)
 
 
 class ReleaseMigrationError(RuntimeError):

--- a/docs/development/00-development-guide.md
+++ b/docs/development/00-development-guide.md
@@ -358,6 +358,9 @@ ecube-release-migration ensure
 # ECUBE version starts and no versioned migration file exists yet
 ecube-release-migration create
 
+# Refresh the current release-scoped migration from model metadata
+ecube-release-migration autogenerate
+
 # Apply
 alembic upgrade head
 
@@ -368,7 +371,7 @@ alembic current
 alembic downgrade -1
 ```
 
-For ECUBE's pre-release workflow, all schema changes for the current app version accumulate in a single Alembic module named from `project.version`, for example `alembic/versions/v0_2_0.py`. Run `ecube-release-migration ensure` first, then update that one file in place instead of creating additional unreleased revisions.
+For ECUBE's pre-release workflow, all schema changes for the current app version accumulate in a single Alembic module named from `project.version`, for example `alembic/versions/v0_2_0.py`. Run `ecube-release-migration ensure` first, use `ecube-release-migration create` only when a new unreleased version starts, and use `ecube-release-migration autogenerate` to refresh that one file from current model metadata instead of creating additional unreleased revisions.
 
 ### Reset PostgreSQL Database (Start Fresh)
 

--- a/docs/development/00-development-guide.md
+++ b/docs/development/00-development-guide.md
@@ -351,11 +351,12 @@ All models inherit from `app.database.Base` and live in `app/models/`. Key conve
 ### Creating Migrations
 
 ```bash
-# Auto-generate from model changes
-alembic revision --autogenerate -m "describe change"
+# Ensure the current release-scoped migration exists (or print its path)
+ecube-release-migration ensure
 
-# Or create an empty migration for manual SQL
-alembic revision -m "describe change"
+# Create the current release-scoped migration once when a new unreleased
+# ECUBE version starts and no versioned migration file exists yet
+ecube-release-migration create
 
 # Apply
 alembic upgrade head
@@ -366,6 +367,8 @@ alembic current
 # Rollback one step
 alembic downgrade -1
 ```
+
+For ECUBE's pre-release workflow, all schema changes for the current app version accumulate in a single Alembic module named from `project.version`, for example `alembic/versions/v0_2_0.py`. Run `ecube-release-migration ensure` first, then update that one file in place instead of creating additional unreleased revisions.
 
 ### Reset PostgreSQL Database (Start Fresh)
 
@@ -394,7 +397,7 @@ sudo -u postgres psql -c "DROP OWNED BY ecube; DROP ROLE IF EXISTS ecube;"
 
 ### Migration Naming
 
-Migrations use sequential revision IDs. While ECUBE remains pre-release, the baseline migration may still be amended in place when the history is intentionally collapsed; once the schema is locked for release, all further changes must use new sequential revision files.
+Release-scoped migration filenames use `v<major>_<minor>_<patch>.py`, derived from `[project].version` in `pyproject.toml`. While a version remains unreleased, ECUBE keeps exactly one mutable migration module for that version, and `ecube-release-migration create` fails clearly if that file already exists. Once the version ships, that file becomes immutable and the next unreleased version gets its own release-scoped migration module.
 
 ---
 

--- a/docs/development/02-windows-development-guide.md
+++ b/docs/development/02-windows-development-guide.md
@@ -242,12 +242,17 @@ alembic upgrade head
 # Check current migration version
 alembic current
 
-# Auto-generate a migration from model changes
-alembic revision --autogenerate -m "describe change"
+# Ensure the current release-scoped migration exists (or print its path)
+ecube-release-migration ensure
+
+# Create the current release-scoped migration once for a new unreleased version
+ecube-release-migration create
 
 # Rollback one step
 alembic downgrade -1
 ```
+
+During the pre-release cycle, keep all schema edits for the current ECUBE version in the single versioned file that `ecube-release-migration ensure` reports, for example `alembic/versions/v0_2_0.py`.
 
 > **Note:** Migrations require a running PostgreSQL database. Start the Docker database first (see [Running the Application](#running-the-application)).
 

--- a/docs/development/02-windows-development-guide.md
+++ b/docs/development/02-windows-development-guide.md
@@ -248,11 +248,14 @@ ecube-release-migration ensure
 # Create the current release-scoped migration once for a new unreleased version
 ecube-release-migration create
 
+# Refresh the current release-scoped migration from model metadata
+ecube-release-migration autogenerate
+
 # Rollback one step
 alembic downgrade -1
 ```
 
-During the pre-release cycle, keep all schema edits for the current ECUBE version in the single versioned file that `ecube-release-migration ensure` reports, for example `alembic/versions/v0_2_0.py`.
+During the pre-release cycle, keep all schema edits for the current ECUBE version in the single versioned file that `ecube-release-migration ensure` reports, for example `alembic/versions/v0_2_0.py`. Use `ecube-release-migration autogenerate` when you need to refresh that file from current model metadata.
 
 > **Note:** Migrations require a running PostgreSQL database. Start the Docker database first (see [Running the Application](#running-the-application)).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
 [project.scripts]
 ecube-setup = "app.setup:main"
 ecube-demo-bootstrap = "app.demo_bootstrap:main"
+ecube-release-migration = "app.utils.release_migration:main"
 
 [project.optional-dependencies]
 redis = [

--- a/tests/test_release_migration_tool.py
+++ b/tests/test_release_migration_tool.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+import pytest
+
+from app.utils.release_migration import (
+    ReleaseMigrationError,
+    create_release_migration,
+    ensure_release_migration,
+    release_migration_module_name,
+    release_migration_revision_id,
+)
+
+
+def _write_pyproject(repo_root: Path, version: str) -> None:
+    (repo_root / "pyproject.toml").write_text(
+        """
+[project]
+name = "ecube"
+version = "%s"
+""".strip()
+        % version,
+        encoding="utf-8",
+    )
+
+
+def _write_migration(path: Path, revision: str, down_revision: str | None) -> None:
+    rendered_down_revision = f'"{down_revision}"' if down_revision is not None else "None"
+    path.write_text(
+        """
+revision = "%s"
+down_revision = %s
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass
+""".strip()
+        % (revision, rendered_down_revision),
+        encoding="utf-8",
+    )
+
+
+def test_release_migration_module_name_normalizes_semver() -> None:
+    assert release_migration_module_name("0.2.0") == "v0_2_0.py"
+    assert release_migration_revision_id("0.2.0") == "v0_2_0"
+
+
+def test_release_migration_module_name_rejects_non_semver() -> None:
+    with pytest.raises(ReleaseMigrationError, match="must use major\.minor\.patch"):
+        release_migration_module_name("0.2")
+
+
+def test_ensure_release_migration_returns_existing_release_file(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    versions_dir = repo_root / "alembic" / "versions"
+    versions_dir.mkdir(parents=True)
+    _write_pyproject(repo_root, "0.2.0")
+    existing_path = versions_dir / "v0_2_0.py"
+    _write_migration(existing_path, revision="0001", down_revision=None)
+
+    result = ensure_release_migration(repo_root)
+
+    assert result.path == existing_path
+    assert result.created is False
+    assert result.version == "0.2.0"
+
+
+def test_create_release_migration_fails_when_current_release_file_exists(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    versions_dir = repo_root / "alembic" / "versions"
+    versions_dir.mkdir(parents=True)
+    _write_pyproject(repo_root, "0.2.0")
+    _write_migration(versions_dir / "v0_2_0.py", revision="0001", down_revision=None)
+
+    with pytest.raises(ReleaseMigrationError, match="already exists.*update it in place"):
+        create_release_migration(repo_root)
+
+
+def test_create_release_migration_creates_single_file_for_current_version(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    versions_dir = repo_root / "alembic" / "versions"
+    versions_dir.mkdir(parents=True)
+    _write_pyproject(repo_root, "0.2.0")
+    _write_migration(versions_dir / "v0_1_0.py", revision="v0_1_0", down_revision=None)
+
+    result = create_release_migration(repo_root)
+
+    assert result.created is True
+    assert result.path == versions_dir / "v0_2_0.py"
+    created_text = result.path.read_text(encoding="utf-8")
+    assert 'revision = "v0_2_0"' in created_text
+    assert 'down_revision = "v0_1_0"' in created_text
+    assert "ECUBE release-scoped migration for v0.2.0" in created_text

--- a/tests/test_release_migration_tool.py
+++ b/tests/test_release_migration_tool.py
@@ -70,6 +70,29 @@ def test_ensure_release_migration_returns_existing_release_file(tmp_path: Path) 
     assert result.version == "0.2.0"
 
 
+def test_ensure_release_migration_accepts_typed_alembic_metadata(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    versions_dir = repo_root / "alembic" / "versions"
+    versions_dir.mkdir(parents=True)
+    _write_pyproject(repo_root, "0.2.0")
+    existing_path = versions_dir / "v0_2_0.py"
+    existing_path.write_text(
+        """
+revision: str = "v0_2_0"
+down_revision: str | None = None
+branch_labels = None
+depends_on = None
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = ensure_release_migration(repo_root)
+
+    assert result.path == existing_path
+    assert result.revision == "v0_2_0"
+    assert result.down_revision is None
+
+
 def test_create_release_migration_fails_when_current_release_file_exists(tmp_path: Path) -> None:
     repo_root = tmp_path
     versions_dir = repo_root / "alembic" / "versions"

--- a/tests/test_release_migration_tool.py
+++ b/tests/test_release_migration_tool.py
@@ -1,9 +1,12 @@
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from app.utils.release_migration import (
     ReleaseMigrationError,
+    ReleaseMigrationResult,
+    autogenerate_release_migration,
     create_release_migration,
     ensure_release_migration,
     release_migration_module_name,
@@ -119,3 +122,46 @@ def test_create_release_migration_creates_single_file_for_current_version(tmp_pa
     assert 'revision = "v0_2_0"' in created_text
     assert 'down_revision = "v0_1_0"' in created_text
     assert "ECUBE release-scoped migration for v0.2.0" in created_text
+
+
+def test_autogenerate_release_migration_requires_existing_release_file(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    versions_dir = repo_root / "alembic" / "versions"
+    versions_dir.mkdir(parents=True)
+    _write_pyproject(repo_root, "0.2.0")
+
+    with pytest.raises(ReleaseMigrationError, match="Run 'ecube-release-migration create' first"):
+        autogenerate_release_migration(repo_root)
+
+
+def test_autogenerate_release_migration_replaces_existing_release_file(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    versions_dir = repo_root / "alembic" / "versions"
+    versions_dir.mkdir(parents=True)
+    _write_pyproject(repo_root, "0.2.0")
+    release_path = versions_dir / "v0_2_0.py"
+    _write_migration(release_path, revision="v0_2_0", down_revision=None)
+
+    generated_path = versions_dir / "generated.py"
+    generated_path.write_text(
+        """
+revision: str = "v0_2_0"
+down_revision: str | None = None
+branch_labels = None
+depends_on = None
+""".strip(),
+        encoding="utf-8",
+    )
+
+    temp_dir = versions_dir / "ecube-release-migration-temp"
+    temp_dir.mkdir()
+
+    with patch("app.utils.release_migration._run_autogenerate_revision", return_value=(generated_path, temp_dir)):
+        result = autogenerate_release_migration(repo_root)
+
+    assert result.path == release_path
+    assert result.revision == "v0_2_0"
+    assert release_path.read_text(encoding="utf-8").startswith('revision: str = "v0_2_0"')
+    assert not generated_path.exists()
+    assert not release_path.with_suffix(".py.bak").exists()
+    assert not temp_dir.exists()


### PR DESCRIPTION
## Summary

This branch formalizes ECUBE’s pre-release Alembic workflow around a single release-scoped migration module per app version. It introduces repo-supported tooling to locate, create, and refresh the current unreleased migration, renames the current baseline migration to the version-derived module name for ECUBE 0.2.0, and updates contributor docs so the release workflow is deterministic and repeatable without changing runtime `alembic upgrade head` behavior.

## Changes Included

- Added a new `ecube-release-migration` CLI entry point in `pyproject.toml`.
- Added `app/utils/release_migration.py` to:
  - derive the approved release migration filename from `project.version`
  - enforce the `v<major>_<minor>_<patch>.py` naming convention
  - locate the current release migration with `ensure`
  - create it once with `create`
  - fail clearly if a second unreleased migration would be created for the same version
  - refresh the current release migration with `autogenerate`
  - support both legacy and typed Alembic revision metadata parsing
- Renamed the current unreleased migration from `0001_initial.py` to `v0_2_0.py`.
- Updated the migration header comments to reflect the release-scoped pre-release workflow for ECUBE v0.2.0.
- Updated development documentation for Linux and Windows contributors to replace raw `alembic revision` guidance with the repo-supported release workflow.

## User-Facing / Operator-Facing Effects

- This is primarily a contributor and release-process change rather than a runtime product change.
- Runtime migration application remains unchanged: ECUBE still uses normal Alembic `upgrade head` flows.
- The branch improves release auditability by making one unreleased migration module the standard workflow for each app version.
- Contributors now have a documented repo-supported path for creating and updating the current release migration instead of relying on ad hoc sequential revisions.

## Validation

- Focused utility tests passed:
  - `.venv/bin/python -m pytest tests/test_release_migration_tool.py -q`
- Migration compatibility smoke tests passed:
  - `.venv/bin/python -m pytest tests/test_release_migration_tool.py tests/test_migrations.py -q`
- Verified the parser against Alembic’s installed template format so typed revision metadata is supported.
- Verified current branch delta against `origin/main` and reviewed the unmerged commits on the `alembic` branch.