### PR TITLE
Online help

### DIFF
--- a/.cursor/rules/core.mdc
+++ b/.cursor/rules/core.mdc
@@ -23,6 +23,7 @@ If a requested change conflicts with security, isolation, or trust boundaries, p
 
 Always:
 - Inspect nearby code before changing patterns
+- Inspect the closest existing implementation before introducing a new visual or interaction pattern
 - Prefer the smallest correct change
 - Preserve existing abstractions unless the task requires restructuring
 - Add or update focused tests for changed behavior

--- a/.cursor/rules/frontend.mdc
+++ b/.cursor/rules/frontend.mdc
@@ -37,6 +37,8 @@ Apply when touching Vue, frontend components, templates, CSS, frontend tests, or
 
 ## CSS and Templates
 
+- Before creating new UI styling, inspect the closest existing component with the same visual or interaction pattern and match it unless the task explicitly asks for a new variant
+- Reuse the same design tokens, spacing, scrollbar styling, button treatment, panel treatment, and hover or focus states from the existing component when those patterns already exist nearby
 - Remove unused styles
 - Keep class names aligned with template usage
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,8 @@
 - Business logic must live in `services/`, not routers.
 - All new behavior must include tests.
 - Code must follow Black, Ruff, ESLint, and Prettier formatting.
+- When extending an existing UI surface, inspect the closest existing component that already solves the same visual or interaction problem and match its styling patterns before introducing a new variant.
+- For UI styling work, prefer reusing the same tokens, spacing, scrollbar, button, panel, and state treatments from the existing component unless the task explicitly requires a different design.
 
 ## 2. Architecture & Trust Boundaries
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ To locally preflight the same packaging path used by CI workflows, run:
 bash scripts/package-local.sh --sha "$(git rev-parse --short=8 HEAD)"
 ```
 
+The installer packaging flow now expects the generated in-app help asset to be current before packaging. Review or refresh it with:
+
+```bash
+node scripts/build-help.mjs
+```
+
 ```bash
 tar -xzf ecube-package-<version>.tar.gz
 cd ecube-package-<version>
@@ -159,6 +165,7 @@ Installer/package artifact workflows (`build-artifact.yml` and `tag-release.yml`
 
 - **Testing** — see [docs/testing/01-automated-test-requirements.md](docs/testing/01-automated-test-requirements.md) for test conventions, fixture patterns, and backend/frontend suite execution. For manual QA procedures and test-case assets, use [docs/testing/](docs/testing/).
 - **Development** — start with [docs/development/00-development-guide.md](docs/development/00-development-guide.md) for local setup and workflow. Windows-specific development guidance is in [docs/development/02-windows-development-guide.md](docs/development/02-windows-development-guide.md).
+- **In-app help generation** — the packaged Help modal is generated from [docs/operations/13-user-manual.md](docs/operations/13-user-manual.md) by `node scripts/build-help.mjs`, which writes [frontend/public/help/manual.html](frontend/public/help/manual.html). Run the generator locally, review the HTML output, and then package so CI and local artifacts use the same curated help content.
 - **Documentation** — operational and end-user documentation is in [docs/operations/](docs/operations/). System design and requirement sources are in [docs/design/](docs/design/) and [docs/requirements/](docs/requirements/).
 
 ## Documentation

--- a/docs/development/00-development-guide.md
+++ b/docs/development/00-development-guide.md
@@ -77,6 +77,12 @@ sudo .venv/bin/uvicorn app.main:app --reload
 cd frontend && npm ci && npm run dev
 ```
 
+If you are editing the in-app help during development, regenerate the packaged help file from the repository root after changing the source manual or help generator:
+
+```bash
+node scripts/build-help.mjs
+```
+
 Then open the setup wizard at `http://localhost:5173` to provision the application database/user, run migrations, and create the first ECUBE admin user. The wizard auto-fills superuser credentials from `PG_SUPERUSER_NAME`/`PG_SUPERUSER_PASS` in `.env` (defaulting to `ecube`/`ecube`).
 
 | URL | Purpose |
@@ -331,6 +337,49 @@ npm run dev
 ```
 
 To access the frontend from another machine, browse to `http://<host-ip>:5173`.
+
+### In-App Help Development
+
+ECUBE's packaged in-app help is generated static HTML, not handwritten frontend component markup.
+
+The development workflow uses these files and tools:
+
+- Canonical source content: `docs/operations/13-user-manual.md`
+- Generator: `scripts/build-help.mjs`
+- Generated output: `frontend/public/help/manual.html`
+- Frontend build hook: `frontend/package.json` scripts `build:help`, `build:help:check`, and `build`
+- Frontend consumption point: `frontend/src/components/layout/AppHeader.vue` loads `/help/manual.html` in the Help modal iframe
+
+Typical workflow while developing help content:
+
+1. Edit `docs/operations/13-user-manual.md` when the canonical user-facing content changes.
+2. Edit `scripts/build-help.mjs` when the curated in-app help output, styling, numbering, filtering, or theme behavior needs to change.
+3. Regenerate the packaged help file from the repository root:
+
+```bash
+node scripts/build-help.mjs
+```
+
+4. Open the frontend and review the Help modal against the regenerated `frontend/public/help/manual.html` output.
+5. Before committing or packaging, verify the generated help file is current:
+
+```bash
+node scripts/build-help.mjs --check
+```
+
+6. When validating frontend packaging behavior, use the existing frontend build/test hooks:
+
+```bash
+npm --prefix frontend run build:help
+npm --prefix frontend run build:help:check
+npm --prefix frontend run test:unit -- --run src/build/__tests__/helpAsset.spec.js
+```
+
+Important workflow notes:
+
+- `npm run dev` serves the generated file from `frontend/public/`, but it does not regenerate help automatically when the manual changes.
+- `npm --prefix frontend run build` runs `build:help` before `vite build`, so packaged frontend artifacts include the current generated help.
+- The in-app help is curated from the user manual rather than mirroring it verbatim; generator logic controls which sections are excluded, renumbered, or restyled for the modal experience.
 
 ### Access URLs
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build:help": "node ../scripts/build-help.mjs",
+    "build:help:check": "node ../scripts/build-help.mjs --check",
+    "build": "npm run build:help && vite build",
     "preview": "vite preview",
     "test:unit": "vitest run --coverage",
     "test:e2e": "playwright test"

--- a/frontend/public/help/manual.html
+++ b/frontend/public/help/manual.html
@@ -550,7 +550,7 @@ Credentials file
 <p>After a service restart, ECUBE may automatically restore an expected managed share mount or remove a stale ECUBE-managed mount point that no longer matches persisted system state. These startup corrections are intentional and are recorded in the audit log with sanitized details.</p>
 <p>The exact credential fields required depend on the mount type and your environment.</p>
 <p>If share browsing is unavailable because the ECUBE host is missing a required discovery tool, the dialog now shows an actionable message telling the operator which host package to install before retrying. The browse control is hidden entirely when ECUBE is running in demo mode.</p>
-<h2 id="5-1-1-editing-a-mount">5.1.1 Editing a Mount</h2>
+<h3 id="5-1-1-editing-a-mount">5.1.1 Editing a Mount</h3>
 <p>Use <code>Edit</code> on an existing mount row to reopen the same dialog in edit mode.</p>
 <ul><li>
 The dialog pre-fills the current type, remote path, and project ID.
@@ -568,7 +568,7 @@ Use <code>Clear saved credentials</code> if you need to remove previously stored
 <p>Remove a mount only if it is no longer needed. If existing workflows depend on it, removing the definition can interrupt job creation or repeatability.</p>
 <p class="help-back-to-top"><a href="#help-toc-title">Back to top</a></p>
 <hr />
-<h1 id="5-4-directory-browser">5.4 Directory Browser</h1>
+<h2 id="5-4-directory-browser">5.4 Directory Browser</h2>
 <p>The directory browser allows users to explore the contents of active mount points (USB drives and network shares) before creating an export job.</p>
 <p><strong>Accessing the browser:</strong></p>
 <ul><li>

--- a/frontend/public/help/manual.html
+++ b/frontend/public/help/manual.html
@@ -1,0 +1,1401 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ECUBE Help</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --help-bg: #f4efe7;
+        --help-panel: #fffdf8;
+        --help-border: #d8cbb7;
+        --help-text: #2f261b;
+        --help-muted: #6b5f51;
+        --help-accent: #0f5c4d;
+        --help-accent-soft: #e2f0ec;
+        --help-code-bg: #f1e7d8;
+        --help-shadow: 0 18px 48px rgba(47, 38, 27, 0.12);
+        --help-radius: 18px;
+        --help-font: Georgia, 'Times New Roman', serif;
+        --help-ui-font: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      }
+
+      * { box-sizing: border-box; }
+
+      body {
+        margin: 0;
+        padding: 24px;
+        background:
+          radial-gradient(circle at top left, rgba(15, 92, 77, 0.08), transparent 30%),
+          linear-gradient(180deg, #f8f3ec 0%, var(--help-bg) 100%);
+        color: var(--help-text);
+        font-family: var(--help-font);
+        line-height: 1.6;
+      }
+
+      main {
+        max-width: 920px;
+        margin: 0 auto;
+        padding: 32px;
+        background: var(--help-panel);
+        border: 1px solid var(--help-border);
+        border-radius: var(--help-radius);
+        box-shadow: var(--help-shadow);
+      }
+
+      .help-kicker {
+        margin: 0;
+        font-family: var(--help-ui-font);
+        font-size: 0.8rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--help-accent);
+      }
+
+      h1 {
+        margin: 0.35rem 0 0.25rem;
+        font-size: clamp(2rem, 3vw, 3rem);
+        line-height: 1.1;
+      }
+
+      .help-meta,
+      .help-lead {
+        margin: 0.25rem 0 0;
+        font-family: var(--help-ui-font);
+        color: var(--help-muted);
+      }
+
+      h1,
+      h2,
+      h3,
+      h4 {
+        color: #1e1a14;
+      }
+
+      h2,
+      h3,
+      h4 {
+        margin-top: 2rem;
+        font-family: var(--help-ui-font);
+      }
+
+      a {
+        color: var(--help-accent);
+      }
+
+      hr {
+        border: 0;
+        border-top: 1px solid var(--help-border);
+        margin: 2rem 0;
+      }
+
+      blockquote {
+        margin: 1rem 0;
+        padding: 0.9rem 1rem;
+        border-left: 4px solid var(--help-accent);
+        background: var(--help-accent-soft);
+        border-radius: 0 12px 12px 0;
+        font-family: var(--help-ui-font);
+      }
+
+      code,
+      pre {
+        font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+      }
+
+      code {
+        padding: 0.1rem 0.3rem;
+        background: var(--help-code-bg);
+        border-radius: 4px;
+      }
+
+      pre {
+        overflow-x: auto;
+        padding: 1rem;
+        background: #2f261b;
+        color: #fff8ee;
+        border-radius: 14px;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+        font-family: var(--help-ui-font);
+      }
+
+      th,
+      td {
+        padding: 0.75rem;
+        border: 1px solid var(--help-border);
+        text-align: left;
+        vertical-align: top;
+      }
+
+      th {
+        background: #f1e7d8;
+      }
+
+      ul,
+      ol {
+        padding-left: 1.5rem;
+      }
+
+      @media (max-width: 720px) {
+        body {
+          padding: 12px;
+        }
+
+        main {
+          padding: 20px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p class="help-kicker">In-App Help</p>
+      <h1>ECUBE User Guide</h1>
+      <p class="help-meta">Updated: 04/25/26</p>
+      <p class="help-lead">Generated from docs/operations/13-user-manual.md for authenticated in-app help.</p>
+      <h1 id="purpose">Purpose</h1>
+<p>This manual explains how to use the ECUBE web interface for day-to-day work. It focuses on tasks performed in the browser after the platform has already been deployed and made available by an administrator.</p>
+<p>Primary workflows covered in this guide:</p>
+<ul><li>
+Accessing the ECUBE web interface
+</li><li>
+Understanding role-based navigation
+</li><li>
+Viewing system status and drive state
+</li><li>
+Creating and monitoring export jobs
+</li><li>
+Reviewing job results, hashes, and file comparisons
+</li><li>
+Managing mount definitions
+</li><li>
+Viewing and exporting audit logs
+</li><li>
+Accessing user and system pages when your role permits it
+</li><li>
+Managing selected runtime configuration settings (admin-only)
+</li></ul>
+<h1 id="scope">Scope</h1>
+<p>This guide is intended for users who interact with ECUBE through the web UI. It does not cover operating-system setup, service management, certificate provisioning, Docker administration, or backend troubleshooting.</p>
+<p>For those topics, use the companion guides:</p>
+<ul><li>
+01-installation.md for packaged installation options
+</li><li>
+02-manual-installation.md for native/manual deployment
+</li><li>
+03-docker-deployment.md for Docker Compose deployment
+</li><li>
+09-administration-automation-guide.md for administrative and API-driven tasks
+</li><li>
+11-api-quick-reference.md for direct API usage
+</li></ul>
+<hr />
+<h1 id="2-before-you-begin">2. Before You Begin</h1>
+<p>Before using ECUBE, make sure you have:</p>
+<ul><li>
+A supported browser
+</li><li>
+The correct ECUBE URL
+</li><li>
+A valid user account and password or SSO-backed identity
+</li><li>
+Permission for the tasks you need to perform
+</li></ul>
+<p>Supported browser targets for the current frontend:</p>
+<ul><li>
+Google Chrome
+</li><li>
+Microsoft Edge
+</li><li>
+Safari
+</li></ul>
+<p>Use one of the latest two major browser versions maintained by your organization. Firefox is not currently a supported target for the frontend.</p>
+<p>If you do not know your role, ask your ECUBE administrator. ECUBE uses role-based access control, so some pages and buttons are visible only to certain users.</p>
+<hr />
+<h1 id="3-roles-and-access">3. Roles and Access</h1>
+<p>The UI adapts to the roles assigned to your account.</p>
+<table><thead><tr>
+<th>Role</th>
+<th>Typical Access</th>
+</tr></thead>
+<tbody>
+<tr>
+<td><code>admin</code></td>
+<td>Full access to all UI areas, including user administration</td>
+</tr>
+<tr>
+<td><code>manager</code></td>
+<td>Drive, mount, and job oversight</td>
+</tr>
+<tr>
+<td><code>processor</code></td>
+<td>Create and manage export jobs, view system state</td>
+</tr>
+<tr>
+<td><code>auditor</code></td>
+<td>Read-only access to audit, job verification, and evidence review areas</td>
+</tr>
+</tbody>
+</table>
+<p>Common role effects in the UI:</p>
+<ul><li>
+The <code>Audit</code> page is visible only to roles allowed to inspect audit records.
+</li><li>
+The <code>Users</code> page is visible only to roles allowed to manage users.
+</li><li>
+The <code>Configuration</code> page is visible only to <code>admin</code> users.
+</li><li>
+Action buttons such as formatting or initializing drives may be disabled if your role does not permit them.
+</li></ul>
+<hr />
+<h1 id="4-first-access">4. First Access</h1>
+<h2 id="4-2-login">4.2 Login</h2>
+<blockquote><p><strong>Access Summary</strong></p></blockquote>
+<blockquote><p><strong>Page visibility:</strong> Available to unauthenticated users after setup is complete.</p></blockquote>
+<blockquote><p><strong>Restricted actions:</strong> None.</p></blockquote>
+<p>After setup is complete, open the ECUBE URL and sign in with your assigned username and password.</p>
+<p>The login page includes:</p>
+<ul><li>
+Username field
+</li><li>
+Password field
+</li><li>
+Login button
+</li><li>
+Session-expired banner when you were redirected after token expiry
+</li><li>
+Error banner for invalid credentials or connectivity failures
+</li></ul>
+<p>If login fails:</p>
+<ul><li>
+Re-enter username and password carefully
+</li><li>
+Confirm you are using the correct ECUBE URL
+</li><li>
+Check whether your browser can reach the site over HTTPS
+</li><li>
+Contact an administrator if your account may be locked, missing, or incorrectly assigned
+</li></ul>
+<hr />
+<h1 id="5-interface-overview">5. Interface Overview</h1>
+<blockquote><p><strong>Access Summary</strong></p></blockquote>
+<blockquote><p><strong>Page visibility:</strong> Available to authenticated users.</p></blockquote>
+<blockquote><p><strong>Restricted actions:</strong> Navigation items shown in the shell depend on the roles assigned to your account.</p></blockquote>
+<p>After login, ECUBE displays a standard application shell:</p>
+<ul><li>
+Header at the top
+</li><li>
+Sidebar navigation on the left
+</li><li>
+Main content area in the center
+</li><li>
+Footer at the bottom
+</li></ul>
+<p>Common navigation items include:</p>
+<ul><li>
+<code>Dashboard</code>
+</li><li>
+<code>Drives</code>
+</li><li>
+<code>Mounts</code>
+</li><li>
+<code>Jobs</code>
+</li><li>
+<code>Audit</code> (role-restricted)
+</li><li>
+<code>System</code>
+</li><li>
+<code>Users</code> (admin-only or otherwise restricted)
+</li><li>
+<code>Configuration</code> (admin-only)
+</li></ul>
+<p>If you do not see a page described in this manual, your role may not include access to it.</p>
+<h2 id="5-1-theme-selection-light-dark-custom">5.1 Theme Selection (Light/Dark/Custom)</h2>
+<blockquote><p><strong>Access Summary</strong></p></blockquote>
+<blockquote><p><strong>Page visibility:</strong> Available to authenticated users.</p></blockquote>
+<blockquote><p><strong>Restricted actions:</strong> None. Theme selection is user-level and does not require an elevated role.</p></blockquote>
+<p>To change your theme in the current session:</p>
+<ol><li>
+Open the theme selector in the top-right header area.
+</li><li>
+Choose the desired theme (for example <code>Light</code> or <code>Dark</code>).
+</li><li>
+Confirm visual changes are applied immediately.
+</li></ol>
+<p>How theme preference is stored:</p>
+<ul><li>
+Theme choice is saved in browser local storage for that browser profile.
+</li><li>
+Different browsers or machines may show different themes for the same user account.
+</li></ul>
+<p>Important default-theme note:</p>
+<ul><li>
+The web UI currently does not provide an administrator control to set a system-wide default theme for all users.
+</li><li>
+Platform administrators can still influence the deployment default by controlling which CSS is served as <code>default.css</code> in the mounted themes directory.
+</li></ul>
+<p>For deployment-side theme and branding management, see 14-theme-and-branding-guide.md and 04-configuration-reference.md (<code>ECUBE_THEMES_DIR</code>).</p>
+<p>Example dark-theme appearance:</p>
+<hr />
+<h1 id="6-dashboard">6. Dashboard</h1>
+<blockquote><p><strong>Access Summary</strong></p></blockquote>
+<blockquote><p><strong>Page visibility:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code></p></blockquote>
+<blockquote><p><strong>Restricted actions:</strong> None described on this screen; use linked pages for operational actions.</p></blockquote>
+<p>The dashboard provides a quick operational summary.</p>
+<p>Typical information shown:</p>
+<ul><li>
+Overall system health
+</li><li>
+Database status
+</li><li>
+Number of active jobs
+</li><li>
+Drive state summary (<code>DISCONNECTED</code>, <code>AVAILABLE</code>, <code>IN_USE</code>)
+</li><li>
+Table of active jobs
+</li></ul>
+<p>Use the dashboard when you need a quick answer to questions such as:</p>
+<ul><li>
+Is the system healthy?
+</li><li>
+Are any jobs currently running or verifying?
+</li><li>
+How many drives are ready for use?
+</li></ul>
+<p>The dashboard is intended for situational awareness, not full task execution. Use the dedicated pages for detailed operations.</p>
+<hr />
+<h1 id="7-drives">7. Drives</h1>
+<blockquote><p><strong>Access Summary</strong></p></blockquote>
+<blockquote><p><strong>Page visibility:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code></p></blockquote>
+<blockquote><p><strong>Restricted actions:</strong> Drive detail actions such as format, initialize, and prepare eject are currently enabled only for <code>admin</code> and <code>manager</code>.</p></blockquote>
+<p>The <code>Drives</code> page shows detected USB drives and their current state.</p>
+<p>Typical drive fields include:</p>
+<ul><li>
+Device (port-based identifier such as <code>2-1</code>)
+</li><li>
+Serial Number
+</li><li>
+Filesystem type
+</li><li>
+Capacity
+</li><li>
+Assigned project
+</li><li>
+Current state
+</li></ul>
+<p>Available actions depend on your role and the selected drive.</p>
+<h2 id="7-1-drive-states">7.1 Drive States</h2>
+<p>Every drive moves through a defined set of states. Actions available in the UI depend on the current state.</p>
+<table><thead><tr>
+<th>State</th>
+<th>Meaning</th>
+<th>Actions available</th>
+</tr></thead>
+<tbody>
+<tr>
+<td><code>DISCONNECTED</code></td>
+<td>Drive is known to the system but not currently accessible — either not physically present, or present on a disabled port.</td>
+<td>Enable port when the drive is still physically detected on a known port</td>
+</tr>
+<tr>
+<td><code>AVAILABLE</code></td>
+<td>Drive is present on an enabled port and ready to be formatted or assigned to a project.</td>
+<td>Format, Initialize</td>
+</tr>
+<tr>
+<td><code>IN_USE</code></td>
+<td>Drive is assigned to a project. Jobs can target this drive.</td>
+<td>Prepare Eject</td>
+</tr>
+<tr>
+<td><code>ARCHIVED</code></td>
+<td>Drive has been permanently handed off via the Chain of Custody workflow.</td>
+<td>None — drive is read-only.</td>
+</tr>
+</tbody>
+</table>
+<p>State transitions follow this order:</p>
+<pre><code>DISCONNECTED → AVAILABLE → IN_USE → AVAILABLE → ARCHIVED
+                       ↑____________|
+                     (re-insert same project)</code></pre>
+<p>A drive assigned to one project cannot be re-assigned to a different project without first being formatted. Formatting wipes the drive and clears the project binding.</p>
+<p>After a service restart, ECUBE may automatically restore a previously mounted managed USB drive to its expected ECUBE mount slot. If a drive or mount appears to have changed state during startup, review the <code>Audit Logs</code> page for reconciliation events recorded by the system.</p>
+<h2 id="7-2-viewing-drives">7.2 Viewing Drives</h2>
+<p>Use the page controls to:</p>
+<ul><li>
+Refresh the current drive list
+</li><li>
+Trigger a rescan of connected drives
+</li><li>
+Search by device, serial number, or project information
+</li><li>
+Filter by drive state
+</li><li>
+Sort results
+</li></ul>
+<h2 id="7-3-drive-detail-page">7.3 Drive Detail Page</h2>
+<p>Selecting a drive opens a detail view showing:</p>
+<ul><li>
+The port-based <code>Device</code> value, the separate <code>Serial Number</code> value, and filesystem details, with sensitive path values shown as <code>Protected</code> in standard operator views when appropriate
+</li><li>
+Current project assignment
+</li><li>
+Current status badge
+</li><li>
+Available actions such as format, initialize, and prepare eject
+</li></ul>
+<p>Reference screen:</p>
+<h2 id="7-4-formatting-a-drive">7.4 Formatting a Drive</h2>
+<p>If your role allows it, you can format a drive from the detail page.</p>
+<p>Current UI options include:</p>
+<ul><li>
+<code>ext4</code>
+</li><li>
+<code>exfat</code>
+</li></ul>
+<p>Formatting removes all existing data and clears the project binding. After formatting, the drive can be initialized for any project that has an eligible mounted share.</p>
+<p>The Format action is unavailable while the drive is mounted. If the drive is currently mounted, use the appropriate unmount or prepare-eject workflow first.</p>
+<p>Confirm the target drive carefully before proceeding.</p>
+<h2 id="7-5-initializing-a-drive">7.5 Initializing a Drive</h2>
+<p>Initialization assigns a drive to a project identifier and transitions it to <code>IN_USE</code>. Once initialized, project isolation rules apply to all writes performed through ECUBE.</p>
+<p>Initialization now requires at least one network share that is both assigned to the same project and currently in the <code>MOUNTED</code> state. If no eligible mounted share exists, the UI disables submission and the API rejects the request.</p>
+<p>When you open the Initialize dialog:</p>
+<ul><li>
+The <strong>Project</strong> field is shown as a dropdown populated from distinct project IDs on mounted shares only.
+</li><li>
+The dialog also shows the mounted destination context for the selected USB drive while still redacting the raw internal path from standard operator views.
+</li><li>
+If the drive has a previous project assignment and that project still has an eligible mounted share, that project is pre-selected.
+</li><li>
+If no eligible mounted project exists, the dialog shows a helper message telling you to add and mount a share first.
+</li><li>
+Canceling the dialog does not change the drive state, project binding, or action availability.
+</li></ul>
+<p>Before initializing a drive:</p>
+<ul><li>
+Confirm the correct source share for the case or matter has already been added and mounted.
+</li><li>
+Select the correct project from the dropdown list.
+</li><li>
+Confirm the drive is the intended destination media.
+</li><li>
+If you need to assign the drive to a <em>different</em> project, format it first to clear the existing binding.
+</li></ul>
+<h2 id="7-6-prepare-eject">7.6 Prepare Eject</h2>
+<p>Use <code>Prepare Eject</code> before physically removing a drive. This flushes pending writes, unmounts the filesystem, and transitions the drive to <code>AVAILABLE</code>.</p>
+<p>After a successful prepare-eject:</p>
+<ul><li>
+The drive state returns to <code>AVAILABLE</code>.
+</li><li>
+The project binding is preserved so the drive can be re-initialized for the same project without reformatting.
+</li><li>
+The drive <strong>cannot</strong> be initialized for a <em>different</em> project until it has been formatted.
+</li><li>
+The drive can be physically removed once the operation completes.
+</li></ul>
+<p>If ECUBE reports that the drive is still busy, the confirmation dialog closes cleanly and the page shows a specific retry message. Close any open shell, file browser, or process still using the mounted drive, then retry <code>Prepare Eject</code>.</p>
+<p>If ECUBE detects timed-out or failed files in active drive assignments, the first <code>Prepare Eject</code> attempt is blocked with an explicit confirmation-required warning. Review the warning details, then confirm a second prompt to continue with ejection.</p>
+<blockquote><p>To permanently retire a drive after removal, use the Chain of Custody handoff workflow on the <code>Audit</code> page. Confirming a handoff transitions the drive to <code>ARCHIVED</code>.</p></blockquote>
+<hr />
+<h1 id="8-mounts">8. Mounts</h1>
+<blockquote><p><strong>Access Summary</strong></p></blockquote>
+<blockquote><p><strong>Page visibility:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code></p></blockquote>
+<blockquote><p><strong>Restricted actions:</strong> The mounts page is currently available to all authenticated users in the frontend.</p></blockquote>
+<p>The <code>Mounts</code> page manages source locations used for export jobs.</p>
+<p>You can typically:</p>
+<ul><li>
+Refresh the mount list
+</li><li>
+Validate all mounts
+</li><li>
+Validate an individual mount
+</li><li>
+Add a new mount definition
+</li><li>
+Edit an existing mount definition
+</li><li>
+Remove an existing mount definition
+</li></ul>
+<h2 id="8-1-adding-a-mount">8.1 Adding a Mount</h2>
+<p>The add-mount dialog supports common fields such as:</p>
+<ul><li>
+Type (<code>SMB</code> or <code>NFS</code>)
+</li><li>
+Project ID
+</li><li>
+Remote path
+</li><li>
+Username
+</li><li>
+Password
+</li><li>
+Credentials file
+</li></ul>
+<p>When adding a new mount, <code>admin</code> and <code>manager</code> users can use <code>Browse</code> inside the dialog to discover available SMB shares or NFS exports from the entered target server. The browse dialog reuses any credentials entered in the form, shows discovered shares in a scrollable picker when the result set is long, and selecting a result fills the <code>Remote path</code> field automatically.</p>
+<p>Project assignment is required when creating a mount. Drives can only be initialized for projects that have at least one assigned share in the <code>MOUNTED</code> state.</p>
+<p>ECUBE rejects exact duplicate remote paths and blocks overlapping parent or child remote paths across different projects. Nested paths for the same project remain allowed. If two operators submit changes at the same time, one request may briefly return a conflict while ECUBE finishes the in-progress update.</p>
+<p>For security, the standard mount list and browse labels intentionally redact raw remote paths and local mount points in operator-facing views.</p>
+<p>ECUBE now creates the local mount point automatically based on the remote path and mount type (for example, NFS mounts are created under <code>/nfs/<em></code> and SMB mounts under <code>/smb/</em></code>).</p>
+<p>After a service restart, ECUBE may automatically restore an expected managed share mount or remove a stale ECUBE-managed mount point that no longer matches persisted system state. These startup corrections are intentional and are recorded in the audit log with sanitized details.</p>
+<p>The exact credential fields required depend on the mount type and your environment.</p>
+<p>If share browsing is unavailable because the ECUBE host is missing a required discovery tool, the dialog now shows an actionable message telling the operator which host package to install before retrying. The browse control is hidden entirely when ECUBE is running in demo mode.</p>
+<h2 id="8-1-1-editing-a-mount">8.1.1 Editing a Mount</h2>
+<p>Use <code>Edit</code> on an existing mount row to reopen the same dialog in edit mode.</p>
+<ul><li>
+The dialog pre-fills the current type, remote path, and project ID.
+</li><li>
+The local mount point is shown as read-only informational context and is not directly editable.
+</li><li>
+Stored credentials are not returned to the UI. Leaving the credential fields blank preserves the stored values.
+</li><li>
+Use <code>Clear saved credentials</code> if you need to remove previously stored SMB credentials without replacing them in the same edit.
+</li></ul>
+<p>When you save, ECUBE updates the existing mount record instead of creating a new one, then refreshes the row status in the list. If the backend rejects the change, or if the returned mount status is <code>ERROR</code>, the dialog stays open so you can review the returned error state before closing it.</p>
+<h2 id="8-2-testing-mount-connectivity">8.2 Testing Mount Connectivity</h2>
+<p>Use <code>Test</code> or <code>Test All</code> to verify that configured source mounts are reachable and valid before creating jobs that depend on them.</p>
+<h2 id="8-3-removing-a-mount">8.3 Removing a Mount</h2>
+<p>Remove a mount only if it is no longer needed. If existing workflows depend on it, removing the definition can interrupt job creation or repeatability.</p>
+<hr />
+<h1 id="8-4-directory-browser">8.4 Directory Browser</h1>
+<p>The directory browser allows users to explore the contents of active mount points (USB drives and network shares) before creating an export job.</p>
+<p><strong>Accessing the browser:</strong></p>
+<ul><li>
+<strong>From Drive Detail:</strong> Click the mount path link on any mounted drive to open the directory browser rooted at that drive's mount point.
+</li><li>
+<strong>From Mounts:</strong> Click the <code>Browse</code> button on any mounted network share. The button is disabled for shares that are not currently mounted.
+</li></ul>
+<p><strong>Navigating:</strong></p>
+<ul><li>
+Click a folder name to descend into it. The breadcrumb trail at the top shows the current path.
+</li><li>
+Click any breadcrumb segment to navigate back up.
+</li><li>
+Symlinks appear with a link icon and are not navigable.
+</li><li>
+Results are paginated; use the page controls at the bottom to navigate large directories.
+</li></ul>
+<p><strong>Roles:</strong> All authenticated roles (<code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code>) can browse directories.</p>
+<blockquote><p><strong>Note:</strong> Only active, registered mount points can be browsed. Arbitrary filesystem paths are not accessible through this feature.</p></blockquote>
+<hr />
+<h1 id="9-jobs">9. Jobs</h1>
+<blockquote><p><strong>Access Summary</strong></p></blockquote>
+<blockquote><p><strong>Page visibility:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code></p></blockquote>
+<blockquote><p><strong>Restricted actions:</strong> Creating jobs in the current UI is enabled for <code>admin</code>, <code>manager</code>, and <code>processor</code>.</p></blockquote>
+<p>The <code>Jobs</code> page is the main workspace for creating and tracking export operations.</p>
+<p>The page includes:</p>
+<ul><li>
+A jobs table
+</li><li>
+Search and status filters
+</li><li>
+Refresh action
+</li><li>
+<code>Create Job</code> dialog
+</li></ul>
+<h2 id="9-1-viewing-jobs">9.1 Viewing Jobs</h2>
+<p>Use the jobs table to review:</p>
+<ul><li>
+Job ID
+</li><li>
+Project ID
+</li><li>
+Evidence number
+</li><li>
+Device
+</li><li>
+Current status
+</li><li>
+Progress label or percentage
+</li></ul>
+<p>For active jobs, the progress value stays synchronized with both copied bytes and completed file counts. During startup analysis, a newly started job can show <code>Preparing...</code> in the Jobs list while ECUBE scans the source files and calculates totals. A running, pausing, or verifying job does not show 100% until the finished-file totals also indicate completion.</p>
+<p>Common statuses include:</p>
+<ul><li>
+<code>PENDING</code>
+</li><li>
+<code>RUNNING</code>
+</li><li>
+<code>PAUSING</code>
+</li><li>
+<code>PAUSED</code>
+</li><li>
+<code>VERIFYING</code>
+</li><li>
+<code>COMPLETED</code>
+</li><li>
+<code>FAILED</code>
+</li></ul>
+<p>The jobs table also exposes row-level <code>Details</code>, <code>Start</code>, and <code>Pause</code> actions for authorized operators. <code>PAUSING</code> means ECUBE is waiting for in-flight copy threads to finish their current work before the job becomes fully <code>PAUSED</code>.</p>
+<h2 id="9-2-creating-a-job">9.2 Creating a Job</h2>
+<p>The current job-creation flow uses a grouped dialog instead of a four-step wizard.</p>
+<p>The dialog is organized into four sections:</p>
+<ol><li>
+<code>Job details</code> — project, evidence number, optional notes, and thread count
+</li><li>
+<code>Source</code> — the mounted project source and source path
+</li><li>
+<code>Destination</code> — the eligible mounted USB device for the selected project
+</li><li>
+<code>Execution</code> — the optional <code>Run job immediately</code> checkbox
+</li></ol>
+<p>Only the <code>Project</code> field is active when the dialog opens. After you select a project, ECUBE unlocks the remaining fields and filters the available mounts and destination drives to project-matching, currently eligible resources.</p>
+<p>The destination selector is labeled <code>Select device</code> and shows the same port-based <code>Device</code> value used elsewhere in the UI, rather than a serial number or <code>#id</code> prefix.</p>
+<p>Before creating a job, confirm:</p>
+<ul><li>
+The correct project is selected first
+</li><li>
+The source mount and destination drive both match that project
+</li><li>
+The evidence number and source path are correct
+</li><li>
+If you enable <code>Run job immediately</code>, the job will start as soon as creation succeeds
+</li></ul>
+<p>The source path is interpreted inside the selected mounted share. Entering only / uses the root of that share, and attempts to navigate outside the selected share are rejected before the job is created.</p>
+<h2 id="9-3-opening-a-job">9.3 Opening a Job</h2>
+<p>Open a job to view details and perform follow-up actions.</p>
+<hr />
+<h1 id="10-job-detail-verification-and-file-review">10. Job Detail, Verification, and File Review</h1>
+<blockquote><p><strong>Access Summary</strong></p></blockquote>
+<blockquote><p><strong>Page visibility:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code></p></blockquote>
+<blockquote><p><strong>Restricted actions:</strong> <code>Analyze</code>, <code>Edit</code>, <code>Start</code>, <code>Retry Failed Files</code>, <code>Pause</code>, <code>Complete</code>, <code>Verify</code>, and <code>Manifest</code> are enabled for <code>admin</code>, <code>manager</code>, and <code>processor</code> when the current job state allows them. <code>Clear startup analysis cache</code> is shown only to <code>admin</code> and <code>manager</code> when the job still has a persisted startup-analysis snapshot. <code>Delete</code> is shown only for eligible pending jobs. Hash inspection and source/destination comparison remain available to <code>admin</code> and <code>auditor</code>.</p></blockquote>
+<p>The job detail page provides deeper inspection and follow-up controls.</p>
+<p>Typical functions include:</p>
+<ul><li>
+Run manual startup analysis before copy starts so the operator can review discovered files and estimated bytes
+</li><li>
+Edit a pending, paused, or failed job before resuming work
+</li><li>
+Start a pending job or resume a paused one
+</li><li>
+Retry only the failed or timed-out files from a partial-success completed job
+</li><li>
+Pause a running job and resume it later
+</li><li>
+Manually complete a safe non-active job when required by the workflow
+</li><li>
+Clear a persisted startup-analysis snapshot before the next restart when the cached scan should be discarded
+</li><li>
+Generate a manifest and confirm where it was written
+</li><li>
+Review copied files
+</li><li>
+Inspect hashes for individual files
+</li><li>
+Compare a file's source version against its copied destination version
+</li></ul>
+<h2 id="10-1-editing-starting-retrying-failed-files-pausing-completing-verifying-and-generating-a-manifest">10.1 Editing, Starting, Retrying Failed Files, Pausing, Completing, Verifying, and Generating a Manifest</h2>
+<p>Action buttons are shown near the top of the job detail screen.</p>
+<p>Use them when appropriate:</p>
+<ul><li>
+<code>Analyze</code> to run startup analysis for an eligible job without starting copy
+</li><li>
+<code>Edit</code> to adjust evidence number, source path, drive, or thread count for a <code>PENDING</code>, <code>PAUSED</code>, or <code>FAILED</code> job
+</li><li>
+<code>Start</code> to begin a new job or resume a paused one
+</li><li>
+<code>Retry Failed Files</code> to re-queue only <code>ERROR</code> and <code>TIMEOUT</code> file rows on a <code>COMPLETED</code> job that finished with partial-success results
+</li><li>
+<code>Pause</code> to request a safe stop after the current copy work finishes
+</li><li>
+<code>Complete</code> to manually mark a pending, paused, or failed job as complete when the operational workflow requires it
+</li><li>
+<code>Clear startup analysis cache</code> to remove a persisted startup scan after explicit confirmation; this is available only to <code>admin</code> and <code>manager</code> when cached startup-analysis data exists for the job
+</li><li>
+<code>Verify</code> to run verification checks once the job is fully complete with no failed or timed-out files
+</li><li>
+<code>Manifest</code> to generate the manifest output once the job is fully complete with no failed or timed-out files
+</li></ul>
+<p>When a pause is requested, the Jobs list and Job Detail page can show a <code>Pause in progress</code> dialog while ECUBE waits for active copy threads to drain. The Start action remains unavailable during <code>PAUSING</code> and becomes available again once the job reaches <code>PAUSED</code>.</p>
+<p>While a job is actively copying, Job Detail shows a live <code>Duration</code> field that reflects cumulative active runtime only. The displayed value continues updating while the job is <code>RUNNING</code>, does not add paused time while the job is <code>PAUSED</code>, and resumes from the previously stored active runtime after a later restart instead of resetting to zero.</p>
+<p>Verify and Manifest stay disabled until the job reaches a truly complete 100% state. After manifest generation, the detail page shows a success banner with the location of the refreshed <code>manifest.json</code> file on the destination drive.</p>
+<p>For a partial-success <code>COMPLETED</code> job, Job Detail can show <code>Retry Failed Files</code> instead of exposing Verify or Manifest too early. This action is available only to <code>admin</code>, <code>manager</code>, and <code>processor</code>, moves the job back into <code>RUNNING</code>, re-queues only failed or timed-out files, and preserves already successful copies.</p>
+<p>The completion summary uses the normal success styling for clean completions. If the summary still shows any failed or timed-out file counts, the summary switches to a red warning background so operators can distinguish a partial-success completion from a clean completed run at a glance.</p>
+<p>During startup analysis, Job Detail can show <code>Preparing copy...</code> before any totals are known. While this state is visible, the page also explains that ECUBE is still scanning the source files and calculating totals, which can take time for large evidence sets.</p>
+<p>Manual Analyze runs use the same startup-analysis engine before copy begins. Job Detail can show <code>Startup analysis started.</code> while the scan is running, then replace it with <code>Startup analysis completed.</code> when the persisted analysis summary is ready. The summary panel can show the startup-analysis state, discovered files, estimated total bytes, last analyzed time, and a sanitized failure reason when analysis fails.</p>
+<p>While startup analysis is actively running, Job Detail disables conflicting lifecycle actions so operators cannot edit, start, complete, delete, or clear the startup-analysis cache until the analyze run finishes. Delete and <code>Clear startup analysis cache</code> can remain visible for eligible jobs but stay disabled until the startup-analysis state leaves <code>ANALYZING</code>.</p>
+<p>If the Jobs page remains open while a manual analyze run finishes, ECUBE can show a page-level completion message for that job so operators notice the result without reopening Job Detail.</p>
+<p>If a job is restarted after a failed, paused, or partially successful run and its persisted startup-analysis snapshot is still current, ECUBE can reuse that cached scan instead of repeating the full startup analysis. ECUBE clears the reusable snapshot automatically only after a clean completion with no failed or timed-out files. When operators need to discard that snapshot, the <code>Clear startup analysis cache</code> action opens a confirmation dialog and removes only the cached startup-analysis data. It does not remove per-file history, copied-file state, or other audit-relevant job records.</p>
+<p>When a job is paused, completed, or fails, the detail view shows a summary with the job start time, copy thread count, files copied, files failed, files timed out, total copied, elapsed time, copy rate, and any failure reason or related log hint. A <code>COMPLETED</code> job means all files reached a terminal state, not necessarily that every file copied successfully, so the summary can still report failed or timed-out files after a partial-success completion. The elapsed time remains cumulative across earlier run segments, so a paused and later resumed job keeps the same additive runtime history that was shown while it was active. Failed jobs prefer a persisted sanitized job-level failure reason when one is available, so operators can see stable messages such as <code>Unexpected copy failure</code> or <code>Job interrupted by service restart before completion</code> before any derived per-file fallback. Completed jobs with file-level failures instead show the safe per-file failure summaries and counters without exposing raw provider errors or host paths. When <code>COPY_JOB_TIMEOUT</code> is exceeded for an individual file attempt, that timeout is recorded as a per-file error (for example <code>File copy timed out after 3600s</code>) rather than a whole-job timeout reason.</p>
+<p>When ECUBE can safely correlate a failed copy to the selected source or destination for that job, the failure summary may add relative hints such as <code>source: reports/a.txt</code> or <code>destination: reports/a.txt</code>. Raw host or mount paths are not shown in the Job Detail summary.</p>
+<h2 id="10-2-file-list">10.2 File List</h2>
+<p>The Files panel is collapsed by default on Job Detail. Use <code>Show files</code> to expand it and <code>Hide files</code> to collapse it again without losing the current page.</p>
+<p>When expanded, the file table usually shows:</p>
+<ul><li>
+Relative path
+</li><li>
+Status
+</li><li>
+Failure details when a row includes a safe file-level error summary
+</li><li>
+<code>View Hashes</code> actions for users allowed to inspect file hashes
+</li></ul>
+<p>If the job contains more rows than fit on one page, the panel shows a numbered pagination control with 10-page shortcut windows and left/right navigation. The number of rows shown per page is controlled by the admin-only <code>Job Detail Files Per Page</code> runtime setting and is bounded between 20 and 100.</p>
+<h2 id="10-3-hash-viewer">10.3 Hash Viewer</h2>
+<p>Users with sufficient permissions can inspect file hashes, including values such as:</p>
+<ul><li>
+MD5
+</li><li>
+SHA-256
+</li></ul>
+<h2 id="10-4-compare-source-and-destination">10.4 Compare Source and Destination</h2>
+<p>The compare panel now uses clear <code>Source</code> and <code>Destination</code> terminology. After you load hashes for an exported file, choose that file in the compare selector to evaluate the original source version against the copied destination version.</p>
+<p>Comparison output includes:</p>
+<ul><li>
+Overall match
+</li><li>
+Hash match
+</li><li>
+Size match
+</li><li>
+Path match
+</li></ul>
+<p>This is useful when reviewing evidence consistency or confirming repeatability after copy or verification steps. If either side is unavailable, ECUBE shows a sanitized conflict message instead of exposing raw filesystem details.</p>
+<p>Verify and Manifest stay disabled until the job reaches a truly complete 100% state. After manifest generation, the detail page shows a success banner with the location of the refreshed <code>manifest.json</code> file on the destination drive and starts a browser download of the same generated manifest JSON.</p>
+<hr />
+<h1 id="11-audit-logs">11. Audit Logs</h1>
+<blockquote><p><strong>Access Summary</strong></p></blockquote>
+<blockquote><p><strong>Page visibility:</strong> <code>admin</code>, <code>manager</code>, <code>auditor</code></p></blockquote>
+<blockquote><p><strong>Restricted actions:</strong> CSV export is available from the page for authorized users.</p></blockquote>
+<p>The <code>Audit</code> page is available only to authorized roles.</p>
+<p>Use it to:</p>
+<ul><li>
+Refresh recent audit activity
+</li><li>
+Filter by user
+</li><li>
+Filter by action
+</li><li>
+Filter by date/time range
+</li><li>
+Expand structured details for individual records
+</li><li>
+Export the result set as CSV
+</li></ul>
+<p>The audit page is useful for review, compliance, and incident follow-up.</p>
+<p>When exporting CSV:</p>
+<ul><li>
+Review filters before export so the file contains the intended data set
+</li><li>
+Treat exported audit data as sensitive operational evidence
+</li></ul>
+<h2 id="11-1-chain-of-custody-workflow">11.1 Chain of Custody Workflow</h2>
+<p>Use the Chain of Custody panel on the <code>Audit</code> page to generate custody reports, prefill handoff fields, and record final transfer details when physical media leaves active operations.</p>
+<p>Typical workflow:</p>
+<ol><li>
+Open <code>Audit</code>.
+</li><li>
+In the <strong>Chain of Custody</strong> section, filter by drive ID, drive serial, and/or project ID.
+</li><li>
+Click <code>Load CoC</code> to load custody report data.
+</li><li>
+Review the report card for the selected drive (drive ID, serial, project, manifest summary, and custody events).
+</li><li>
+Click <code>Prefill Handoff</code> to populate the handoff form from the selected report.
+</li><li>
+Enter required handoff details (<code>Possessor</code> and <code>Delivery Time</code>) and any optional receipt fields. The delivery time picker uses your browser's local timezone; the application converts it to UTC automatically before storing.
+</li><li>
+Click <code>Confirm Handoff</code>.
+</li><li>
+Review the <strong>Permanent Archive Warning</strong> modal.
+</li><li>
+Choose one of the following:
+<ul><li>
+<code>Cancel</code>: closes the warning modal and does not record a handoff.
+</li><li>
+<code>Yes, archive drive</code>: records the handoff and archives the drive.
+</li></ul>
+</li></ol>
+<p>What happens when handoff is confirmed:</p>
+<ul><li>
+The custody handoff event is written to the immutable audit trail.
+</li><li>
+The selected drive is automatically transitioned to the <code>ARCHIVED</code> state.
+</li><li>
+The drive is removed from active circulation workflows.
+</li><li>
+The drive no longer appears in Chain of Custody search results intended for active media.
+</li><li>
+Operational actions for that drive are blocked as part of archival enforcement.
+</li></ul>
+<p>Operational guidance:</p>
+<ul><li>
+Treat <code>Yes, archive drive</code> as a finalization action.
+</li><li>
+Verify drive ID, project, possessor, and delivery timestamp before confirming.
+</li><li>
+Use <code>Cancel</code> if any custody detail needs correction before archival.
+</li></ul>
+<hr />
+<h1 id="12-users">12. Users</h1>
+<blockquote><p><strong>Access Summary</strong></p></blockquote>
+<blockquote><p><strong>Page visibility:</strong> <code>admin</code></p></blockquote>
+<blockquote><p><strong>Restricted actions:</strong> All user-management actions on this page are administrator-only.</p></blockquote>
+<p>The <code>Users</code> page is role-restricted and is generally intended for administrators.</p>
+<p>Functions available from this page can include:</p>
+<ul><li>
+Refreshing the current user list
+</li><li>
+Creating an operating-system user for ECUBE access
+</li><li>
+Assigning or removing ECUBE roles
+</li><li>
+Resetting a user's password
+</li></ul>
+<h2 id="12-1-reset-a-user-password">12.1 Reset a User Password</h2>
+<p><strong>Allowed roles:</strong> <code>admin</code></p>
+<ol><li>
+Open <code>Users</code>.
+</li><li>
+Locate the target account in the users table.
+</li><li>
+Open the password reset action for that user.
+</li><li>
+Enter a temporary or policy-compliant new password.
+</li><li>
+Confirm the reset action.
+</li><li>
+Verify the UI shows a success confirmation.
+</li><li>
+Communicate the temporary password through your approved secure channel.
+</li><li>
+Require the user to change it at first sign-in if required by your policy.
+</li></ol>
+<p>Notes:</p>
+<ul><li>
+Reset only ECUBE-managed accounts from this workflow.
+</li><li>
+Use strong passwords that meet your organization security requirements.
+</li><li>
+Record administrative password-reset actions according to your SOP.
+</li></ul>
+<p>If your role does not include access to this page, the navigation item will not appear.</p>
+<h2 id="12-2-configuration-page-administrator">12.2 Configuration Page (Administrator)</h2>
+<p><strong>Allowed roles:</strong> <code>admin</code></p>
+<p>Use the <code>Configuration</code> page to update selected runtime settings from the UI without logging into the host terminal.</p>
+<p>In a standard deployment, the Logging section loads with file logging already enabled and the log path prefilled as <code>/var/log/ecube/app.log</code>. Unchecking the file logging toggle clears <code>LOG_FILE</code> and returns ECUBE to console-only logging.</p>
+<p>What this page is for:</p>
+<ul><li>
+Adjusting logging behavior (level, format, and file logging options)
+</li><li>
+Adjusting selected database pool settings exposed by the UI
+</li><li>
+Applying safe configuration changes through role-restricted workflows
+</li></ul>
+<p>Basic workflow:</p>
+<ol><li>
+Open <code>Configuration</code> from the admin navigation area.
+</li><li>
+Review current values in each section.
+</li><li>
+Edit one or more fields.
+</li><li>
+Click <code>Save</code>.
+</li><li>
+Review post-save status: some changes apply immediately, and some changes are marked as pending restart.
+</li></ol>
+<p>Restart-required workflow:</p>
+<ol><li>
+If the page indicates that restart is required, review the listed changed settings.
+</li><li>
+Click <code>Restart Service</code> only when you are ready.
+</li><li>
+Read the confirmation dialog.
+</li><li>
+Confirm restart to submit the service restart request.
+</li><li>
+If you select cancel, no restart is triggered and the service keeps running.
+</li></ol>
+<p>Important operational notes:</p>
+<ul><li>
+Restart actions are never automatic from this page and always require explicit confirmation.
+</li><li>
+Restarting the application service can interrupt active operations. Prefer using a maintenance window or an idle period.
+</li><li>
+If restart submission fails, use the displayed error and contact platform support or perform restart through approved host-level procedures.
+</li><li>
+For field-by-field meaning and defaults, see 04-configuration-reference.md.
+</li></ul>
+<p>If your role does not include access to this page, the navigation item will not appear.</p>
+<hr />
+<h1 id="13-system">13. System</h1>
+<blockquote><p><strong>Access Summary</strong></p></blockquote>
+<blockquote><p><strong>Page visibility:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code></p></blockquote>
+<blockquote><p><strong>Restricted actions:</strong> Most diagnostics on this page are relevant to administrators and support personnel. Log viewing is admin-only.</p></blockquote>
+<p>The <code>System</code> page provides operational and diagnostic information. Depending on deployment and permissions, this may include system health, USB information, block-device data, mount diagnostics, application logs, and job-debug details.</p>
+<p>This page is useful when:</p>
+<ul><li>
+Confirming the backend is healthy
+</li><li>
+Checking whether hardware is visible to ECUBE
+</li><li>
+Reviewing mount or log details during issue investigation
+</li><li>
+Investigating system errors or performance issues via application logs (admin-only)
+</li></ul>
+<p>End users who only perform evidence exports may rarely need this page. Administrators and support personnel are more likely to use it during troubleshooting.</p>
+<p>In the <code>USB Topology</code> tab, ECUBE shows a sorted device table that includes <code>Device</code> and <code>Serial Number</code> columns. Rows with no meaningful USB metadata are hidden so the list stays focused on useful hardware entries.</p>
+<p>For users with <code>admin</code> or <code>manager</code> roles, the System tab bar includes a <code>Reconcile managed mounts</code> action button positioned between <code>Mounts</code> and <code>Logs</code>. This action triggers a manual managed-mount reconciliation pass and opens a dedicated results page.</p>
+<h2 id="13-1-application-logs-tab">13.1 Application Logs Tab</h2>
+<p><strong>Access:</strong> <code>admin</code> role only</p>
+<p>The <strong>Logs</strong> tab allows administrators to inspect the active application log and eligible rotated log files in real time without requiring SSH or command-line access to the ECUBE host. This is useful for diagnosing system issues, checking for errors, and monitoring application behavior.</p>
+<h3 id="viewing-logs">Viewing Logs</h3>
+<ol><li>
+Open the <code>System</code> page.
+</li><li>
+Click the <strong>Logs</strong> tab (visible to admins only).
+</li><li>
+Use the <strong>Source</strong> selector to choose the active application log or an available rotated file such as <code>app.log.1</code>.
+</li><li>
+The selected source loads automatically into the viewer.
+</li><li>
+Log entries are displayed in reverse chronological order (newest first) within the current window.
+</li><li>
+File metadata shows:
+<ul><li>
+<strong>Source:</strong> Log source display path (basename only, for example <code>app.log</code>)
+</li><li>
+<strong>Fetched at:</strong> Viewer-local date/time (converted by the browser from the UTC timestamp returned by the API)
+</li><li>
+<strong>File modified:</strong> Last modification time of the log file
+</li></ul>
+</li></ol>
+<h3 id="searching-logs">Searching Logs</h3>
+<ol><li>
+Enter a search term in the <strong>Search</strong> field.
+</li><li>
+Only log lines containing your search term will be displayed.
+</li><li>
+The search is case-insensitive.
+</li><li>
+Click <strong>Refresh</strong> to rerun the search with fresh log data.
+</li></ol>
+<h3 id="pagination">Pagination</h3>
+<ol><li>
+The current Logs tab UI does not expose <strong>Limit</strong> or <strong>Offset</strong> controls.
+</li><li>
+Scroll within the log viewer to move to older or newer pages of the selected source.
+</li><li>
+When you reach the end of the current buffer, ECUBE fetches the next page for that direction instead of loading the full file into memory.
+</li><li>
+A total-count indicator (for example, &quot;X of Y lines&quot;) is not currently shown in the UI.
+</li></ol>
+<h3 id="automatic-redaction">Automatic Redaction</h3>
+<p>All sensitive values are automatically redacted from displayed log lines:</p>
+<ul><li>
+<strong>Passwords and tokens:</strong> Any field containing password, secret, api_key, or token values are masked (e.g., <code>password=[REDACTED]</code>)
+</li><li>
+<strong>Authorization headers:</strong> Bearer tokens in Authorization headers are sanitized
+</li><li>
+<strong>Credential-like values:</strong> Other sensitive patterns (e.g., sensitive JSON fields) are masked
+</li></ul>
+<p>This redaction occurs automatically; you cannot bypass it via search or filter options.</p>
+<h3 id="refreshing-log-data">Refreshing Log Data</h3>
+<ol><li>
+Click the <strong>Refresh</strong> button to retrieve the latest log entries.
+</li><li>
+The displayed lines update immediately for the currently selected source and reset the viewer to the newest page for that selection.
+</li><li>
+The <strong>Download</strong> button exports the currently selected log source.
+</li><li>
+If the selected log file is unavailable, unreadable, or no longer present, an appropriate error message appears.
+</li></ol>
+<h3 id="troubleshooting-log-viewing">Troubleshooting Log Viewing</h3>
+<p>If the Logs tab shows an error or is unavailable:</p>
+<ul><li>
+Verify you have the <code>admin</code> role (non-admin users will not see this tab).
+</li><li>
+Check that the selected log file still exists on the ECUBE host.
+</li><li>
+Verify the ECUBE service account has read permissions on the selected log file.
+</li><li>
+If you selected a rotated file, confirm the file has not been removed or replaced during log rotation.
+</li><li>
+Consult <a href="#15-troubleshooting">15. Troubleshooting</a> for service-level issues.
+</li></ul>
+<p>Governance note: denied log access attempts by non-admin users are recorded in the audit trail for accountability and compliance visibility.</p>
+<h2 id="13-2-manual-mount-reconciliation">13.2 Manual Mount Reconciliation</h2>
+<p><strong>Access:</strong> <code>admin</code>, <code>manager</code> roles</p>
+<p>Use this action when mounted-share state appears stale or inconsistent and you need to reconcile managed network and USB mount state without restarting the service.</p>
+<h3 id="run-reconciliation-from-the-system-page">Run Reconciliation from the System Page</h3>
+<ol><li>
+Open the <code>System</code> page.
+</li><li>
+In the tab bar, locate <code>Reconcile managed mounts</code> next to <code>Mounts</code>:
+<ul><li>
+<code>admin</code>: between <code>Mounts</code> and <code>Logs</code>
+</li><li>
+<code>manager</code>: between <code>Mounts</code> and <code>Job Debug</code> (the <code>Logs</code> tab is admin-only)
+</li></ul>
+</li><li>
+Click <code>Reconcile managed mounts</code>.
+</li><li>
+While the request is running, the button label changes to <code>Loading</code>.
+</li><li>
+On success, ECUBE navigates to the <code>Reconciliation Results</code> page.
+</li></ol>
+<h3 id="interpret-reconciliation-results">Interpret Reconciliation Results</h3>
+<p>The results page shows:</p>
+<ul><li>
+A summary panel with <code>Status</code>, checked/corrected counts for network mounts and USB mounts, and <code>Corrective operations failed</code>.
+</li><li>
+A <code>Current USB Drives</code> table with drive fields similar to the Drives page.
+</li><li>
+A <code>Current Shared Mounts</code> table with mount fields similar to the Mounts page.
+</li></ul>
+<p>These tables are post-run snapshots of current drive and mount state to help operators investigate reconciliation outcomes; they are not limited to only rows that were corrected during the run.</p>
+<p>Status meanings:</p>
+<ul><li>
+<code>completed</code> means no corrective-operation failures were recorded.
+</li><li>
+<code>completed with warnings</code> means one or more corrective operations failed (<code>failure_count &gt; 0</code>).
+</li></ul>
+<h3 id="result-page-states">Result Page States</h3>
+<ul><li>
+If no result context is available (for example direct navigation or browser refresh), ECUBE shows <code>Reconciliation results are not available. Please run reconciliation from the System page.</code>
+</li><li>
+If reconciliation returns no mount or drive rows, ECUBE shows <code>No reconciliation data available. Run reconciliation to see results.</code>
+</li></ul>
+<p>Use the <code>Back</code> button on the results page to return to the System page.</p>
+<hr />
+<h1 id="14-common-tasks">14. Common Tasks</h1>
+<h2 id="14-1-insert-a-new-drive-and-associate-it-with-a-project">14.1 Insert a New Drive and Associate It with a Project</h2>
+<p><strong>Allowed roles:</strong> <code>admin</code>, <code>manager</code></p>
+<ol><li>
+Insert the new USB drive into the ECUBE host.
+</li><li>
+Open <code>Mounts</code> and confirm the correct source share for the project has been added, assigned to the project ID, and is currently <code>MOUNTED</code>.
+</li><li>
+Open <code>Drives</code>.
+</li><li>
+Refresh or rescan the drive list until the new device appears.
+</li><li>
+Open the drive detail page.
+</li><li>
+If the drive is not yet formatted (state is <code>DISCONNECTED</code> or filesystem shows <code>unformatted</code>), format it using the intended filesystem.
+</li><li>
+If the drive is not yet mounted to the ECUBE-managed mount root, click <code>Mount</code> and wait for the mount path to appear.
+</li><li>
+Click <code>Initialize</code>, choose the project from the dropdown list, and submit.
+</li><li>
+Confirm the drive now shows <code>IN_USE</code> and the expected project association.
+</li></ol>
+<p>Notes:</p>
+<ul><li>
+<code>processor</code> and <code>auditor</code> users can view drives but cannot perform format, mount, or initialize actions in the current UI.
+</li><li>
+Only projects backed by an actively mounted share appear in the Initialize dropdown.
+</li><li>
+The destination drive itself must also already be mounted; otherwise ECUBE returns a conflict and records the rejection in the audit log.
+</li><li>
+Confirm the project carefully before initialization because project isolation is enforced after association.
+</li></ul>
+<h2 id="14-1a-re-insert-a-drive-to-add-more-data-to-the-same-project">14.1a Re-insert a Drive to Add More Data to the Same Project</h2>
+<p><strong>Allowed roles:</strong> <code>admin</code>, <code>manager</code></p>
+<p>If a drive was previously ejected and needs to receive more data for the same project:</p>
+<ol><li>
+Re-insert the drive into the ECUBE host.
+</li><li>
+Confirm the project's source share is still configured and currently <code>MOUNTED</code>.
+</li><li>
+Open <code>Drives</code> and locate the drive (state will be <code>AVAILABLE</code>).
+</li><li>
+Open the drive detail page.
+</li><li>
+If the drive is not mounted, click <code>Mount</code> and wait for the mount path to appear.
+</li><li>
+Click <code>Initialize</code>. The previous project is selected automatically only if that project still has an eligible mounted share.
+</li><li>
+Confirm and submit.
+</li><li>
+The drive transitions back to <code>IN_USE</code> for the same project.
+</li></ol>
+<p>No format is required when re-using the same project, but both the mounted-share and mounted-drive prerequisites still apply.</p>
+<h2 id="14-1b-re-assign-a-drive-to-a-different-project">14.1b Re-assign a Drive to a Different Project</h2>
+<p><strong>Allowed roles:</strong> <code>admin</code>, <code>manager</code></p>
+<p>If a drive must be reassigned to a different project, a format is required to wipe existing data and clear the project binding:</p>
+<ol><li>
+Open <code>Mounts</code> and make sure the destination project's source share has already been added, assigned the correct project ID, and mounted successfully.
+</li><li>
+Open <code>Drives</code> and locate the drive (state must be <code>AVAILABLE</code>).
+</li><li>
+Open the drive detail page.
+</li><li>
+Click <code>Format</code> and select the target filesystem. Confirm the format.
+</li><li>
+If the drive is not yet mounted after formatting, click <code>Mount</code> and wait for the mount path to appear.
+</li><li>
+Click <code>Initialize</code>.
+</li><li>
+Choose the new project from the dropdown and confirm.
+</li><li>
+The drive transitions to <code>IN_USE</code> for the new project.
+</li></ol>
+<blockquote><p><strong>Warning:</strong> Formatting permanently deletes all data on the drive. Verify that copies and chain-of-custody records for prior project data are complete before proceeding.</p></blockquote>
+<h2 id="14-2-prepare-a-drive-for-removal-and-shipment">14.2 Prepare a Drive for Removal and Shipment</h2>
+<p><strong>Allowed roles:</strong> <code>admin</code>, <code>manager</code></p>
+<ol><li>
+Confirm the export job is complete and any required verification or manifest generation has finished.
+</li><li>
+Open <code>Drives</code> and select the target drive.
+</li><li>
+Review the drive details to confirm you have the correct media.
+</li><li>
+Click <code>Prepare Eject</code>.
+</li><li>
+Wait for the UI to indicate success.
+</li><li>
+Physically remove the drive only after the operation completes.
+</li></ol>
+<p>Notes:</p>
+<ul><li>
+Use this workflow before final packaging or shipment.
+</li><li>
+Do not remove the drive while a copy or verification step is still active.
+</li><li>
+After ejection the drive returns to <code>AVAILABLE</code> with its project binding intact. It can be re-initialized for the same project without reformatting.
+</li><li>
+To permanently retire the drive, complete the Chain of Custody handoff on the <code>Audit</code> page after removal.
+</li></ul>
+<h2 id="14-3-export-evidence-to-a-drive">14.3 Export Evidence to a Drive</h2>
+<p><strong>Allowed roles:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code></p>
+<ol><li>
+Confirm the correct drive is present and in the expected state.
+</li><li>
+Confirm the source mount is available.
+</li><li>
+Open <code>Jobs</code>.
+</li><li>
+Click <code>Create Job</code> to open the grouped dialog.
+</li><li>
+Select the project first.
+</li><li>
+Choose the filtered source mount and eligible destination drive, then enter the evidence number and source path.
+</li><li>
+Create the job, or enable <code>Run job immediately</code> if you want it to start as soon as creation succeeds.
+</li><li>
+Open the job detail page.
+</li><li>
+Monitor progress until completion.
+</li><li>
+Run verification and generate a manifest if required by your workflow.
+</li></ol>
+<h2 id="14-4-review-copy-results">14.4 Review Copy Results</h2>
+<p><strong>Allowed roles:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code></p>
+<ol><li>
+Open the job detail page.
+</li><li>
+Review the file list and status values.
+</li><li>
+Inspect hashes for specific files if your role allows it.
+</li><li>
+Compare files when you need side-by-side validation.
+</li><li>
+Export or retain the manifest as required by policy.
+</li></ol>
+<p>Notes:</p>
+<ul><li>
+Hash inspection is currently available to <code>admin</code> and <code>auditor</code> in the UI.
+</li><li>
+Operational actions such as <code>Start</code>, <code>Verify</code>, and <code>Manifest</code> are available to <code>admin</code>, <code>manager</code>, and <code>processor</code>.
+</li></ul>
+<h2 id="14-5-review-audit-activity">14.5 Review Audit Activity</h2>
+<p><strong>Allowed roles:</strong> <code>admin</code>, <code>manager</code>, <code>auditor</code></p>
+<ol><li>
+Open <code>Audit</code>.
+</li><li>
+Apply user, action, and date filters.
+</li><li>
+Expand details for relevant records.
+</li><li>
+Export CSV if you need to retain or share the filtered results.
+</li></ol>
+<h2 id="14-6-add-a-new-user">14.6 Add a New User</h2>
+<p><strong>Allowed roles:</strong> <code>admin</code></p>
+<ol><li>
+Open <code>Users</code>.
+</li><li>
+Click <code>Create User</code>.
+</li><li>
+Enter the username.
+</li><li>
+Select the appropriate ECUBE roles.
+</li><li>
+Click <code>Create</code>.
+</li><li>
+If the username already exists on the host (or directory-backed identity source), review the confirmation prompt and choose whether to add that existing account to ECUBE.
+</li><li>
+If this is a brand-new user, complete the password dialog by entering and confirming the password, then submit.
+</li><li>
+Refresh the page and confirm the user appears with the intended role assignments.
+</li></ol>
+<p>Notes:</p>
+<ul><li>
+Choose the smallest role set needed for the user's responsibilities.
+</li><li>
+If your organization uses a separate account-provisioning process, follow that policy before creating ECUBE access.
+</li><li>
+Existing users that are linked into ECUBE are not prompted for a new password in this flow.
+</li><li>
+For directory-backed users that cannot be fully enumerated by host account listing, ECUBE may show placeholder host fields while still exposing role management controls.
+</li></ul>
+<h2 id="14-7-remove-a-user-s-ecube-access">14.7 Remove a User's ECUBE Access</h2>
+<p><strong>Allowed roles:</strong> <code>admin</code></p>
+<ol><li>
+Open <code>Users</code>.
+</li><li>
+Locate the target user.
+</li><li>
+Clear all assigned ECUBE role checkboxes for that user.
+</li><li>
+Save the role changes.
+</li><li>
+Confirm the user no longer has ECUBE roles assigned.
+</li></ol>
+<p>Notes:</p>
+<ul><li>
+In the current web UI, removing all roles is the visible workflow for removing ECUBE access.
+</li><li>
+Full operating-system user deletion is not currently exposed in the web UI and should be handled through administrative procedures outside this manual.
+</li></ul>
+<h2 id="14-8-view-application-logs-for-troubleshooting">14.8 View Application Logs for Troubleshooting</h2>
+<p><strong>Allowed roles:</strong> <code>admin</code></p>
+<ol><li>
+Open the <code>System</code> page.
+</li><li>
+Click the <strong>Logs</strong> tab (available to admins only).
+</li><li>
+Choose the active log or a rotated file from the <strong>Source</strong> selector.
+</li><li>
+Optionally, enter a search term to filter the displayed lines.
+</li><li>
+Click <strong>Refresh</strong> to reload the newest page for the selected source.
+</li><li>
+Scroll within the viewer to move to older or newer log pages for that source.
+</li><li>
+Review the redacted log entries for errors, warnings, or relevant diagnostic messages.
+</li><li>
+If you need to investigate further, take note of timestamps or error messages to share with support, or click <strong>Download</strong> to export the currently selected log file.
+</li></ol>
+<p>Notes:</p>
+<ul><li>
+Sensitive values (passwords, tokens, API keys) are automatically redacted from displayed logs for security.
+</li><li>
+The log viewer pages through the selected source as you scroll and does not load the entire file into memory.
+</li><li>
+Download always follows the currently selected source.
+</li><li>
+This feature is admin-only to prevent information leakage from diagnostic data.
+</li></ul>
+<hr />
+<h1 id="15-troubleshooting">15. Troubleshooting</h1>
+<h2 id="15-1-i-cannot-log-in">15.1 I Cannot Log In</h2>
+<p>Possible causes:</p>
+<ul><li>
+Incorrect username or password
+</li><li>
+Wrong ECUBE URL
+</li><li>
+Browser cannot reach the site
+</li><li>
+Your account has not been created or assigned the right role
+</li></ul>
+<h2 id="15-2-a-page-or-menu-item-is-missing">15.2 A Page or Menu Item Is Missing</h2>
+<p>Possible causes:</p>
+<ul><li>
+Your role does not include access to that feature
+</li><li>
+The system is not fully initialized
+</li><li>
+The deployment is using an older or partially upgraded frontend/backend combination
+</li></ul>
+<h2 id="15-3-a-button-is-visible-but-disabled">15.3 A Button Is Visible but Disabled</h2>
+<p>Possible causes:</p>
+<ul><li>
+Your role is read-only for that operation
+</li><li>
+The selected object is not in a state that permits the action
+</li><li>
+Required data has not been entered yet
+</li></ul>
+<h2 id="15-4-the-ui-shows-a-network-error">15.4 The UI Shows a Network Error</h2>
+<p>Possible causes:</p>
+<ul><li>
+Backend service unavailable
+</li><li>
+Reverse proxy or TLS issue
+</li><li>
+Browser blocked cross-origin requests in a nonstandard deployment
+</li><li>
+Expired session or lost authentication state
+</li></ul>
+<p>If the problem persists, collect:</p>
+<ul><li>
+The exact page where the error occurred
+</li><li>
+The action you attempted
+</li><li>
+The visible error text
+</li><li>
+The approximate date and time
+</li></ul>
+<p>Then provide that information to your ECUBE administrator.</p>
+<h2 id="15-5-usb-drive-is-not-recognized">15.5 USB Drive Is Not Recognized</h2>
+<p><strong>Who can do what:</strong></p>
+<ul><li>
+End users (<code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code>) can perform UI-level checks.
+</li><li>
+Administrators (<code>admin</code>) can perform host-level diagnostics and recovery.
+</li></ul>
+<p>If a newly inserted USB drive does not appear in ECUBE, use this sequence.</p>
+<p>User-level checks:</p>
+<ol><li>
+Re-seat the drive and wait 10-20 seconds.
+</li><li>
+Open <code>Drives</code>, then click <code>Refresh</code> and <code>Rescan</code>.
+</li><li>
+Confirm the drive is connected to the expected copy station and not another host.
+</li><li>
+If available in your role, open <code>System</code> and review USB/device information for recent detection changes.
+</li><li>
+If the drive still does not appear, notify an administrator and include:
+<p>Approximate insert time, drive label/vendor/capacity (if known), and USB port or hub location used.</p>
+</li></ol>
+<p>Administrator checks:</p>
+<ol><li>
+Verify physical connectivity first:
+<p>Test a known-good port on the same hub and confirm hub power and cable integrity.</p>
+</li><li>
+Verify host-level USB detection:
+<p><code>lsusb</code> and <code>lsblk</code>.</p>
+</li><li>
+Check ECUBE service health and recent logs:
+<p><code>systemctl status ecube</code> and <code>journalctl -u ecube -n 200</code>.</p>
+</li><li>
+In Docker deployments, verify container USB passthrough configuration matches the deployment design.
+</li><li>
+If the device appears at OS level but not in ECUBE, capture logs and escalate with timestamps and device identifiers.
+</li></ol>
+<p>Common causes:</p>
+<ul><li>
+Faulty cable, port, or unpowered USB hub
+</li><li>
+Unsupported or failing media
+</li><li>
+Host permission/device passthrough issues (especially in containerized setups)
+</li><li>
+ECUBE service not running or unable to complete hardware discovery
+</li></ul>
+<hr />
+<h1 id="references">References</h1>
+<ul><li>
+docs/operations/00-operational-guide.md
+</li></ul>
+    </main>
+  </body>
+</html>

--- a/frontend/public/help/manual.html
+++ b/frontend/public/help/manual.html
@@ -4,54 +4,87 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>ECUBE Help</title>
+    <link id="ecube-theme-stylesheet" rel="stylesheet" href="../themes/default.css" />
+    <script>
+      (() => {
+        const themeStorageKey = 'ecube_theme'
+        const validThemeName = /^[a-z0-9][a-z0-9-]*$/
+        let themeName = 'default'
+
+        try {
+          const storedTheme = localStorage.getItem(themeStorageKey)
+          if (storedTheme && validThemeName.test(storedTheme)) {
+            themeName = storedTheme
+          }
+        } catch {
+          // Ignore storage access failures and keep the default theme.
+        }
+
+        const themeLink = document.getElementById('ecube-theme-stylesheet')
+        if (themeLink) {
+          themeLink.href = '../themes/' + themeName + '.css'
+        }
+      })()
+    </script>
     <style>
       :root {
-        color-scheme: light;
-        --help-bg: #f4efe7;
-        --help-panel: #fffdf8;
-        --help-border: #d8cbb7;
-        --help-text: #2f261b;
-        --help-muted: #6b5f51;
-        --help-accent: #0f5c4d;
-        --help-accent-soft: #e2f0ec;
-        --help-code-bg: #f1e7d8;
-        --help-shadow: 0 18px 48px rgba(47, 38, 27, 0.12);
-        --help-radius: 18px;
-        --help-font: Georgia, 'Times New Roman', serif;
-        --help-ui-font: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        color-scheme: light dark;
+        --help-bg: var(--color-bg-secondary, #f8f9fa);
+        --help-panel: var(--color-bg-primary, #ffffff);
+        --help-border: var(--color-border, #e2e8f0);
+        --help-text: var(--color-text-primary, #1e293b);
+        --help-muted: var(--color-text-secondary, #64748b);
+        --help-accent: var(--color-text-link, #2563eb);
+        --help-accent-soft: var(--color-bg-selected, #dbeafe);
+        --help-code-bg: var(--color-bg-hover, #e2e8f0);
+        --help-shadow: var(--shadow-lg, 0 10px 15px rgba(0, 0, 0, 0.1));
+        --help-radius: var(--border-radius-lg, 8px);
+        --help-font: var(--font-family, 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+        --help-ui-font: var(--font-family, 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
       }
 
       * { box-sizing: border-box; }
 
+      html {
+        overflow-y: scroll;
+        scrollbar-gutter: stable;
+        scrollbar-width: auto;
+        scrollbar-color: var(--color-border) var(--color-bg-secondary);
+      }
+
       body {
         margin: 0;
-        padding: 24px;
-        background:
-          radial-gradient(circle at top left, rgba(15, 92, 77, 0.08), transparent 30%),
-          linear-gradient(180deg, #f8f3ec 0%, var(--help-bg) 100%);
+        padding: 0;
+        background: var(--help-panel);
         color: var(--help-text);
         font-family: var(--help-font);
         line-height: 1.6;
+      }
+
+      html::-webkit-scrollbar {
+        width: 12px;
+        height: 12px;
+      }
+
+      html::-webkit-scrollbar-track {
+        background: var(--color-bg-secondary);
+        border-left: 1px solid var(--color-border);
+      }
+
+      html::-webkit-scrollbar-thumb {
+        background: var(--color-border);
+        border-radius: 999px;
+        border: 2px solid var(--color-bg-secondary);
+      }
+
+      html::-webkit-scrollbar-thumb:hover {
+        background: var(--color-text-secondary);
       }
 
       main {
         max-width: 920px;
         margin: 0 auto;
         padding: 32px;
-        background: var(--help-panel);
-        border: 1px solid var(--help-border);
-        border-radius: var(--help-radius);
-        box-shadow: var(--help-shadow);
-      }
-
-      .help-kicker {
-        margin: 0;
-        font-family: var(--help-ui-font);
-        font-size: 0.8rem;
-        font-weight: 700;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        color: var(--help-accent);
       }
 
       h1 {
@@ -60,40 +93,19 @@
         line-height: 1.1;
       }
 
-      .help-meta,
-      .help-lead {
-        margin: 0.25rem 0 0;
-        font-family: var(--help-ui-font);
-        color: var(--help-muted);
-      }
-
       .help-toc {
         margin: 1.5rem 0 2rem;
-        padding: 1rem 1.25rem;
-        background: #f7f1e6;
-        border: 1px solid var(--help-border);
-        border-radius: 14px;
+        padding: 0;
       }
 
-      .help-toc-header {
-        margin-bottom: 0.75rem;
-      }
-
-      .help-toc-header h2,
-      .help-toc-header p {
-        margin: 0;
-      }
-
-      .help-toc-header p {
-        margin-top: 0.25rem;
-        font-family: var(--help-ui-font);
-        color: var(--help-muted);
+      .help-toc h2 {
+        margin: 0 0 0.75rem;
+        font-size: clamp(2rem, 3vw, 3rem);
+        line-height: 1.1;
       }
 
       .help-toc ol {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 0.35rem 1.5rem;
+        display: block;
         margin: 0;
         padding: 0;
         list-style: none;
@@ -101,6 +113,7 @@
 
       .help-toc li {
         font-family: var(--help-ui-font);
+        margin: 0.25rem 0;
       }
 
       .help-toc .toc-level-3,
@@ -109,7 +122,6 @@
       }
 
       .help-toc a {
-        display: inline-block;
         text-decoration: none;
       }
 
@@ -118,11 +130,27 @@
         text-decoration: underline;
       }
 
+      .help-back-to-top {
+        margin: 1.5rem 0 0.75rem;
+        font-family: var(--help-ui-font);
+        font-size: 0.95rem;
+        text-align: right;
+      }
+
+      .help-back-to-top a {
+        text-decoration: none;
+      }
+
+      .help-back-to-top a:hover,
+      .help-back-to-top a:focus-visible {
+        text-decoration: underline;
+      }
+
       h1,
       h2,
       h3,
       h4 {
-        color: #1e1a14;
+        color: var(--help-text);
       }
 
       h2,
@@ -165,8 +193,8 @@
       pre {
         overflow-x: auto;
         padding: 1rem;
-        background: #2f261b;
-        color: #fff8ee;
+        background: var(--color-bg-sidebar, #1e293b);
+        color: var(--help-text);
         border-radius: 14px;
       }
 
@@ -186,7 +214,7 @@
       }
 
       th {
-        background: #f1e7d8;
+        background: var(--help-bg);
       }
 
       ul,
@@ -195,10 +223,6 @@
       }
 
       @media (max-width: 720px) {
-        body {
-          padding: 12px;
-        }
-
         main {
           padding: 20px;
         }
@@ -207,143 +231,24 @@
   </head>
   <body>
     <main>
-      <p class="help-kicker">In-App Help</p>
-      <h1>ECUBE User Guide</h1>
-      <p class="help-meta">Updated: 04/25/26</p>
-      <p class="help-lead">Task-focused guidance for signed-in ECUBE users.</p>
       <nav class="help-toc" aria-labelledby="help-toc-title">
-        <div class="help-toc-header">
-          <h2 id="help-toc-title">Quick Index</h2>
-          <p>Jump directly to a task or section.</p>
-        </div>
+      <h2 id="help-toc-title">Table of Contents</h2>
         <ol>
-<li class="toc-level-1"><a href="#purpose">Purpose</a></li>
-<li class="toc-level-1"><a href="#scope">Scope</a></li>
-<li class="toc-level-1"><a href="#2-before-you-begin">2. Before You Begin</a></li>
-<li class="toc-level-1"><a href="#3-roles-and-access">3. Roles and Access</a></li>
-<li class="toc-level-1"><a href="#4-first-access">4. First Access</a></li>
-<li class="toc-level-2"><a href="#4-2-login">4.2 Login</a></li>
-<li class="toc-level-1"><a href="#5-interface-overview">5. Interface Overview</a></li>
-<li class="toc-level-2"><a href="#5-1-theme-selection-light-dark-custom">5.1 Theme Selection (Light/Dark/Custom)</a></li>
-<li class="toc-level-1"><a href="#6-dashboard">6. Dashboard</a></li>
-<li class="toc-level-1"><a href="#7-drives">7. Drives</a></li>
-<li class="toc-level-2"><a href="#7-1-drive-states">7.1 Drive States</a></li>
-<li class="toc-level-2"><a href="#7-2-viewing-drives">7.2 Viewing Drives</a></li>
-<li class="toc-level-2"><a href="#7-3-drive-detail-page">7.3 Drive Detail Page</a></li>
-<li class="toc-level-2"><a href="#7-4-formatting-a-drive">7.4 Formatting a Drive</a></li>
-<li class="toc-level-2"><a href="#7-5-initializing-a-drive">7.5 Initializing a Drive</a></li>
-<li class="toc-level-2"><a href="#7-6-prepare-eject">7.6 Prepare Eject</a></li>
-<li class="toc-level-1"><a href="#8-mounts">8. Mounts</a></li>
-<li class="toc-level-2"><a href="#8-1-adding-a-mount">8.1 Adding a Mount</a></li>
-<li class="toc-level-2"><a href="#8-1-1-editing-a-mount">8.1.1 Editing a Mount</a></li>
-<li class="toc-level-2"><a href="#8-2-testing-mount-connectivity">8.2 Testing Mount Connectivity</a></li>
-<li class="toc-level-2"><a href="#8-3-removing-a-mount">8.3 Removing a Mount</a></li>
-<li class="toc-level-1"><a href="#8-4-directory-browser">8.4 Directory Browser</a></li>
-<li class="toc-level-1"><a href="#9-jobs">9. Jobs</a></li>
-<li class="toc-level-2"><a href="#9-1-viewing-jobs">9.1 Viewing Jobs</a></li>
-<li class="toc-level-2"><a href="#9-2-creating-a-job">9.2 Creating a Job</a></li>
-<li class="toc-level-2"><a href="#9-3-opening-a-job">9.3 Opening a Job</a></li>
-<li class="toc-level-1"><a href="#10-job-detail-verification-and-file-review">10. Job Detail, Verification, and File Review</a></li>
-<li class="toc-level-2"><a href="#10-1-editing-starting-retrying-failed-files-pausing-completing-verifying-and-generating-a-manifest">10.1 Editing, Starting, Retrying Failed Files, Pausing, Completing, Verifying, and Generating a Manifest</a></li>
-<li class="toc-level-2"><a href="#10-2-file-list">10.2 File List</a></li>
-<li class="toc-level-2"><a href="#10-3-hash-viewer">10.3 Hash Viewer</a></li>
-<li class="toc-level-2"><a href="#10-4-compare-source-and-destination">10.4 Compare Source and Destination</a></li>
-<li class="toc-level-1"><a href="#11-audit-logs">11. Audit Logs</a></li>
-<li class="toc-level-2"><a href="#11-1-chain-of-custody-workflow">11.1 Chain of Custody Workflow</a></li>
-<li class="toc-level-1"><a href="#12-users">12. Users</a></li>
-<li class="toc-level-2"><a href="#12-1-reset-a-user-password">12.1 Reset a User Password</a></li>
-<li class="toc-level-2"><a href="#12-2-configuration-page-administrator">12.2 Configuration Page (Administrator)</a></li>
-<li class="toc-level-1"><a href="#13-system">13. System</a></li>
-<li class="toc-level-2"><a href="#13-1-application-logs-tab">13.1 Application Logs Tab</a></li>
-<li class="toc-level-3"><a href="#viewing-logs">Viewing Logs</a></li>
-<li class="toc-level-3"><a href="#searching-logs">Searching Logs</a></li>
-<li class="toc-level-3"><a href="#pagination">Pagination</a></li>
-<li class="toc-level-3"><a href="#automatic-redaction">Automatic Redaction</a></li>
-<li class="toc-level-3"><a href="#refreshing-log-data">Refreshing Log Data</a></li>
-<li class="toc-level-3"><a href="#troubleshooting-log-viewing">Troubleshooting Log Viewing</a></li>
-<li class="toc-level-2"><a href="#13-2-manual-mount-reconciliation">13.2 Manual Mount Reconciliation</a></li>
-<li class="toc-level-3"><a href="#run-reconciliation-from-the-system-page">Run Reconciliation from the System Page</a></li>
-<li class="toc-level-3"><a href="#interpret-reconciliation-results">Interpret Reconciliation Results</a></li>
-<li class="toc-level-3"><a href="#result-page-states">Result Page States</a></li>
-<li class="toc-level-1"><a href="#14-common-tasks">14. Common Tasks</a></li>
-<li class="toc-level-2"><a href="#14-1-insert-a-new-drive-and-associate-it-with-a-project">14.1 Insert a New Drive and Associate It with a Project</a></li>
-<li class="toc-level-2"><a href="#14-1a-re-insert-a-drive-to-add-more-data-to-the-same-project">14.1a Re-insert a Drive to Add More Data to the Same Project</a></li>
-<li class="toc-level-2"><a href="#14-1b-re-assign-a-drive-to-a-different-project">14.1b Re-assign a Drive to a Different Project</a></li>
-<li class="toc-level-2"><a href="#14-2-prepare-a-drive-for-removal-and-shipment">14.2 Prepare a Drive for Removal and Shipment</a></li>
-<li class="toc-level-2"><a href="#14-3-export-evidence-to-a-drive">14.3 Export Evidence to a Drive</a></li>
-<li class="toc-level-2"><a href="#14-4-review-copy-results">14.4 Review Copy Results</a></li>
-<li class="toc-level-2"><a href="#14-5-review-audit-activity">14.5 Review Audit Activity</a></li>
-<li class="toc-level-2"><a href="#14-6-add-a-new-user">14.6 Add a New User</a></li>
-<li class="toc-level-2"><a href="#14-7-remove-a-user-s-ecube-access">14.7 Remove a User's ECUBE Access</a></li>
-<li class="toc-level-2"><a href="#14-8-view-application-logs-for-troubleshooting">14.8 View Application Logs for Troubleshooting</a></li>
-<li class="toc-level-1"><a href="#15-troubleshooting">15. Troubleshooting</a></li>
-<li class="toc-level-2"><a href="#15-1-i-cannot-log-in">15.1 I Cannot Log In</a></li>
-<li class="toc-level-2"><a href="#15-2-a-page-or-menu-item-is-missing">15.2 A Page or Menu Item Is Missing</a></li>
-<li class="toc-level-2"><a href="#15-3-a-button-is-visible-but-disabled">15.3 A Button Is Visible but Disabled</a></li>
-<li class="toc-level-2"><a href="#15-4-the-ui-shows-a-network-error">15.4 The UI Shows a Network Error</a></li>
-<li class="toc-level-2"><a href="#15-5-usb-drive-is-not-recognized">15.5 USB Drive Is Not Recognized</a></li>
+<li class="toc-level-1"><a href="#1-roles-and-access">1. Roles and Access</a></li>
+<li class="toc-level-1"><a href="#2-interface-overview">2. Interface Overview</a></li>
+<li class="toc-level-1"><a href="#3-dashboard">3. Dashboard</a></li>
+<li class="toc-level-1"><a href="#4-drives">4. Drives</a></li>
+<li class="toc-level-1"><a href="#5-mounts">5. Mounts</a></li>
+<li class="toc-level-1"><a href="#6-jobs">6. Jobs</a></li>
+<li class="toc-level-1"><a href="#7-job-detail-verification-and-file-review">7. Job Detail, Verification, and File Review</a></li>
+<li class="toc-level-1"><a href="#8-audit-logs">8. Audit Logs</a></li>
+<li class="toc-level-1"><a href="#9-users">9. Users</a></li>
+<li class="toc-level-1"><a href="#10-system">10. System</a></li>
+<li class="toc-level-1"><a href="#11-common-tasks">11. Common Tasks</a></li>
+<li class="toc-level-1"><a href="#12-troubleshooting">12. Troubleshooting</a></li>
         </ol>
       </nav>
-      <h1 id="purpose">Purpose</h1>
-<p>This manual explains how to use the ECUBE web interface for day-to-day work. It focuses on tasks performed in the browser after the platform has already been deployed and made available by an administrator.</p>
-<p>Primary workflows covered in this guide:</p>
-<ul><li>
-Accessing the ECUBE web interface
-</li><li>
-Understanding role-based navigation
-</li><li>
-Viewing system status and drive state
-</li><li>
-Creating and monitoring export jobs
-</li><li>
-Reviewing job results, hashes, and file comparisons
-</li><li>
-Managing mount definitions
-</li><li>
-Viewing and exporting audit logs
-</li><li>
-Accessing user and system pages when your role permits it
-</li><li>
-Managing selected runtime configuration settings (admin-only)
-</li></ul>
-<h1 id="scope">Scope</h1>
-<p>This guide is intended for users who interact with ECUBE through the web UI. It does not cover operating-system setup, service management, certificate provisioning, Docker administration, or backend troubleshooting.</p>
-<p>For those topics, use the companion guides:</p>
-<ul><li>
-Installation for packaged installation options
-</li><li>
-Manual installation for native/manual deployment
-</li><li>
-Docker deployment for Docker Compose deployment
-</li><li>
-Administration automation guide for administrative and API-driven tasks
-</li><li>
-API quick reference for direct API usage
-</li></ul>
-<hr />
-<h1 id="2-before-you-begin">2. Before You Begin</h1>
-<p>Before using ECUBE, make sure you have:</p>
-<ul><li>
-A supported browser
-</li><li>
-The correct ECUBE URL
-</li><li>
-A valid user account and password or SSO-backed identity
-</li><li>
-Permission for the tasks you need to perform
-</li></ul>
-<p>Supported browser targets for the current frontend:</p>
-<ul><li>
-Google Chrome
-</li><li>
-Microsoft Edge
-</li><li>
-Safari
-</li></ul>
-<p>Use one of the latest two major browser versions maintained by your organization. Firefox is not currently a supported target for the frontend.</p>
-<p>If you do not know your role, ask your ECUBE administrator. ECUBE uses role-based access control, so some pages and buttons are visible only to certain users.</p>
-<hr />
-<h1 id="3-roles-and-access">3. Roles and Access</h1>
+      <h1 id="1-roles-and-access">1. Roles and Access</h1>
 <p>The UI adapts to the roles assigned to your account.</p>
 <table><thead><tr>
 <th>Role</th>
@@ -378,37 +283,9 @@ The <code>Configuration</code> page is visible only to <code>admin</code> users.
 </li><li>
 Action buttons such as formatting or initializing drives may be disabled if your role does not permit them.
 </li></ul>
+<p class="help-back-to-top"><a href="#help-toc-title">Back to top</a></p>
 <hr />
-<h1 id="4-first-access">4. First Access</h1>
-<h2 id="4-2-login">4.2 Login</h2>
-<blockquote><p><strong>Access Summary</strong></p></blockquote>
-<blockquote><p><strong>Page visibility:</strong> Available to unauthenticated users after setup is complete.</p></blockquote>
-<blockquote><p><strong>Restricted actions:</strong> None.</p></blockquote>
-<p>After setup is complete, open the ECUBE URL and sign in with your assigned username and password.</p>
-<p>The login page includes:</p>
-<ul><li>
-Username field
-</li><li>
-Password field
-</li><li>
-Login button
-</li><li>
-Session-expired banner when you were redirected after token expiry
-</li><li>
-Error banner for invalid credentials or connectivity failures
-</li></ul>
-<p>If login fails:</p>
-<ul><li>
-Re-enter username and password carefully
-</li><li>
-Confirm you are using the correct ECUBE URL
-</li><li>
-Check whether your browser can reach the site over HTTPS
-</li><li>
-Contact an administrator if your account may be locked, missing, or incorrectly assigned
-</li></ul>
-<hr />
-<h1 id="5-interface-overview">5. Interface Overview</h1>
+<h1 id="2-interface-overview">2. Interface Overview</h1>
 <blockquote><p><strong>Access Summary</strong></p></blockquote>
 <blockquote><p><strong>Page visibility:</strong> Available to authenticated users.</p></blockquote>
 <blockquote><p><strong>Restricted actions:</strong> Navigation items shown in the shell depend on the roles assigned to your account.</p></blockquote>
@@ -441,7 +318,7 @@ Footer at the bottom
 <code>Configuration</code> (admin-only)
 </li></ul>
 <p>If you do not see a page described in this manual, your role may not include access to it.</p>
-<h2 id="5-1-theme-selection-light-dark-custom">5.1 Theme Selection (Light/Dark/Custom)</h2>
+<h2 id="2-1-theme-selection-light-dark-custom">2.1 Theme Selection (Light/Dark/Custom)</h2>
 <blockquote><p><strong>Access Summary</strong></p></blockquote>
 <blockquote><p><strong>Page visibility:</strong> Available to authenticated users.</p></blockquote>
 <blockquote><p><strong>Restricted actions:</strong> None. Theme selection is user-level and does not require an elevated role.</p></blockquote>
@@ -467,8 +344,9 @@ Platform administrators can still influence the deployment default by controllin
 </li></ul>
 <p>For deployment-side theme and branding management, see Theme and branding guide and Configuration reference (<code>ECUBE_THEMES_DIR</code>).</p>
 <p>Example dark-theme appearance:</p>
+<p class="help-back-to-top"><a href="#help-toc-title">Back to top</a></p>
 <hr />
-<h1 id="6-dashboard">6. Dashboard</h1>
+<h1 id="3-dashboard">3. Dashboard</h1>
 <blockquote><p><strong>Access Summary</strong></p></blockquote>
 <blockquote><p><strong>Page visibility:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code></p></blockquote>
 <blockquote><p><strong>Restricted actions:</strong> None described on this screen; use linked pages for operational actions.</p></blockquote>
@@ -494,8 +372,9 @@ Are any jobs currently running or verifying?
 How many drives are ready for use?
 </li></ul>
 <p>The dashboard is intended for situational awareness, not full task execution. Use the dedicated pages for detailed operations.</p>
+<p class="help-back-to-top"><a href="#help-toc-title">Back to top</a></p>
 <hr />
-<h1 id="7-drives">7. Drives</h1>
+<h1 id="4-drives">4. Drives</h1>
 <blockquote><p><strong>Access Summary</strong></p></blockquote>
 <blockquote><p><strong>Page visibility:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code></p></blockquote>
 <blockquote><p><strong>Restricted actions:</strong> Drive detail actions such as format, initialize, and prepare eject are currently enabled only for <code>admin</code> and <code>manager</code>.</p></blockquote>
@@ -515,7 +394,7 @@ Assigned project
 Current state
 </li></ul>
 <p>Available actions depend on your role and the selected drive.</p>
-<h2 id="7-1-drive-states">7.1 Drive States</h2>
+<h2 id="4-1-drive-states">4.1 Drive States</h2>
 <p>Every drive moves through a defined set of states. Actions available in the UI depend on the current state.</p>
 <table><thead><tr>
 <th>State</th>
@@ -551,7 +430,7 @@ Current state
                      (re-insert same project)</code></pre>
 <p>A drive assigned to one project cannot be re-assigned to a different project without first being formatted. Formatting wipes the drive and clears the project binding.</p>
 <p>After a service restart, ECUBE may automatically restore a previously mounted managed USB drive to its expected ECUBE mount slot. If a drive or mount appears to have changed state during startup, review the <code>Audit Logs</code> page for reconciliation events recorded by the system.</p>
-<h2 id="7-2-viewing-drives">7.2 Viewing Drives</h2>
+<h2 id="4-2-viewing-drives">4.2 Viewing Drives</h2>
 <p>Use the page controls to:</p>
 <ul><li>
 Refresh the current drive list
@@ -564,7 +443,7 @@ Filter by drive state
 </li><li>
 Sort results
 </li></ul>
-<h2 id="7-3-drive-detail-page">7.3 Drive Detail Page</h2>
+<h2 id="4-3-drive-detail-page">4.3 Drive Detail Page</h2>
 <p>Selecting a drive opens a detail view showing:</p>
 <ul><li>
 The port-based <code>Device</code> value, the separate <code>Serial Number</code> value, and filesystem details, with sensitive path values shown as <code>Protected</code> in standard operator views when appropriate
@@ -576,7 +455,7 @@ Current status badge
 Available actions such as format, initialize, and prepare eject
 </li></ul>
 <p>Reference screen:</p>
-<h2 id="7-4-formatting-a-drive">7.4 Formatting a Drive</h2>
+<h2 id="4-4-formatting-a-drive">4.4 Formatting a Drive</h2>
 <p>If your role allows it, you can format a drive from the detail page.</p>
 <p>Current UI options include:</p>
 <ul><li>
@@ -587,7 +466,7 @@ Available actions such as format, initialize, and prepare eject
 <p>Formatting removes all existing data and clears the project binding. After formatting, the drive can be initialized for any project that has an eligible mounted share.</p>
 <p>The Format action is unavailable while the drive is mounted. If the drive is currently mounted, use the appropriate unmount or prepare-eject workflow first.</p>
 <p>Confirm the target drive carefully before proceeding.</p>
-<h2 id="7-5-initializing-a-drive">7.5 Initializing a Drive</h2>
+<h2 id="4-5-initializing-a-drive">4.5 Initializing a Drive</h2>
 <p>Initialization assigns a drive to a project identifier and transitions it to <code>IN_USE</code>. Once initialized, project isolation rules apply to all writes performed through ECUBE.</p>
 <p>Initialization now requires at least one network share that is both assigned to the same project and currently in the <code>MOUNTED</code> state. If no eligible mounted share exists, the UI disables submission and the API rejects the request.</p>
 <p>When you open the Initialize dialog:</p>
@@ -612,7 +491,7 @@ Confirm the drive is the intended destination media.
 </li><li>
 If you need to assign the drive to a <em>different</em> project, format it first to clear the existing binding.
 </li></ul>
-<h2 id="7-6-prepare-eject">7.6 Prepare Eject</h2>
+<h2 id="4-6-prepare-eject">4.6 Prepare Eject</h2>
 <p>Use <code>Prepare Eject</code> before physically removing a drive. This flushes pending writes, unmounts the filesystem, and transitions the drive to <code>AVAILABLE</code>.</p>
 <p>After a successful prepare-eject:</p>
 <ul><li>
@@ -627,8 +506,9 @@ The drive can be physically removed once the operation completes.
 <p>If ECUBE reports that the drive is still busy, the confirmation dialog closes cleanly and the page shows a specific retry message. Close any open shell, file browser, or process still using the mounted drive, then retry <code>Prepare Eject</code>.</p>
 <p>If ECUBE detects timed-out or failed files in active drive assignments, the first <code>Prepare Eject</code> attempt is blocked with an explicit confirmation-required warning. Review the warning details, then confirm a second prompt to continue with ejection.</p>
 <blockquote><p>To permanently retire a drive after removal, use the Chain of Custody handoff workflow on the <code>Audit</code> page. Confirming a handoff transitions the drive to <code>ARCHIVED</code>.</p></blockquote>
+<p class="help-back-to-top"><a href="#help-toc-title">Back to top</a></p>
 <hr />
-<h1 id="8-mounts">8. Mounts</h1>
+<h1 id="5-mounts">5. Mounts</h1>
 <blockquote><p><strong>Access Summary</strong></p></blockquote>
 <blockquote><p><strong>Page visibility:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code></p></blockquote>
 <blockquote><p><strong>Restricted actions:</strong> The mounts page is currently available to all authenticated users in the frontend.</p></blockquote>
@@ -647,7 +527,7 @@ Edit an existing mount definition
 </li><li>
 Remove an existing mount definition
 </li></ul>
-<h2 id="8-1-adding-a-mount">8.1 Adding a Mount</h2>
+<h2 id="5-1-adding-a-mount">5.1 Adding a Mount</h2>
 <p>The add-mount dialog supports common fields such as:</p>
 <ul><li>
 Type (<code>SMB</code> or <code>NFS</code>)
@@ -670,7 +550,7 @@ Credentials file
 <p>After a service restart, ECUBE may automatically restore an expected managed share mount or remove a stale ECUBE-managed mount point that no longer matches persisted system state. These startup corrections are intentional and are recorded in the audit log with sanitized details.</p>
 <p>The exact credential fields required depend on the mount type and your environment.</p>
 <p>If share browsing is unavailable because the ECUBE host is missing a required discovery tool, the dialog now shows an actionable message telling the operator which host package to install before retrying. The browse control is hidden entirely when ECUBE is running in demo mode.</p>
-<h2 id="8-1-1-editing-a-mount">8.1.1 Editing a Mount</h2>
+<h2 id="5-1-1-editing-a-mount">5.1.1 Editing a Mount</h2>
 <p>Use <code>Edit</code> on an existing mount row to reopen the same dialog in edit mode.</p>
 <ul><li>
 The dialog pre-fills the current type, remote path, and project ID.
@@ -682,12 +562,13 @@ Stored credentials are not returned to the UI. Leaving the credential fields bla
 Use <code>Clear saved credentials</code> if you need to remove previously stored SMB credentials without replacing them in the same edit.
 </li></ul>
 <p>When you save, ECUBE updates the existing mount record instead of creating a new one, then refreshes the row status in the list. If the backend rejects the change, or if the returned mount status is <code>ERROR</code>, the dialog stays open so you can review the returned error state before closing it.</p>
-<h2 id="8-2-testing-mount-connectivity">8.2 Testing Mount Connectivity</h2>
+<h2 id="5-2-testing-mount-connectivity">5.2 Testing Mount Connectivity</h2>
 <p>Use <code>Test</code> or <code>Test All</code> to verify that configured source mounts are reachable and valid before creating jobs that depend on them.</p>
-<h2 id="8-3-removing-a-mount">8.3 Removing a Mount</h2>
+<h2 id="5-3-removing-a-mount">5.3 Removing a Mount</h2>
 <p>Remove a mount only if it is no longer needed. If existing workflows depend on it, removing the definition can interrupt job creation or repeatability.</p>
+<p class="help-back-to-top"><a href="#help-toc-title">Back to top</a></p>
 <hr />
-<h1 id="8-4-directory-browser">8.4 Directory Browser</h1>
+<h1 id="5-4-directory-browser">5.4 Directory Browser</h1>
 <p>The directory browser allows users to explore the contents of active mount points (USB drives and network shares) before creating an export job.</p>
 <p><strong>Accessing the browser:</strong></p>
 <ul><li>
@@ -707,8 +588,9 @@ Results are paginated; use the page controls at the bottom to navigate large dir
 </li></ul>
 <p><strong>Roles:</strong> All authenticated roles (<code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code>) can browse directories.</p>
 <blockquote><p><strong>Note:</strong> Only active, registered mount points can be browsed. Arbitrary filesystem paths are not accessible through this feature.</p></blockquote>
+<p class="help-back-to-top"><a href="#help-toc-title">Back to top</a></p>
 <hr />
-<h1 id="9-jobs">9. Jobs</h1>
+<h1 id="6-jobs">6. Jobs</h1>
 <blockquote><p><strong>Access Summary</strong></p></blockquote>
 <blockquote><p><strong>Page visibility:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code></p></blockquote>
 <blockquote><p><strong>Restricted actions:</strong> Creating jobs in the current UI is enabled for <code>admin</code>, <code>manager</code>, and <code>processor</code>.</p></blockquote>
@@ -723,7 +605,7 @@ Refresh action
 </li><li>
 <code>Create Job</code> dialog
 </li></ul>
-<h2 id="9-1-viewing-jobs">9.1 Viewing Jobs</h2>
+<h2 id="6-1-viewing-jobs">6.1 Viewing Jobs</h2>
 <p>Use the jobs table to review:</p>
 <ul><li>
 Job ID
@@ -756,7 +638,7 @@ Progress label or percentage
 <code>FAILED</code>
 </li></ul>
 <p>The jobs table also exposes row-level <code>Details</code>, <code>Start</code>, and <code>Pause</code> actions for authorized operators. <code>PAUSING</code> means ECUBE is waiting for in-flight copy threads to finish their current work before the job becomes fully <code>PAUSED</code>.</p>
-<h2 id="9-2-creating-a-job">9.2 Creating a Job</h2>
+<h2 id="6-2-creating-a-job">6.2 Creating a Job</h2>
 <p>The current job-creation flow uses a grouped dialog instead of a four-step wizard.</p>
 <p>The dialog is organized into four sections:</p>
 <ol><li>
@@ -781,10 +663,11 @@ The evidence number and source path are correct
 If you enable <code>Run job immediately</code>, the job will start as soon as creation succeeds
 </li></ul>
 <p>The source path is interpreted inside the selected mounted share. Entering only / uses the root of that share, and attempts to navigate outside the selected share are rejected before the job is created.</p>
-<h2 id="9-3-opening-a-job">9.3 Opening a Job</h2>
+<h2 id="6-3-opening-a-job">6.3 Opening a Job</h2>
 <p>Open a job to view details and perform follow-up actions.</p>
+<p class="help-back-to-top"><a href="#help-toc-title">Back to top</a></p>
 <hr />
-<h1 id="10-job-detail-verification-and-file-review">10. Job Detail, Verification, and File Review</h1>
+<h1 id="7-job-detail-verification-and-file-review">7. Job Detail, Verification, and File Review</h1>
 <blockquote><p><strong>Access Summary</strong></p></blockquote>
 <blockquote><p><strong>Page visibility:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code></p></blockquote>
 <blockquote><p><strong>Restricted actions:</strong> <code>Analyze</code>, <code>Edit</code>, <code>Start</code>, <code>Retry Failed Files</code>, <code>Pause</code>, <code>Complete</code>, <code>Verify</code>, and <code>Manifest</code> are enabled for <code>admin</code>, <code>manager</code>, and <code>processor</code> when the current job state allows them. <code>Clear startup analysis cache</code> is shown only to <code>admin</code> and <code>manager</code> when the job still has a persisted startup-analysis snapshot. <code>Delete</code> is shown only for eligible pending jobs. Hash inspection and source/destination comparison remain available to <code>admin</code> and <code>auditor</code>.</p></blockquote>
@@ -813,7 +696,7 @@ Inspect hashes for individual files
 </li><li>
 Compare a file's source version against its copied destination version
 </li></ul>
-<h2 id="10-1-editing-starting-retrying-failed-files-pausing-completing-verifying-and-generating-a-manifest">10.1 Editing, Starting, Retrying Failed Files, Pausing, Completing, Verifying, and Generating a Manifest</h2>
+<h2 id="7-1-editing-starting-retrying-failed-files-pausing-completing-verifying-and-generating-a-manifest">7.1 Editing, Starting, Retrying Failed Files, Pausing, Completing, Verifying, and Generating a Manifest</h2>
 <p>Action buttons are shown near the top of the job detail screen.</p>
 <p>Use them when appropriate:</p>
 <ul><li>
@@ -847,7 +730,7 @@ Compare a file's source version against its copied destination version
 <p>If a job is restarted after a failed, paused, or partially successful run and its persisted startup-analysis snapshot is still current, ECUBE can reuse that cached scan instead of repeating the full startup analysis. ECUBE clears the reusable snapshot automatically only after a clean completion with no failed or timed-out files. When operators need to discard that snapshot, the <code>Clear startup analysis cache</code> action opens a confirmation dialog and removes only the cached startup-analysis data. It does not remove per-file history, copied-file state, or other audit-relevant job records.</p>
 <p>When a job is paused, completed, or fails, the detail view shows a summary with the job start time, copy thread count, files copied, files failed, files timed out, total copied, elapsed time, copy rate, and any failure reason or related log hint. A <code>COMPLETED</code> job means all files reached a terminal state, not necessarily that every file copied successfully, so the summary can still report failed or timed-out files after a partial-success completion. The elapsed time remains cumulative across earlier run segments, so a paused and later resumed job keeps the same additive runtime history that was shown while it was active. Failed jobs prefer a persisted sanitized job-level failure reason when one is available, so operators can see stable messages such as <code>Unexpected copy failure</code> or <code>Job interrupted by service restart before completion</code> before any derived per-file fallback. Completed jobs with file-level failures instead show the safe per-file failure summaries and counters without exposing raw provider errors or host paths. When <code>COPY_JOB_TIMEOUT</code> is exceeded for an individual file attempt, that timeout is recorded as a per-file error (for example <code>File copy timed out after 3600s</code>) rather than a whole-job timeout reason.</p>
 <p>When ECUBE can safely correlate a failed copy to the selected source or destination for that job, the failure summary may add relative hints such as <code>source: reports/a.txt</code> or <code>destination: reports/a.txt</code>. Raw host or mount paths are not shown in the Job Detail summary.</p>
-<h2 id="10-2-file-list">10.2 File List</h2>
+<h2 id="7-2-file-list">7.2 File List</h2>
 <p>The Files panel is collapsed by default on Job Detail. Use <code>Show files</code> to expand it and <code>Hide files</code> to collapse it again without losing the current page.</p>
 <p>When expanded, the file table usually shows:</p>
 <ul><li>
@@ -860,14 +743,14 @@ Failure details when a row includes a safe file-level error summary
 <code>View Hashes</code> actions for users allowed to inspect file hashes
 </li></ul>
 <p>If the job contains more rows than fit on one page, the panel shows a numbered pagination control with 10-page shortcut windows and left/right navigation. The number of rows shown per page is controlled by the admin-only <code>Job Detail Files Per Page</code> runtime setting and is bounded between 20 and 100.</p>
-<h2 id="10-3-hash-viewer">10.3 Hash Viewer</h2>
+<h2 id="7-3-hash-viewer">7.3 Hash Viewer</h2>
 <p>Users with sufficient permissions can inspect file hashes, including values such as:</p>
 <ul><li>
 MD5
 </li><li>
 SHA-256
 </li></ul>
-<h2 id="10-4-compare-source-and-destination">10.4 Compare Source and Destination</h2>
+<h2 id="7-4-compare-source-and-destination">7.4 Compare Source and Destination</h2>
 <p>The compare panel now uses clear <code>Source</code> and <code>Destination</code> terminology. After you load hashes for an exported file, choose that file in the compare selector to evaluate the original source version against the copied destination version.</p>
 <p>Comparison output includes:</p>
 <ul><li>
@@ -881,8 +764,9 @@ Path match
 </li></ul>
 <p>This is useful when reviewing evidence consistency or confirming repeatability after copy or verification steps. If either side is unavailable, ECUBE shows a sanitized conflict message instead of exposing raw filesystem details.</p>
 <p>Verify and Manifest stay disabled until the job reaches a truly complete 100% state. After manifest generation, the detail page shows a success banner with the location of the refreshed <code>manifest.json</code> file on the destination drive and starts a browser download of the same generated manifest JSON.</p>
+<p class="help-back-to-top"><a href="#help-toc-title">Back to top</a></p>
 <hr />
-<h1 id="11-audit-logs">11. Audit Logs</h1>
+<h1 id="8-audit-logs">8. Audit Logs</h1>
 <blockquote><p><strong>Access Summary</strong></p></blockquote>
 <blockquote><p><strong>Page visibility:</strong> <code>admin</code>, <code>manager</code>, <code>auditor</code></p></blockquote>
 <blockquote><p><strong>Restricted actions:</strong> CSV export is available from the page for authorized users.</p></blockquote>
@@ -908,7 +792,7 @@ Review filters before export so the file contains the intended data set
 </li><li>
 Treat exported audit data as sensitive operational evidence
 </li></ul>
-<h2 id="11-1-chain-of-custody-workflow">11.1 Chain of Custody Workflow</h2>
+<h2 id="8-1-chain-of-custody-workflow">8.1 Chain of Custody Workflow</h2>
 <p>Use the Chain of Custody panel on the <code>Audit</code> page to generate custody reports, prefill handoff fields, and record final transfer details when physical media leaves active operations.</p>
 <p>Typical workflow:</p>
 <ol><li>
@@ -955,8 +839,9 @@ Verify drive ID, project, possessor, and delivery timestamp before confirming.
 </li><li>
 Use <code>Cancel</code> if any custody detail needs correction before archival.
 </li></ul>
+<p class="help-back-to-top"><a href="#help-toc-title">Back to top</a></p>
 <hr />
-<h1 id="12-users">12. Users</h1>
+<h1 id="9-users">9. Users</h1>
 <blockquote><p><strong>Access Summary</strong></p></blockquote>
 <blockquote><p><strong>Page visibility:</strong> <code>admin</code></p></blockquote>
 <blockquote><p><strong>Restricted actions:</strong> All user-management actions on this page are administrator-only.</p></blockquote>
@@ -971,7 +856,7 @@ Assigning or removing ECUBE roles
 </li><li>
 Resetting a user's password
 </li></ul>
-<h2 id="12-1-reset-a-user-password">12.1 Reset a User Password</h2>
+<h2 id="9-1-reset-a-user-password">9.1 Reset a User Password</h2>
 <p><strong>Allowed roles:</strong> <code>admin</code></p>
 <ol><li>
 Open <code>Users</code>.
@@ -999,7 +884,7 @@ Use strong passwords that meet your organization security requirements.
 Record administrative password-reset actions according to your SOP.
 </li></ul>
 <p>If your role does not include access to this page, the navigation item will not appear.</p>
-<h2 id="12-2-configuration-page-administrator">12.2 Configuration Page (Administrator)</h2>
+<h2 id="9-2-configuration-page-administrator">9.2 Configuration Page (Administrator)</h2>
 <p><strong>Allowed roles:</strong> <code>admin</code></p>
 <p>Use the <code>Configuration</code> page to update selected runtime settings from the UI without logging into the host terminal.</p>
 <p>In a standard deployment, the Logging section loads with file logging already enabled and the log path prefilled as <code>/var/log/ecube/app.log</code>. Unchecking the file logging toggle clears <code>LOG_FILE</code> and returns ECUBE to console-only logging.</p>
@@ -1046,8 +931,9 @@ If restart submission fails, use the displayed error and contact platform suppor
 For field-by-field meaning and defaults, see Configuration reference.
 </li></ul>
 <p>If your role does not include access to this page, the navigation item will not appear.</p>
+<p class="help-back-to-top"><a href="#help-toc-title">Back to top</a></p>
 <hr />
-<h1 id="13-system">13. System</h1>
+<h1 id="10-system">10. System</h1>
 <blockquote><p><strong>Access Summary</strong></p></blockquote>
 <blockquote><p><strong>Page visibility:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code></p></blockquote>
 <blockquote><p><strong>Restricted actions:</strong> Most diagnostics on this page are relevant to administrators and support personnel. Log viewing is admin-only.</p></blockquote>
@@ -1065,7 +951,7 @@ Investigating system errors or performance issues via application logs (admin-on
 <p>End users who only perform evidence exports may rarely need this page. Administrators and support personnel are more likely to use it during troubleshooting.</p>
 <p>In the <code>USB Topology</code> tab, ECUBE shows a sorted device table that includes <code>Device</code> and <code>Serial Number</code> columns. Rows with no meaningful USB metadata are hidden so the list stays focused on useful hardware entries.</p>
 <p>For users with <code>admin</code> or <code>manager</code> roles, the System tab bar includes a <code>Reconcile managed mounts</code> action button positioned between <code>Mounts</code> and <code>Logs</code>. This action triggers a manual managed-mount reconciliation pass and opens a dedicated results page.</p>
-<h2 id="13-1-application-logs-tab">13.1 Application Logs Tab</h2>
+<h2 id="10-1-application-logs-tab">10.1 Application Logs Tab</h2>
 <p><strong>Access:</strong> <code>admin</code> role only</p>
 <p>The <strong>Logs</strong> tab allows administrators to inspect the active application log and eligible rotated log files in real time without requiring SSH or command-line access to the ECUBE host. This is useful for diagnosing system issues, checking for errors, and monitoring application behavior.</p>
 <h3 id="viewing-logs">Viewing Logs</h3>
@@ -1140,10 +1026,10 @@ Verify the ECUBE service account has read permissions on the selected log file.
 </li><li>
 If you selected a rotated file, confirm the file has not been removed or replaced during log rotation.
 </li><li>
-Consult <a href="#15-troubleshooting">15. Troubleshooting</a> for service-level issues.
+Consult <a href="#12-troubleshooting">12. Troubleshooting</a> for service-level issues.
 </li></ul>
 <p>Governance note: denied log access attempts by non-admin users are recorded in the audit trail for accountability and compliance visibility.</p>
-<h2 id="13-2-manual-mount-reconciliation">13.2 Manual Mount Reconciliation</h2>
+<h2 id="10-2-manual-mount-reconciliation">10.2 Manual Mount Reconciliation</h2>
 <p><strong>Access:</strong> <code>admin</code>, <code>manager</code> roles</p>
 <p>Use this action when mounted-share state appears stale or inconsistent and you need to reconcile managed network and USB mount state without restarting the service.</p>
 <h3 id="run-reconciliation-from-the-system-page">Run Reconciliation from the System Page</h3>
@@ -1186,9 +1072,10 @@ If no result context is available (for example direct navigation or browser refr
 If reconciliation returns no mount or drive rows, ECUBE shows <code>No reconciliation data available. Run reconciliation to see results.</code>
 </li></ul>
 <p>Use the <code>Back</code> button on the results page to return to the System page.</p>
+<p class="help-back-to-top"><a href="#help-toc-title">Back to top</a></p>
 <hr />
-<h1 id="14-common-tasks">14. Common Tasks</h1>
-<h2 id="14-1-insert-a-new-drive-and-associate-it-with-a-project">14.1 Insert a New Drive and Associate It with a Project</h2>
+<h1 id="11-common-tasks">11. Common Tasks</h1>
+<h2 id="11-1-insert-a-new-drive-and-associate-it-with-a-project">11.1 Insert a New Drive and Associate It with a Project</h2>
 <p><strong>Allowed roles:</strong> <code>admin</code>, <code>manager</code></p>
 <ol><li>
 Insert the new USB drive into the ECUBE host.
@@ -1219,7 +1106,7 @@ The destination drive itself must also already be mounted; otherwise ECUBE retur
 </li><li>
 Confirm the project carefully before initialization because project isolation is enforced after association.
 </li></ul>
-<h2 id="14-1a-re-insert-a-drive-to-add-more-data-to-the-same-project">14.1a Re-insert a Drive to Add More Data to the Same Project</h2>
+<h2 id="11-1a-re-insert-a-drive-to-add-more-data-to-the-same-project">11.1a Re-insert a Drive to Add More Data to the Same Project</h2>
 <p><strong>Allowed roles:</strong> <code>admin</code>, <code>manager</code></p>
 <p>If a drive was previously ejected and needs to receive more data for the same project:</p>
 <ol><li>
@@ -1240,7 +1127,7 @@ Confirm and submit.
 The drive transitions back to <code>IN_USE</code> for the same project.
 </li></ol>
 <p>No format is required when re-using the same project, but both the mounted-share and mounted-drive prerequisites still apply.</p>
-<h2 id="14-1b-re-assign-a-drive-to-a-different-project">14.1b Re-assign a Drive to a Different Project</h2>
+<h2 id="11-1b-re-assign-a-drive-to-a-different-project">11.1b Re-assign a Drive to a Different Project</h2>
 <p><strong>Allowed roles:</strong> <code>admin</code>, <code>manager</code></p>
 <p>If a drive must be reassigned to a different project, a format is required to wipe existing data and clear the project binding:</p>
 <ol><li>
@@ -1261,7 +1148,7 @@ Choose the new project from the dropdown and confirm.
 The drive transitions to <code>IN_USE</code> for the new project.
 </li></ol>
 <blockquote><p><strong>Warning:</strong> Formatting permanently deletes all data on the drive. Verify that copies and chain-of-custody records for prior project data are complete before proceeding.</p></blockquote>
-<h2 id="14-2-prepare-a-drive-for-removal-and-shipment">14.2 Prepare a Drive for Removal and Shipment</h2>
+<h2 id="11-2-prepare-a-drive-for-removal-and-shipment">11.2 Prepare a Drive for Removal and Shipment</h2>
 <p><strong>Allowed roles:</strong> <code>admin</code>, <code>manager</code></p>
 <ol><li>
 Confirm the export job is complete and any required verification or manifest generation has finished.
@@ -1286,7 +1173,7 @@ After ejection the drive returns to <code>AVAILABLE</code> with its project bind
 </li><li>
 To permanently retire the drive, complete the Chain of Custody handoff on the <code>Audit</code> page after removal.
 </li></ul>
-<h2 id="14-3-export-evidence-to-a-drive">14.3 Export Evidence to a Drive</h2>
+<h2 id="11-3-export-evidence-to-a-drive">11.3 Export Evidence to a Drive</h2>
 <p><strong>Allowed roles:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code></p>
 <ol><li>
 Confirm the correct drive is present and in the expected state.
@@ -1309,7 +1196,7 @@ Monitor progress until completion.
 </li><li>
 Run verification and generate a manifest if required by your workflow.
 </li></ol>
-<h2 id="14-4-review-copy-results">14.4 Review Copy Results</h2>
+<h2 id="11-4-review-copy-results">11.4 Review Copy Results</h2>
 <p><strong>Allowed roles:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code></p>
 <ol><li>
 Open the job detail page.
@@ -1328,7 +1215,7 @@ Hash inspection is currently available to <code>admin</code> and <code>auditor</
 </li><li>
 Operational actions such as <code>Start</code>, <code>Verify</code>, and <code>Manifest</code> are available to <code>admin</code>, <code>manager</code>, and <code>processor</code>.
 </li></ul>
-<h2 id="14-5-review-audit-activity">14.5 Review Audit Activity</h2>
+<h2 id="11-5-review-audit-activity">11.5 Review Audit Activity</h2>
 <p><strong>Allowed roles:</strong> <code>admin</code>, <code>manager</code>, <code>auditor</code></p>
 <ol><li>
 Open <code>Audit</code>.
@@ -1339,7 +1226,7 @@ Expand details for relevant records.
 </li><li>
 Export CSV if you need to retain or share the filtered results.
 </li></ol>
-<h2 id="14-6-add-a-new-user">14.6 Add a New User</h2>
+<h2 id="11-6-add-a-new-user">11.6 Add a New User</h2>
 <p><strong>Allowed roles:</strong> <code>admin</code></p>
 <ol><li>
 Open <code>Users</code>.
@@ -1368,7 +1255,7 @@ Existing users that are linked into ECUBE are not prompted for a new password in
 </li><li>
 For directory-backed users that cannot be fully enumerated by host account listing, ECUBE may show placeholder host fields while still exposing role management controls.
 </li></ul>
-<h2 id="14-7-remove-a-user-s-ecube-access">14.7 Remove a User's ECUBE Access</h2>
+<h2 id="11-7-remove-a-user-s-ecube-access">11.7 Remove a User's ECUBE Access</h2>
 <p><strong>Allowed roles:</strong> <code>admin</code></p>
 <ol><li>
 Open <code>Users</code>.
@@ -1387,7 +1274,7 @@ In the current web UI, removing all roles is the visible workflow for removing E
 </li><li>
 Full operating-system user deletion is not currently exposed in the web UI and should be handled through administrative procedures outside this manual.
 </li></ul>
-<h2 id="14-8-view-application-logs-for-troubleshooting">14.8 View Application Logs for Troubleshooting</h2>
+<h2 id="11-8-view-application-logs-for-troubleshooting">11.8 View Application Logs for Troubleshooting</h2>
 <p><strong>Allowed roles:</strong> <code>admin</code></p>
 <ol><li>
 Open the <code>System</code> page.
@@ -1416,9 +1303,10 @@ Download always follows the currently selected source.
 </li><li>
 This feature is admin-only to prevent information leakage from diagnostic data.
 </li></ul>
+<p class="help-back-to-top"><a href="#help-toc-title">Back to top</a></p>
 <hr />
-<h1 id="15-troubleshooting">15. Troubleshooting</h1>
-<h2 id="15-1-i-cannot-log-in">15.1 I Cannot Log In</h2>
+<h1 id="12-troubleshooting">12. Troubleshooting</h1>
+<h2 id="12-1-i-cannot-log-in">12.1 I Cannot Log In</h2>
 <p>Possible causes:</p>
 <ul><li>
 Incorrect username or password
@@ -1429,7 +1317,7 @@ Browser cannot reach the site
 </li><li>
 Your account has not been created or assigned the right role
 </li></ul>
-<h2 id="15-2-a-page-or-menu-item-is-missing">15.2 A Page or Menu Item Is Missing</h2>
+<h2 id="12-2-a-page-or-menu-item-is-missing">12.2 A Page or Menu Item Is Missing</h2>
 <p>Possible causes:</p>
 <ul><li>
 Your role does not include access to that feature
@@ -1438,7 +1326,7 @@ The system is not fully initialized
 </li><li>
 The deployment is using an older or partially upgraded frontend/backend combination
 </li></ul>
-<h2 id="15-3-a-button-is-visible-but-disabled">15.3 A Button Is Visible but Disabled</h2>
+<h2 id="12-3-a-button-is-visible-but-disabled">12.3 A Button Is Visible but Disabled</h2>
 <p>Possible causes:</p>
 <ul><li>
 Your role is read-only for that operation
@@ -1447,7 +1335,7 @@ The selected object is not in a state that permits the action
 </li><li>
 Required data has not been entered yet
 </li></ul>
-<h2 id="15-4-the-ui-shows-a-network-error">15.4 The UI Shows a Network Error</h2>
+<h2 id="12-4-the-ui-shows-a-network-error">12.4 The UI Shows a Network Error</h2>
 <p>Possible causes:</p>
 <ul><li>
 Backend service unavailable
@@ -1469,7 +1357,7 @@ The visible error text
 The approximate date and time
 </li></ul>
 <p>Then provide that information to your ECUBE administrator.</p>
-<h2 id="15-5-usb-drive-is-not-recognized">15.5 USB Drive Is Not Recognized</h2>
+<h2 id="12-5-usb-drive-is-not-recognized">12.5 USB Drive Is Not Recognized</h2>
 <p><strong>Who can do what:</strong></p>
 <ul><li>
 End users (<code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code>) can perform UI-level checks.
@@ -1515,6 +1403,7 @@ Host permission/device passthrough issues (especially in containerized setups)
 </li><li>
 ECUBE service not running or unable to complete hardware discovery
 </li></ul>
+<p class="help-back-to-top"><a href="#help-toc-title">Back to top</a></p>
 <hr />
     </main>
   </body>

--- a/frontend/public/help/manual.html
+++ b/frontend/public/help/manual.html
@@ -67,6 +67,57 @@
         color: var(--help-muted);
       }
 
+      .help-toc {
+        margin: 1.5rem 0 2rem;
+        padding: 1rem 1.25rem;
+        background: #f7f1e6;
+        border: 1px solid var(--help-border);
+        border-radius: 14px;
+      }
+
+      .help-toc-header {
+        margin-bottom: 0.75rem;
+      }
+
+      .help-toc-header h2,
+      .help-toc-header p {
+        margin: 0;
+      }
+
+      .help-toc-header p {
+        margin-top: 0.25rem;
+        font-family: var(--help-ui-font);
+        color: var(--help-muted);
+      }
+
+      .help-toc ol {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 0.35rem 1.5rem;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .help-toc li {
+        font-family: var(--help-ui-font);
+      }
+
+      .help-toc .toc-level-3,
+      .help-toc .toc-level-4 {
+        padding-left: 1rem;
+      }
+
+      .help-toc a {
+        display: inline-block;
+        text-decoration: none;
+      }
+
+      .help-toc a:hover,
+      .help-toc a:focus-visible {
+        text-decoration: underline;
+      }
+
       h1,
       h2,
       h3,
@@ -159,7 +210,80 @@
       <p class="help-kicker">In-App Help</p>
       <h1>ECUBE User Guide</h1>
       <p class="help-meta">Updated: 04/25/26</p>
-      <p class="help-lead">Generated from docs/operations/13-user-manual.md for authenticated in-app help.</p>
+      <p class="help-lead">Task-focused guidance for signed-in ECUBE users.</p>
+      <nav class="help-toc" aria-labelledby="help-toc-title">
+        <div class="help-toc-header">
+          <h2 id="help-toc-title">Quick Index</h2>
+          <p>Jump directly to a task or section.</p>
+        </div>
+        <ol>
+<li class="toc-level-1"><a href="#purpose">Purpose</a></li>
+<li class="toc-level-1"><a href="#scope">Scope</a></li>
+<li class="toc-level-1"><a href="#2-before-you-begin">2. Before You Begin</a></li>
+<li class="toc-level-1"><a href="#3-roles-and-access">3. Roles and Access</a></li>
+<li class="toc-level-1"><a href="#4-first-access">4. First Access</a></li>
+<li class="toc-level-2"><a href="#4-2-login">4.2 Login</a></li>
+<li class="toc-level-1"><a href="#5-interface-overview">5. Interface Overview</a></li>
+<li class="toc-level-2"><a href="#5-1-theme-selection-light-dark-custom">5.1 Theme Selection (Light/Dark/Custom)</a></li>
+<li class="toc-level-1"><a href="#6-dashboard">6. Dashboard</a></li>
+<li class="toc-level-1"><a href="#7-drives">7. Drives</a></li>
+<li class="toc-level-2"><a href="#7-1-drive-states">7.1 Drive States</a></li>
+<li class="toc-level-2"><a href="#7-2-viewing-drives">7.2 Viewing Drives</a></li>
+<li class="toc-level-2"><a href="#7-3-drive-detail-page">7.3 Drive Detail Page</a></li>
+<li class="toc-level-2"><a href="#7-4-formatting-a-drive">7.4 Formatting a Drive</a></li>
+<li class="toc-level-2"><a href="#7-5-initializing-a-drive">7.5 Initializing a Drive</a></li>
+<li class="toc-level-2"><a href="#7-6-prepare-eject">7.6 Prepare Eject</a></li>
+<li class="toc-level-1"><a href="#8-mounts">8. Mounts</a></li>
+<li class="toc-level-2"><a href="#8-1-adding-a-mount">8.1 Adding a Mount</a></li>
+<li class="toc-level-2"><a href="#8-1-1-editing-a-mount">8.1.1 Editing a Mount</a></li>
+<li class="toc-level-2"><a href="#8-2-testing-mount-connectivity">8.2 Testing Mount Connectivity</a></li>
+<li class="toc-level-2"><a href="#8-3-removing-a-mount">8.3 Removing a Mount</a></li>
+<li class="toc-level-1"><a href="#8-4-directory-browser">8.4 Directory Browser</a></li>
+<li class="toc-level-1"><a href="#9-jobs">9. Jobs</a></li>
+<li class="toc-level-2"><a href="#9-1-viewing-jobs">9.1 Viewing Jobs</a></li>
+<li class="toc-level-2"><a href="#9-2-creating-a-job">9.2 Creating a Job</a></li>
+<li class="toc-level-2"><a href="#9-3-opening-a-job">9.3 Opening a Job</a></li>
+<li class="toc-level-1"><a href="#10-job-detail-verification-and-file-review">10. Job Detail, Verification, and File Review</a></li>
+<li class="toc-level-2"><a href="#10-1-editing-starting-retrying-failed-files-pausing-completing-verifying-and-generating-a-manifest">10.1 Editing, Starting, Retrying Failed Files, Pausing, Completing, Verifying, and Generating a Manifest</a></li>
+<li class="toc-level-2"><a href="#10-2-file-list">10.2 File List</a></li>
+<li class="toc-level-2"><a href="#10-3-hash-viewer">10.3 Hash Viewer</a></li>
+<li class="toc-level-2"><a href="#10-4-compare-source-and-destination">10.4 Compare Source and Destination</a></li>
+<li class="toc-level-1"><a href="#11-audit-logs">11. Audit Logs</a></li>
+<li class="toc-level-2"><a href="#11-1-chain-of-custody-workflow">11.1 Chain of Custody Workflow</a></li>
+<li class="toc-level-1"><a href="#12-users">12. Users</a></li>
+<li class="toc-level-2"><a href="#12-1-reset-a-user-password">12.1 Reset a User Password</a></li>
+<li class="toc-level-2"><a href="#12-2-configuration-page-administrator">12.2 Configuration Page (Administrator)</a></li>
+<li class="toc-level-1"><a href="#13-system">13. System</a></li>
+<li class="toc-level-2"><a href="#13-1-application-logs-tab">13.1 Application Logs Tab</a></li>
+<li class="toc-level-3"><a href="#viewing-logs">Viewing Logs</a></li>
+<li class="toc-level-3"><a href="#searching-logs">Searching Logs</a></li>
+<li class="toc-level-3"><a href="#pagination">Pagination</a></li>
+<li class="toc-level-3"><a href="#automatic-redaction">Automatic Redaction</a></li>
+<li class="toc-level-3"><a href="#refreshing-log-data">Refreshing Log Data</a></li>
+<li class="toc-level-3"><a href="#troubleshooting-log-viewing">Troubleshooting Log Viewing</a></li>
+<li class="toc-level-2"><a href="#13-2-manual-mount-reconciliation">13.2 Manual Mount Reconciliation</a></li>
+<li class="toc-level-3"><a href="#run-reconciliation-from-the-system-page">Run Reconciliation from the System Page</a></li>
+<li class="toc-level-3"><a href="#interpret-reconciliation-results">Interpret Reconciliation Results</a></li>
+<li class="toc-level-3"><a href="#result-page-states">Result Page States</a></li>
+<li class="toc-level-1"><a href="#14-common-tasks">14. Common Tasks</a></li>
+<li class="toc-level-2"><a href="#14-1-insert-a-new-drive-and-associate-it-with-a-project">14.1 Insert a New Drive and Associate It with a Project</a></li>
+<li class="toc-level-2"><a href="#14-1a-re-insert-a-drive-to-add-more-data-to-the-same-project">14.1a Re-insert a Drive to Add More Data to the Same Project</a></li>
+<li class="toc-level-2"><a href="#14-1b-re-assign-a-drive-to-a-different-project">14.1b Re-assign a Drive to a Different Project</a></li>
+<li class="toc-level-2"><a href="#14-2-prepare-a-drive-for-removal-and-shipment">14.2 Prepare a Drive for Removal and Shipment</a></li>
+<li class="toc-level-2"><a href="#14-3-export-evidence-to-a-drive">14.3 Export Evidence to a Drive</a></li>
+<li class="toc-level-2"><a href="#14-4-review-copy-results">14.4 Review Copy Results</a></li>
+<li class="toc-level-2"><a href="#14-5-review-audit-activity">14.5 Review Audit Activity</a></li>
+<li class="toc-level-2"><a href="#14-6-add-a-new-user">14.6 Add a New User</a></li>
+<li class="toc-level-2"><a href="#14-7-remove-a-user-s-ecube-access">14.7 Remove a User's ECUBE Access</a></li>
+<li class="toc-level-2"><a href="#14-8-view-application-logs-for-troubleshooting">14.8 View Application Logs for Troubleshooting</a></li>
+<li class="toc-level-1"><a href="#15-troubleshooting">15. Troubleshooting</a></li>
+<li class="toc-level-2"><a href="#15-1-i-cannot-log-in">15.1 I Cannot Log In</a></li>
+<li class="toc-level-2"><a href="#15-2-a-page-or-menu-item-is-missing">15.2 A Page or Menu Item Is Missing</a></li>
+<li class="toc-level-2"><a href="#15-3-a-button-is-visible-but-disabled">15.3 A Button Is Visible but Disabled</a></li>
+<li class="toc-level-2"><a href="#15-4-the-ui-shows-a-network-error">15.4 The UI Shows a Network Error</a></li>
+<li class="toc-level-2"><a href="#15-5-usb-drive-is-not-recognized">15.5 USB Drive Is Not Recognized</a></li>
+        </ol>
+      </nav>
       <h1 id="purpose">Purpose</h1>
 <p>This manual explains how to use the ECUBE web interface for day-to-day work. It focuses on tasks performed in the browser after the platform has already been deployed and made available by an administrator.</p>
 <p>Primary workflows covered in this guide:</p>
@@ -186,15 +310,15 @@ Managing selected runtime configuration settings (admin-only)
 <p>This guide is intended for users who interact with ECUBE through the web UI. It does not cover operating-system setup, service management, certificate provisioning, Docker administration, or backend troubleshooting.</p>
 <p>For those topics, use the companion guides:</p>
 <ul><li>
-01-installation.md for packaged installation options
+Installation for packaged installation options
 </li><li>
-02-manual-installation.md for native/manual deployment
+Manual installation for native/manual deployment
 </li><li>
-03-docker-deployment.md for Docker Compose deployment
+Docker deployment for Docker Compose deployment
 </li><li>
-09-administration-automation-guide.md for administrative and API-driven tasks
+Administration automation guide for administrative and API-driven tasks
 </li><li>
-11-api-quick-reference.md for direct API usage
+API quick reference for direct API usage
 </li></ul>
 <hr />
 <h1 id="2-before-you-begin">2. Before You Begin</h1>
@@ -341,7 +465,7 @@ The web UI currently does not provide an administrator control to set a system-w
 </li><li>
 Platform administrators can still influence the deployment default by controlling which CSS is served as <code>default.css</code> in the mounted themes directory.
 </li></ul>
-<p>For deployment-side theme and branding management, see 14-theme-and-branding-guide.md and 04-configuration-reference.md (<code>ECUBE_THEMES_DIR</code>).</p>
+<p>For deployment-side theme and branding management, see Theme and branding guide and Configuration reference (<code>ECUBE_THEMES_DIR</code>).</p>
 <p>Example dark-theme appearance:</p>
 <hr />
 <h1 id="6-dashboard">6. Dashboard</h1>
@@ -919,7 +1043,7 @@ Restarting the application service can interrupt active operations. Prefer using
 </li><li>
 If restart submission fails, use the displayed error and contact platform support or perform restart through approved host-level procedures.
 </li><li>
-For field-by-field meaning and defaults, see 04-configuration-reference.md.
+For field-by-field meaning and defaults, see Configuration reference.
 </li></ul>
 <p>If your role does not include access to this page, the navigation item will not appear.</p>
 <hr />
@@ -1392,10 +1516,6 @@ Host permission/device passthrough issues (especially in containerized setups)
 ECUBE service not running or unable to complete hardware discovery
 </li></ul>
 <hr />
-<h1 id="references">References</h1>
-<ul><li>
-docs/operations/00-operational-guide.md
-</li></ul>
     </main>
   </body>
 </html>

--- a/frontend/src/build/__tests__/helpAsset.spec.js
+++ b/frontend/src/build/__tests__/helpAsset.spec.js
@@ -1,0 +1,74 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { constants as fsConstants } from 'node:fs'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { tmpdir } from 'node:os'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { build } from 'vite'
+
+const execFileAsync = promisify(execFile)
+const testsRoot = dirname(fileURLToPath(import.meta.url))
+const frontendRoot = resolve(testsRoot, '../../..')
+const repoRoot = resolve(frontendRoot, '..')
+let outputDir = ''
+let fixtureRoot = ''
+
+beforeAll(async () => {
+  await execFileAsync('node', ['scripts/build-help.mjs'], { cwd: repoRoot })
+  outputDir = await mkdtemp(resolve(tmpdir(), 'ecube-help-build-'))
+  fixtureRoot = await mkdtemp(resolve(tmpdir(), 'ecube-help-fixture-'))
+  await writeFile(
+    resolve(fixtureRoot, 'index.html'),
+    '<!doctype html><html lang="en"><body><div id="app"></div><script type="module" src="/main.js"></script></body></html>',
+    'utf8',
+  )
+  await writeFile(resolve(fixtureRoot, 'main.js'), 'document.getElementById("app").textContent = "fixture"\n', 'utf8')
+})
+
+afterAll(async () => {
+  if (outputDir) {
+    await rm(outputDir, { recursive: true, force: true })
+  }
+  if (fixtureRoot) {
+    await rm(fixtureRoot, { recursive: true, force: true })
+  }
+})
+
+describe('generated help asset', () => {
+  it('is copied into Vite build output', async () => {
+    await build(
+      {
+        root: fixtureRoot,
+        publicDir: resolve(frontendRoot, 'public'),
+        logLevel: 'silent',
+        build: {
+          outDir: outputDir,
+          emptyOutDir: true,
+        },
+      },
+    )
+
+    const builtHelpPath = resolve(outputDir, 'help/manual.html')
+    await access(builtHelpPath, fsConstants.R_OK)
+    const html = await readFile(builtHelpPath, 'utf8')
+
+    expect(html).toContain('id="ecube-theme-stylesheet"')
+    expect(html).toContain('href="../themes/default.css"')
+    expect(html).toContain("localStorage.getItem(themeStorageKey)")
+    expect(html).toContain("themeLink.href = '../themes/' + themeName + '.css'")
+    expect(html).toContain('--help-bg: var(--color-bg-secondary, #f8f9fa);')
+    expect(html).toContain('<h2 id="help-toc-title">Table of Contents</h2>')
+    expect(html).toContain('aria-labelledby="help-toc-title"')
+    expect(html).toContain('display: block;')
+    expect(html).toContain('href="#1-roles-and-access"')
+    expect(html).toContain('<h1 id="5-mounts">5. Mounts</h1>')
+    expect(html).toContain('<h2 id="5-4-directory-browser">5.4 Directory Browser</h2>')
+    expect(html).not.toContain('<h1 id="5-4-directory-browser">5.4 Directory Browser</h1>')
+    expect(html).toContain('<h3 id="5-1-1-editing-a-mount">5.1.1 Editing a Mount</h3>')
+    expect(html).not.toContain('class="help-kicker"')
+    expect(html).toContain('class="help-back-to-top"')
+    expect(html).toContain('href="#help-toc-title">Back to top</a>')
+  })
+})

--- a/frontend/src/components/layout/AppHeader.vue
+++ b/frontend/src/components/layout/AppHeader.vue
@@ -167,17 +167,13 @@ onUnmounted(() => {
       class="help-panel"
       role="dialog"
       aria-modal="true"
-      aria-labelledby="help-modal-title"
+      :aria-label="t('help.frameTitle')"
     >
-      <div class="help-panel-header">
-        <div>
-          <p class="help-kicker">{{ t('help.kicker') }}</p>
-          <h2 id="help-modal-title">{{ t('help.title') }}</h2>
-        </div>
+      <p class="help-panel-kicker">{{ t('help.kicker') }}</p>
+      <iframe class="help-frame" :src="'/help/manual.html'" :title="t('help.frameTitle')" loading="lazy" />
+      <div class="help-panel-footer">
         <button class="btn-help-close" @click="closeHelpDialog">{{ t('common.actions.close') }}</button>
       </div>
-      <p class="help-description">{{ t('help.description') }}</p>
-      <iframe class="help-frame" :src="'/help/manual.html'" :title="t('help.frameTitle')" loading="lazy" />
     </section>
   </div>
 </template>
@@ -318,14 +314,7 @@ onUnmounted(() => {
   box-shadow: var(--shadow-lg);
 }
 
-.help-panel-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-md);
-}
-
-.help-kicker {
+.help-panel-kicker {
   margin: 0;
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-bold);
@@ -334,13 +323,11 @@ onUnmounted(() => {
   color: var(--color-text-secondary);
 }
 
-.help-panel-header h2,
-.help-description {
-  margin: 0;
-}
-
-.help-description {
-  color: var(--color-text-secondary);
+.help-panel-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-md);
 }
 
 .help-frame {
@@ -362,8 +349,9 @@ onUnmounted(() => {
     padding: var(--space-md);
   }
 
-  .help-panel-header {
+  .help-panel-footer {
     flex-direction: column;
+    align-items: stretch;
   }
 }
 </style>

--- a/frontend/src/components/layout/AppHeader.vue
+++ b/frontend/src/components/layout/AppHeader.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth.js'
 import { useThemeStore } from '@/stores/theme.js'
@@ -11,6 +11,9 @@ const themeStore = useThemeStore()
 
 const now = ref(Date.now())
 const logoLoadFailed = ref(false)
+const showHelpDialog = ref(false)
+const helpDialogRef = ref(null)
+const helpTriggerRef = ref(null)
 let timerInterval = null
 
 const showLogoImage = computed(() => Boolean(themeStore.currentLogo) && !logoLoadFailed.value)
@@ -51,6 +54,76 @@ function handleLogout() {
 function handleLogoError() {
   logoLoadFailed.value = true
 }
+
+function getFocusableElements(container) {
+  if (!(container instanceof HTMLElement)) return []
+  return Array.from(
+    container.querySelectorAll(
+      'button, [href], input, select, textarea, iframe, [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((element) => !element.hasAttribute('disabled') && element.getAttribute('aria-hidden') !== 'true')
+}
+
+function trapFocusWithin(event, container) {
+  const focusable = getFocusableElements(container)
+  if (!focusable.length) return
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  const active = document.activeElement
+
+  if (event.shiftKey && active === first) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+
+function openHelpDialog(event) {
+  helpTriggerRef.value = event?.currentTarget instanceof HTMLElement ? event.currentTarget : document.activeElement
+  showHelpDialog.value = true
+}
+
+function closeHelpDialog() {
+  showHelpDialog.value = false
+}
+
+function handleHelpDialogKeydown(event) {
+  if (!showHelpDialog.value) return
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeHelpDialog()
+    return
+  }
+  if (event.key === 'Tab') {
+    trapFocusWithin(event, helpDialogRef.value)
+  }
+}
+
+watch(showHelpDialog, async (open) => {
+  if (open) {
+    document.addEventListener('keydown', handleHelpDialogKeydown)
+    await nextTick()
+    const firstFocusable = getFocusableElements(helpDialogRef.value)[0]
+    if (firstFocusable instanceof HTMLElement) {
+      firstFocusable.focus()
+    }
+    return
+  }
+
+  document.removeEventListener('keydown', handleHelpDialogKeydown)
+  const trigger = helpTriggerRef.value
+  helpTriggerRef.value = null
+  await nextTick()
+  if (trigger instanceof HTMLElement) {
+    trigger.focus()
+  }
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleHelpDialogKeydown)
+})
 </script>
 
 <template>
@@ -84,9 +157,29 @@ function handleLogoError() {
         <span aria-hidden="true">⏱</span> {{ t('auth.sessionTimerShort', { minutes: remainingMinutes }) }}
       </span>
       <ThemeSwitcher />
+      <button class="btn-help" @click="openHelpDialog">{{ t('help.open') }}</button>
       <button class="btn-logout" @click="handleLogout">{{ t('auth.logout') }}</button>
     </div>
   </header>
+  <div v-if="showHelpDialog" class="help-overlay" @click.self="closeHelpDialog">
+    <section
+      ref="helpDialogRef"
+      class="help-panel"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="help-modal-title"
+    >
+      <div class="help-panel-header">
+        <div>
+          <p class="help-kicker">{{ t('help.kicker') }}</p>
+          <h2 id="help-modal-title">{{ t('help.title') }}</h2>
+        </div>
+        <button class="btn-help-close" @click="closeHelpDialog">{{ t('common.actions.close') }}</button>
+      </div>
+      <p class="help-description">{{ t('help.description') }}</p>
+      <iframe class="help-frame" :src="'/help/manual.html'" :title="t('help.frameTitle')" loading="lazy" />
+    </section>
+  </div>
 </template>
 
 <style scoped>
@@ -183,5 +276,94 @@ function handleLogoError() {
 
 .btn-logout:hover {
   background: var(--color-bg-hover);
+}
+
+.btn-help,
+.btn-help-close {
+  padding: var(--space-xs) var(--space-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+}
+
+.btn-help:hover,
+.btn-help-close:hover {
+  background: var(--color-bg-hover);
+}
+
+.help-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-lg);
+  background: rgba(15, 23, 42, 0.5);
+  z-index: 1000;
+}
+
+.help-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  width: min(1040px, 100%);
+  height: min(86vh, 820px);
+  padding: var(--space-lg);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-lg);
+}
+
+.help-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.help-kicker {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.help-panel-header h2,
+.help-description {
+  margin: 0;
+}
+
+.help-description {
+  color: var(--color-text-secondary);
+}
+
+.help-frame {
+  flex: 1;
+  width: 100%;
+  min-height: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  background: #fff;
+}
+
+@media (max-width: 840px) {
+  .help-overlay {
+    padding: var(--space-sm);
+  }
+
+  .help-panel {
+    height: min(92vh, 920px);
+    padding: var(--space-md);
+  }
+
+  .help-panel-header {
+    flex-direction: column;
+  }
 }
 </style>

--- a/frontend/src/components/layout/AppHeader.vue
+++ b/frontend/src/components/layout/AppHeader.vue
@@ -13,8 +13,11 @@ const now = ref(Date.now())
 const logoLoadFailed = ref(false)
 const showHelpDialog = ref(false)
 const helpDialogRef = ref(null)
+const helpFrameRef = ref(null)
+const helpCloseButtonRef = ref(null)
 const helpTriggerRef = ref(null)
 let timerInterval = null
+let helpFrameDocument = null
 
 const showLogoImage = computed(() => Boolean(themeStore.currentLogo) && !logoLoadFailed.value)
 
@@ -56,12 +59,53 @@ function handleLogoError() {
 }
 
 function getFocusableElements(container) {
-  if (!(container instanceof HTMLElement)) return []
+  if (!(container instanceof HTMLElement) && !(container instanceof Document)) return []
   return Array.from(
     container.querySelectorAll(
-      'button, [href], input, select, textarea, iframe, [tabindex]:not([tabindex="-1"])',
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
     ),
   ).filter((element) => !element.hasAttribute('disabled') && element.getAttribute('aria-hidden') !== 'true')
+}
+
+function getHelpFrameDocument() {
+  return helpFrameRef.value?.contentDocument ?? null
+}
+
+function focusHelpCloseButton() {
+  if (helpCloseButtonRef.value instanceof HTMLElement) {
+    helpCloseButtonRef.value.focus()
+    return true
+  }
+  return false
+}
+
+function focusHelpContent(position = 'first') {
+  const frameDocument = getHelpFrameDocument()
+  const frameFocusable = getFocusableElements(frameDocument)
+  const target = position === 'last' ? frameFocusable.at(-1) : frameFocusable[0]
+
+  if (target instanceof HTMLElement) {
+    target.focus()
+    return true
+  }
+
+  return false
+}
+
+function detachHelpFrameListeners() {
+  if (helpFrameDocument) {
+    helpFrameDocument.removeEventListener('keydown', handleHelpFrameKeydown)
+    helpFrameDocument = null
+  }
+}
+
+function attachHelpFrameListeners() {
+  const frameDocument = getHelpFrameDocument()
+  if (!frameDocument || frameDocument === helpFrameDocument) return
+
+  detachHelpFrameListeners()
+  frameDocument.addEventListener('keydown', handleHelpFrameKeydown)
+  helpFrameDocument = frameDocument
 }
 
 function trapFocusWithin(event, container) {
@@ -97,22 +141,52 @@ function handleHelpDialogKeydown(event) {
     return
   }
   if (event.key === 'Tab') {
+    if (document.activeElement === helpCloseButtonRef.value) {
+      event.preventDefault()
+      focusHelpContent(event.shiftKey ? 'last' : 'first') || focusHelpCloseButton()
+      return
+    }
+
     trapFocusWithin(event, helpDialogRef.value)
   }
+}
+
+function handleHelpFrameKeydown(event) {
+  if (!showHelpDialog.value) return
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeHelpDialog()
+    return
+  }
+  if (event.key !== 'Tab') return
+
+  const frameDocument = getHelpFrameDocument()
+  const frameFocusable = getFocusableElements(frameDocument)
+  const active = frameDocument?.activeElement
+  const first = frameFocusable[0]
+  const last = frameFocusable.at(-1)
+
+  if (!frameFocusable.length || (event.shiftKey && active === first) || (!event.shiftKey && active === last)) {
+    event.preventDefault()
+    focusHelpCloseButton()
+  }
+}
+
+function handleHelpFrameLoad() {
+  attachHelpFrameListeners()
 }
 
 watch(showHelpDialog, async (open) => {
   if (open) {
     document.addEventListener('keydown', handleHelpDialogKeydown)
     await nextTick()
-    const firstFocusable = getFocusableElements(helpDialogRef.value)[0]
-    if (firstFocusable instanceof HTMLElement) {
-      firstFocusable.focus()
-    }
+    attachHelpFrameListeners()
+    focusHelpCloseButton()
     return
   }
 
   document.removeEventListener('keydown', handleHelpDialogKeydown)
+  detachHelpFrameListeners()
   const trigger = helpTriggerRef.value
   helpTriggerRef.value = null
   await nextTick()
@@ -123,6 +197,7 @@ watch(showHelpDialog, async (open) => {
 
 onUnmounted(() => {
   document.removeEventListener('keydown', handleHelpDialogKeydown)
+  detachHelpFrameListeners()
 })
 </script>
 
@@ -170,9 +245,16 @@ onUnmounted(() => {
       :aria-label="t('help.frameTitle')"
     >
       <p class="help-panel-kicker">{{ t('help.kicker') }}</p>
-      <iframe class="help-frame" :src="'/help/manual.html'" :title="t('help.frameTitle')" loading="lazy" />
+      <iframe
+        ref="helpFrameRef"
+        class="help-frame"
+        :src="'/help/manual.html'"
+        :title="t('help.frameTitle')"
+        loading="lazy"
+        @load="handleHelpFrameLoad"
+      />
       <div class="help-panel-footer">
-        <button class="btn-help-close" @click="closeHelpDialog">{{ t('common.actions.close') }}</button>
+        <button ref="helpCloseButtonRef" class="btn-help-close" @click="closeHelpDialog">{{ t('common.actions.close') }}</button>
       </div>
     </section>
   </div>

--- a/frontend/src/components/layout/__tests__/AppHeader.spec.js
+++ b/frontend/src/components/layout/__tests__/AppHeader.spec.js
@@ -25,6 +25,7 @@ describe('AppHeader help modal', () => {
 
   function mountHeader() {
     return mount(AppHeader, {
+      attachTo: document.body,
       global: {
         plugins: [i18n, pinia],
         stubs: {
@@ -32,6 +33,48 @@ describe('AppHeader help modal', () => {
         },
       },
     })
+  }
+
+  function populateHelpFrame(wrapper) {
+    const iframe = wrapper.get('iframe.help-frame').element
+    const frameDocument = document.implementation.createHTMLDocument('help-frame')
+    let frameActiveElement = frameDocument.body
+
+    Object.defineProperty(iframe, 'contentDocument', {
+      configurable: true,
+      value: frameDocument,
+    })
+
+    Object.defineProperty(frameDocument, 'activeElement', {
+      configurable: true,
+      get() {
+        return frameActiveElement
+      },
+    })
+
+    frameDocument.body.innerHTML = `
+      <a href="#toc" id="frame-first">Table of Contents</a>
+      <a href="#top" id="frame-last">Back to top</a>
+    `
+
+    frameDocument.body.focus = () => {
+      frameActiveElement = frameDocument.body
+    }
+
+    for (const focusable of frameDocument.querySelectorAll('a, button, input, select, textarea, [tabindex]')) {
+      focusable.focus = () => {
+        frameActiveElement = focusable
+      }
+    }
+
+    iframe.dispatchEvent(new Event('load'))
+
+    return {
+      iframe,
+      frameDocument,
+      firstLink: frameDocument.getElementById('frame-first'),
+      lastLink: frameDocument.getElementById('frame-last'),
+    }
   }
 
   it('shows a help trigger and opens the modal iframe', async () => {
@@ -54,6 +97,46 @@ describe('AppHeader help modal', () => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.find('[role="dialog"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('cycles focus between the help content and close button', async () => {
+    const wrapper = mountHeader()
+
+    await wrapper.find('.btn-help').trigger('click')
+    const { firstLink } = populateHelpFrame(wrapper)
+    await wrapper.vm.$nextTick()
+
+    const closeButton = wrapper.get('.btn-help-close').element
+    expect(document.activeElement).toBe(closeButton)
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }))
+    expect(firstLink).toBeTruthy()
+    expect(firstLink.ownerDocument.activeElement).toBe(firstLink)
+
+    firstLink.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true }))
+    expect(document.activeElement).toBe(closeButton)
+
+    wrapper.unmount()
+  })
+
+  it('returns focus to the help trigger after closing from the iframe', async () => {
+    const wrapper = mountHeader()
+    const helpTrigger = wrapper.get('.btn-help')
+
+    helpTrigger.element.focus()
+    await helpTrigger.trigger('click')
+    const { firstLink } = populateHelpFrame(wrapper)
+    await wrapper.vm.$nextTick()
+
+    firstLink.focus()
+    firstLink.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(false)
+    expect(document.activeElement).toBe(helpTrigger.element)
+
     wrapper.unmount()
   })
 })

--- a/frontend/src/components/layout/__tests__/AppHeader.spec.js
+++ b/frontend/src/components/layout/__tests__/AppHeader.spec.js
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import i18n from '@/i18n/index.js'
+import AppHeader from '@/components/layout/AppHeader.vue'
+import { useAuthStore } from '@/stores/auth.js'
+
+describe('AppHeader help modal', () => {
+  let pinia
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    pinia = createPinia()
+    setActivePinia(pinia)
+
+    const authStore = useAuthStore()
+    authStore.username = 'processor01'
+    authStore.roles = ['processor']
+    authStore.expiresAt = Date.now() + 10 * 60 * 1000
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function mountHeader() {
+    return mount(AppHeader, {
+      global: {
+        plugins: [i18n, pinia],
+        stubs: {
+          ThemeSwitcher: true,
+        },
+      },
+    })
+  }
+
+  it('shows a help trigger and opens the modal iframe', async () => {
+    const wrapper = mountHeader()
+
+    await wrapper.find('.btn-help').trigger('click')
+
+    const dialog = wrapper.get('[role="dialog"]')
+    expect(dialog.attributes('aria-modal')).toBe('true')
+    const iframe = wrapper.get('iframe.help-frame')
+    expect(iframe.attributes('src')).toBe('/help/manual.html')
+    wrapper.unmount()
+  })
+
+  it('closes the help modal on Escape', async () => {
+    const wrapper = mountHeader()
+
+    await wrapper.find('.btn-help').trigger('click')
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -33,6 +33,13 @@
     "sessionExpiresIn": "Session expires in {minutes} minute | Session expires in {minutes} minutes",
     "sessionTimerShort": "{minutes}m"
   },
+  "help": {
+    "open": "Help",
+    "title": "How To Use ECUBE",
+    "kicker": "User Guide",
+    "description": "This in-app guide is generated from the user manual so the packaged help stays aligned with the reviewed documentation.",
+    "frameTitle": "ECUBE help manual"
+  },
   "drives": {
     "title": "Drives",
     "detail": "Drive Detail",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -35,9 +35,7 @@
   },
   "help": {
     "open": "Help",
-    "title": "How To Use ECUBE",
-    "kicker": "User Guide",
-    "description": "This in-app guide is generated from the user manual so the packaged help stays aligned with the reviewed documentation.",
+    "kicker": "Online Help",
     "frameTitle": "ECUBE help manual"
   },
   "drives": {

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,0 @@
-{"version":"4.1.2","results":[[":frontend/src/components/layout/__tests__/AppHeader.spec.js",{"duration":0,"failed":true}]]}

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,0 +1,1 @@
+{"version":"4.1.2","results":[[":frontend/src/components/layout/__tests__/AppHeader.spec.js",{"duration":0,"failed":true}]]}

--- a/scripts/build-help.mjs
+++ b/scripts/build-help.mjs
@@ -1,0 +1,513 @@
+#!/usr/bin/env node
+
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { constants as fsConstants } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptPath = fileURLToPath(import.meta.url)
+const repoRoot = resolve(dirname(scriptPath), '..')
+const defaultSourcePath = resolve(repoRoot, 'docs/operations/13-user-manual.md')
+const defaultOutputPath = resolve(repoRoot, 'frontend/public/help/manual.html')
+
+function parseArgs(argv) {
+  const options = {
+    source: defaultSourcePath,
+    output: defaultOutputPath,
+    check: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--check') {
+      options.check = true
+      continue
+    }
+    if (arg === '--source') {
+      const value = argv[index + 1]
+      if (!value || value.startsWith('--')) {
+        throw new Error('--source requires a path value')
+      }
+      options.source = resolve(repoRoot, value)
+      index += 1
+      continue
+    }
+    if (arg === '--output') {
+      const value = argv[index + 1]
+      if (!value || value.startsWith('--')) {
+        throw new Error('--output requires a path value')
+      }
+      options.output = resolve(repoRoot, value)
+      index += 1
+      continue
+    }
+    if (arg === '-h' || arg === '--help') {
+      printUsage()
+      process.exit(0)
+    }
+    throw new Error(`Unknown option: ${arg}`)
+  }
+
+  return options
+}
+
+function printUsage() {
+  process.stdout.write(`Usage: node scripts/build-help.mjs [--check] [--source PATH] [--output PATH]\n\n`)
+}
+
+function escapeHtml(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function renderInline(value) {
+  let rendered = escapeHtml(value)
+  rendered = rendered.replace(/`([^`]+)`/g, '<code>$1</code>')
+  rendered = rendered.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+  rendered = rendered.replace(/\*([^*]+)\*/g, '<em>$1</em>')
+  rendered = rendered.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label, href) => {
+    if (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('#')) {
+      return `<a href="${escapeHtml(href)}">${escapeHtml(label)}</a>`
+    }
+    return escapeHtml(label)
+  })
+  return rendered
+}
+
+function parseMetadata(markdown) {
+  const updatedMatch = markdown.match(/\|\s*Updated on\s*\|\s*([^|]+)\|/)
+  return {
+    updatedOn: updatedMatch ? updatedMatch[1].trim() : '',
+  }
+}
+
+function curateMarkdown(markdown) {
+  const excludedSections = new Set(['Table of Contents', '1. Installation Options'])
+  const excludedSubsections = new Set(['4.1 First-Run Setup Screen'])
+  const curated = []
+  const lines = markdown.split(/\r?\n/)
+  let skippingTitleBlock = true
+  let skipUntilNextHeadingLevel = null
+
+  for (const line of lines) {
+    if (skippingTitleBlock) {
+      if (line.startsWith('## ')) {
+        skippingTitleBlock = false
+      } else {
+        continue
+      }
+    }
+
+    const headingMatch = line.match(/^(#{2,4})\s+(.*)$/)
+    if (headingMatch) {
+      const headingLevel = headingMatch[1].length
+      const headingText = headingMatch[2].trim()
+      if (skipUntilNextHeadingLevel !== null && headingLevel <= skipUntilNextHeadingLevel) {
+        skipUntilNextHeadingLevel = null
+      }
+      if (excludedSections.has(headingText) || excludedSubsections.has(headingText)) {
+        skipUntilNextHeadingLevel = headingLevel
+        continue
+      }
+    }
+
+    if (skipUntilNextHeadingLevel !== null) {
+      continue
+    }
+
+    if (line.startsWith('![')) {
+      continue
+    }
+
+    curated.push(line)
+  }
+
+  return curated.join('\n').trim()
+}
+
+function renderMarkdown(markdown) {
+  const lines = markdown.split(/\r?\n/)
+  const output = []
+  const listStack = []
+  let paragraph = []
+  let inCodeBlock = false
+  let codeLines = []
+  let tableState = null
+
+  function flushParagraph() {
+    if (!paragraph.length) return
+    output.push(`<p>${renderInline(paragraph.join(' '))}</p>`)
+    paragraph = []
+  }
+
+  function closeLists(targetDepth = 0) {
+    while (listStack.length > targetDepth) {
+      const tag = listStack.pop()
+      output.push(`</li></${tag}>`)
+    }
+  }
+
+  function flushTable() {
+    if (!tableState) return
+    const [headerRow, ...bodyRows] = tableState.rows
+    output.push('<table><thead><tr>')
+    for (const cell of headerRow) {
+      output.push(`<th>${renderInline(cell)}</th>`)
+    }
+    output.push('</tr></thead>')
+    if (bodyRows.length) {
+      output.push('<tbody>')
+      for (const row of bodyRows) {
+        output.push('<tr>')
+        for (const cell of row) {
+          output.push(`<td>${renderInline(cell)}</td>`)
+        }
+        output.push('</tr>')
+      }
+      output.push('</tbody>')
+    }
+    output.push('</table>')
+    tableState = null
+  }
+
+  function ensureList(depth, tag) {
+    while (listStack.length < depth + 1) {
+      listStack.push(tag)
+      output.push(`<${tag}><li>`)
+    }
+    while (listStack.length > depth + 1) {
+      const closingTag = listStack.pop()
+      output.push(`</li></${closingTag}>`)
+    }
+    if (listStack[listStack.length - 1] !== tag) {
+      const closingTag = listStack.pop()
+      output.push(`</li></${closingTag}>`)
+      listStack.push(tag)
+      output.push(`<${tag}><li>`)
+      return
+    }
+    if (!output.at(-1)?.endsWith('<li>')) {
+      output.push('</li><li>')
+    }
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\t/g, '    ')
+
+    if (inCodeBlock) {
+      if (line.startsWith('```')) {
+        output.push(`<pre><code>${escapeHtml(codeLines.join('\n'))}</code></pre>`)
+        codeLines = []
+        inCodeBlock = false
+      } else {
+        codeLines.push(rawLine)
+      }
+      continue
+    }
+
+    if (line.startsWith('```')) {
+      flushParagraph()
+      flushTable()
+      closeLists()
+      inCodeBlock = true
+      codeLines = []
+      continue
+    }
+
+    if (!line.trim()) {
+      flushParagraph()
+      flushTable()
+      closeLists()
+      continue
+    }
+
+    if (/^\|/.test(line) && /\|$/.test(line.trim())) {
+      flushParagraph()
+      closeLists()
+      const cells = line
+        .trim()
+        .slice(1, -1)
+        .split('|')
+        .map((cell) => cell.trim())
+      if (cells.every((cell) => /^:?-{3,}:?$/.test(cell))) {
+        if (!tableState) {
+          throw new Error('Markdown table separator found before header row')
+        }
+        tableState.separatorSeen = true
+      } else {
+        if (!tableState) {
+          tableState = { rows: [], separatorSeen: false }
+        }
+        tableState.rows.push(cells)
+      }
+      continue
+    }
+
+    flushTable()
+
+    const headingMatch = line.match(/^(#{2,4})\s+(.*)$/)
+    if (headingMatch) {
+      flushParagraph()
+      closeLists()
+      const level = headingMatch[1].length
+      const text = headingMatch[2].trim()
+      const id = slugify(text)
+      output.push(`<h${level - 1} id="${id}">${renderInline(text)}</h${level - 1}>`)
+      continue
+    }
+
+    if (/^---+$/.test(line.trim())) {
+      flushParagraph()
+      closeLists()
+      output.push('<hr />')
+      continue
+    }
+
+    if (line.startsWith('> ')) {
+      flushParagraph()
+      closeLists()
+      output.push(`<blockquote><p>${renderInline(line.slice(2).trim())}</p></blockquote>`)
+      continue
+    }
+
+    const listMatch = line.match(/^(\s*)([-*]|\d+\.)\s+(.*)$/)
+    if (listMatch) {
+      flushParagraph()
+      const depth = Math.floor(listMatch[1].length / 2)
+      const tag = /\d+\./.test(listMatch[2]) ? 'ol' : 'ul'
+      ensureList(depth, tag)
+      output.push(renderInline(listMatch[3].trim()))
+      continue
+    }
+
+    paragraph.push(line.trim())
+  }
+
+  if (inCodeBlock) {
+    output.push(`<pre><code>${escapeHtml(codeLines.join('\n'))}</code></pre>`)
+  }
+  flushParagraph()
+  flushTable()
+  closeLists()
+  return output.join('\n')
+}
+
+function buildHtml(markdown, metadata) {
+  const curated = curateMarkdown(markdown)
+  const body = renderMarkdown(curated)
+  const updatedLabel = metadata.updatedOn ? `<p class="help-meta">Updated: ${escapeHtml(metadata.updatedOn)}</p>` : ''
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ECUBE Help</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --help-bg: #f4efe7;
+        --help-panel: #fffdf8;
+        --help-border: #d8cbb7;
+        --help-text: #2f261b;
+        --help-muted: #6b5f51;
+        --help-accent: #0f5c4d;
+        --help-accent-soft: #e2f0ec;
+        --help-code-bg: #f1e7d8;
+        --help-shadow: 0 18px 48px rgba(47, 38, 27, 0.12);
+        --help-radius: 18px;
+        --help-font: Georgia, 'Times New Roman', serif;
+        --help-ui-font: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      }
+
+      * { box-sizing: border-box; }
+
+      body {
+        margin: 0;
+        padding: 24px;
+        background:
+          radial-gradient(circle at top left, rgba(15, 92, 77, 0.08), transparent 30%),
+          linear-gradient(180deg, #f8f3ec 0%, var(--help-bg) 100%);
+        color: var(--help-text);
+        font-family: var(--help-font);
+        line-height: 1.6;
+      }
+
+      main {
+        max-width: 920px;
+        margin: 0 auto;
+        padding: 32px;
+        background: var(--help-panel);
+        border: 1px solid var(--help-border);
+        border-radius: var(--help-radius);
+        box-shadow: var(--help-shadow);
+      }
+
+      .help-kicker {
+        margin: 0;
+        font-family: var(--help-ui-font);
+        font-size: 0.8rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--help-accent);
+      }
+
+      h1 {
+        margin: 0.35rem 0 0.25rem;
+        font-size: clamp(2rem, 3vw, 3rem);
+        line-height: 1.1;
+      }
+
+      .help-meta,
+      .help-lead {
+        margin: 0.25rem 0 0;
+        font-family: var(--help-ui-font);
+        color: var(--help-muted);
+      }
+
+      h1,
+      h2,
+      h3,
+      h4 {
+        color: #1e1a14;
+      }
+
+      h2,
+      h3,
+      h4 {
+        margin-top: 2rem;
+        font-family: var(--help-ui-font);
+      }
+
+      a {
+        color: var(--help-accent);
+      }
+
+      hr {
+        border: 0;
+        border-top: 1px solid var(--help-border);
+        margin: 2rem 0;
+      }
+
+      blockquote {
+        margin: 1rem 0;
+        padding: 0.9rem 1rem;
+        border-left: 4px solid var(--help-accent);
+        background: var(--help-accent-soft);
+        border-radius: 0 12px 12px 0;
+        font-family: var(--help-ui-font);
+      }
+
+      code,
+      pre {
+        font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+      }
+
+      code {
+        padding: 0.1rem 0.3rem;
+        background: var(--help-code-bg);
+        border-radius: 4px;
+      }
+
+      pre {
+        overflow-x: auto;
+        padding: 1rem;
+        background: #2f261b;
+        color: #fff8ee;
+        border-radius: 14px;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+        font-family: var(--help-ui-font);
+      }
+
+      th,
+      td {
+        padding: 0.75rem;
+        border: 1px solid var(--help-border);
+        text-align: left;
+        vertical-align: top;
+      }
+
+      th {
+        background: #f1e7d8;
+      }
+
+      ul,
+      ol {
+        padding-left: 1.5rem;
+      }
+
+      @media (max-width: 720px) {
+        body {
+          padding: 12px;
+        }
+
+        main {
+          padding: 20px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p class="help-kicker">In-App Help</p>
+      <h1>ECUBE User Guide</h1>
+      ${updatedLabel}
+      <p class="help-lead">Generated from docs/operations/13-user-manual.md for authenticated in-app help.</p>
+      ${body}
+    </main>
+  </body>
+</html>
+`
+}
+
+async function ensureReadable(path) {
+  try {
+    await access(path, fsConstants.R_OK)
+  } catch {
+    throw new Error(`Required file not found or unreadable: ${path}`)
+  }
+}
+
+async function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2))
+    await ensureReadable(options.source)
+    const markdown = await readFile(options.source, 'utf8')
+    const html = buildHtml(markdown, parseMetadata(markdown))
+
+    if (options.check) {
+      await ensureReadable(options.output)
+      const existing = await readFile(options.output, 'utf8')
+      if (existing !== html) {
+        process.stderr.write(`ERROR: ${options.output} is out of date. Run node scripts/build-help.mjs and review the generated help before packaging.\n`)
+        process.exit(1)
+      }
+      process.stdout.write(`verified: ${options.output}\n`)
+      return
+    }
+
+    await mkdir(dirname(options.output), { recursive: true })
+    await writeFile(options.output, html, 'utf8')
+    process.stdout.write(`generated: ${options.output}\n`)
+  } catch (error) {
+    process.stderr.write(`ERROR: ${error.message}\n`)
+    process.exit(1)
+  }
+}
+
+await main()

--- a/scripts/build-help.mjs
+++ b/scripts/build-help.mjs
@@ -110,8 +110,16 @@ function parseMetadata(markdown) {
 }
 
 function curateMarkdown(markdown) {
-  const excludedSections = new Set(['Table of Contents', '1. Installation Options', 'References'])
-  const excludedSubsections = new Set(['4.1 First-Run Setup Screen'])
+  const excludedSections = new Set([
+    'Table of Contents',
+    'Purpose',
+    'Scope',
+    '1. Installation Options',
+    '2. Before You Begin',
+    '4. First Access',
+    'References',
+  ])
+  const excludedSubsections = new Set()
   const curated = []
   const lines = markdown.split(/\r?\n/)
   let skippingTitleBlock = true
@@ -153,6 +161,84 @@ function curateMarkdown(markdown) {
   return curated.join('\n').trim()
 }
 
+function parseNumberedHeading(text) {
+  const match = text.trim().match(/^(\d+)((?:\.[0-9A-Za-z]+)*)\.?\s+(.+)$/)
+  if (!match) {
+    return null
+  }
+
+  return {
+    major: Number.parseInt(match[1], 10),
+    suffix: match[2] ?? '',
+    title: match[3].trim(),
+  }
+}
+
+function renumberCuratedMarkdown(markdown) {
+  const lines = markdown.split(/\r?\n/)
+  const headingIdMap = new Map()
+  const headingTextMap = new Map()
+  const majorNumberMap = new Map()
+  let nextMajorNumber = 1
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{2,4})\s+(.*)$/)
+    if (!headingMatch || headingMatch[1].length !== 2) {
+      continue
+    }
+
+    const numberedHeading = parseNumberedHeading(headingMatch[2].trim())
+    if (!numberedHeading) {
+      continue
+    }
+
+    if (!majorNumberMap.has(numberedHeading.major)) {
+      majorNumberMap.set(numberedHeading.major, nextMajorNumber)
+      nextMajorNumber += 1
+    }
+  }
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{2,4})\s+(.*)$/)
+    if (!headingMatch) {
+      continue
+    }
+
+    const originalText = headingMatch[2].trim()
+    const numberedHeading = parseNumberedHeading(originalText)
+    if (!numberedHeading) {
+      continue
+    }
+
+    const renumberedMajor = majorNumberMap.get(numberedHeading.major)
+    const renumberedText = numberedHeading.suffix
+      ? `${renumberedMajor}${numberedHeading.suffix} ${numberedHeading.title}`
+      : `${renumberedMajor}. ${numberedHeading.title}`
+    headingTextMap.set(originalText, renumberedText)
+    headingIdMap.set(slugify(originalText), slugify(renumberedText))
+  }
+
+  return lines
+    .map((line) => {
+      const headingMatch = line.match(/^(#{2,4})\s+(.*)$/)
+      if (headingMatch) {
+        const originalText = headingMatch[2].trim()
+        const renumberedText = headingTextMap.get(originalText)
+        if (renumberedText) {
+          return `${headingMatch[1]} ${renumberedText}`
+        }
+      }
+
+      return line.replace(/\[([^\]]+)\]\((#[^)]+)\)/g, (_match, label, href) => {
+        const originalId = href.slice(1)
+        const updatedHref = headingIdMap.has(originalId) ? `#${headingIdMap.get(originalId)}` : href
+        const updatedLabel = headingTextMap.get(label) ?? label
+        return `[${updatedLabel}](${updatedHref})`
+      })
+    })
+    .join('\n')
+}
+
 function renderMarkdown(markdown) {
   const lines = markdown.split(/\r?\n/)
   const output = []
@@ -161,6 +247,7 @@ function renderMarkdown(markdown) {
   let inCodeBlock = false
   let codeLines = []
   let tableState = null
+  const backToTopHtml = '<p class="help-back-to-top"><a href="#help-toc-title">Back to top</a></p>'
 
   function flushParagraph() {
     if (!paragraph.length) return
@@ -287,6 +374,7 @@ function renderMarkdown(markdown) {
     if (/^---+$/.test(line.trim())) {
       flushParagraph()
       closeLists()
+      output.push(backToTopHtml)
       output.push('<hr />')
       continue
     }
@@ -317,6 +405,9 @@ function renderMarkdown(markdown) {
   flushParagraph()
   flushTable()
   closeLists()
+  if (output.length && output.at(-1) !== '<hr />') {
+    output.push(backToTopHtml)
+  }
   return output.join('\n')
 }
 
@@ -325,6 +416,11 @@ function extractHeadings(markdown) {
     .split(/\r?\n/)
     .map((line) => line.match(/^(#{2,4})\s+(.*)$/))
     .filter(Boolean)
+    .filter((match) => match[1].length === 2)
+    .filter((match) => {
+      const numberedHeading = parseNumberedHeading(match[2].trim())
+      return !numberedHeading || numberedHeading.suffix === ''
+    })
     .map((match) => ({
       level: match[1].length - 1,
       text: match[2].trim(),
@@ -344,11 +440,8 @@ function renderTableOfContents(headings) {
     )
     .join('\n')
 
-  return `<nav class="help-toc" aria-labelledby="help-toc-title">
-        <div class="help-toc-header">
-          <h2 id="help-toc-title">Quick Index</h2>
-          <p>Jump directly to a task or section.</p>
-        </div>
+    return `<nav class="help-toc" aria-labelledby="help-toc-title">
+      <h2 id="help-toc-title">Table of Contents</h2>
         <ol>
 ${items}
         </ol>
@@ -356,65 +449,97 @@ ${items}
 }
 
 function buildHtml(markdown, metadata) {
-  const curated = curateMarkdown(markdown)
+  const curated = renumberCuratedMarkdown(curateMarkdown(markdown))
   const headings = extractHeadings(curated)
   const body = renderMarkdown(curated)
   const toc = renderTableOfContents(headings)
-  const updatedLabel = metadata.updatedOn ? `<p class="help-meta">Updated: ${escapeHtml(metadata.updatedOn)}</p>` : ''
   return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>ECUBE Help</title>
+    <link id="ecube-theme-stylesheet" rel="stylesheet" href="../themes/default.css" />
+    <script>
+      (() => {
+        const themeStorageKey = 'ecube_theme'
+        const validThemeName = /^[a-z0-9][a-z0-9-]*$/
+        let themeName = 'default'
+
+        try {
+          const storedTheme = localStorage.getItem(themeStorageKey)
+          if (storedTheme && validThemeName.test(storedTheme)) {
+            themeName = storedTheme
+          }
+        } catch {
+          // Ignore storage access failures and keep the default theme.
+        }
+
+        const themeLink = document.getElementById('ecube-theme-stylesheet')
+        if (themeLink) {
+          themeLink.href = '../themes/' + themeName + '.css'
+        }
+      })()
+    </script>
     <style>
       :root {
-        color-scheme: light;
-        --help-bg: #f4efe7;
-        --help-panel: #fffdf8;
-        --help-border: #d8cbb7;
-        --help-text: #2f261b;
-        --help-muted: #6b5f51;
-        --help-accent: #0f5c4d;
-        --help-accent-soft: #e2f0ec;
-        --help-code-bg: #f1e7d8;
-        --help-shadow: 0 18px 48px rgba(47, 38, 27, 0.12);
-        --help-radius: 18px;
-        --help-font: Georgia, 'Times New Roman', serif;
-        --help-ui-font: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        color-scheme: light dark;
+        --help-bg: var(--color-bg-secondary, #f8f9fa);
+        --help-panel: var(--color-bg-primary, #ffffff);
+        --help-border: var(--color-border, #e2e8f0);
+        --help-text: var(--color-text-primary, #1e293b);
+        --help-muted: var(--color-text-secondary, #64748b);
+        --help-accent: var(--color-text-link, #2563eb);
+        --help-accent-soft: var(--color-bg-selected, #dbeafe);
+        --help-code-bg: var(--color-bg-hover, #e2e8f0);
+        --help-shadow: var(--shadow-lg, 0 10px 15px rgba(0, 0, 0, 0.1));
+        --help-radius: var(--border-radius-lg, 8px);
+        --help-font: var(--font-family, 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+        --help-ui-font: var(--font-family, 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
       }
 
       * { box-sizing: border-box; }
 
+      html {
+        overflow-y: scroll;
+        scrollbar-gutter: stable;
+        scrollbar-width: auto;
+        scrollbar-color: var(--color-border) var(--color-bg-secondary);
+      }
+
       body {
         margin: 0;
-        padding: 24px;
-        background:
-          radial-gradient(circle at top left, rgba(15, 92, 77, 0.08), transparent 30%),
-          linear-gradient(180deg, #f8f3ec 0%, var(--help-bg) 100%);
+        padding: 0;
+        background: var(--help-panel);
         color: var(--help-text);
         font-family: var(--help-font);
         line-height: 1.6;
+      }
+
+      html::-webkit-scrollbar {
+        width: 12px;
+        height: 12px;
+      }
+
+      html::-webkit-scrollbar-track {
+        background: var(--color-bg-secondary);
+        border-left: 1px solid var(--color-border);
+      }
+
+      html::-webkit-scrollbar-thumb {
+        background: var(--color-border);
+        border-radius: 999px;
+        border: 2px solid var(--color-bg-secondary);
+      }
+
+      html::-webkit-scrollbar-thumb:hover {
+        background: var(--color-text-secondary);
       }
 
       main {
         max-width: 920px;
         margin: 0 auto;
         padding: 32px;
-        background: var(--help-panel);
-        border: 1px solid var(--help-border);
-        border-radius: var(--help-radius);
-        box-shadow: var(--help-shadow);
-      }
-
-      .help-kicker {
-        margin: 0;
-        font-family: var(--help-ui-font);
-        font-size: 0.8rem;
-        font-weight: 700;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        color: var(--help-accent);
       }
 
       h1 {
@@ -423,40 +548,19 @@ function buildHtml(markdown, metadata) {
         line-height: 1.1;
       }
 
-      .help-meta,
-      .help-lead {
-        margin: 0.25rem 0 0;
-        font-family: var(--help-ui-font);
-        color: var(--help-muted);
-      }
-
       .help-toc {
         margin: 1.5rem 0 2rem;
-        padding: 1rem 1.25rem;
-        background: #f7f1e6;
-        border: 1px solid var(--help-border);
-        border-radius: 14px;
+        padding: 0;
       }
 
-      .help-toc-header {
-        margin-bottom: 0.75rem;
-      }
-
-      .help-toc-header h2,
-      .help-toc-header p {
-        margin: 0;
-      }
-
-      .help-toc-header p {
-        margin-top: 0.25rem;
-        font-family: var(--help-ui-font);
-        color: var(--help-muted);
+      .help-toc h2 {
+        margin: 0 0 0.75rem;
+        font-size: clamp(2rem, 3vw, 3rem);
+        line-height: 1.1;
       }
 
       .help-toc ol {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 0.35rem 1.5rem;
+        display: block;
         margin: 0;
         padding: 0;
         list-style: none;
@@ -464,6 +568,7 @@ function buildHtml(markdown, metadata) {
 
       .help-toc li {
         font-family: var(--help-ui-font);
+        margin: 0.25rem 0;
       }
 
       .help-toc .toc-level-3,
@@ -472,7 +577,6 @@ function buildHtml(markdown, metadata) {
       }
 
       .help-toc a {
-        display: inline-block;
         text-decoration: none;
       }
 
@@ -481,11 +585,27 @@ function buildHtml(markdown, metadata) {
         text-decoration: underline;
       }
 
+      .help-back-to-top {
+        margin: 1.5rem 0 0.75rem;
+        font-family: var(--help-ui-font);
+        font-size: 0.95rem;
+        text-align: right;
+      }
+
+      .help-back-to-top a {
+        text-decoration: none;
+      }
+
+      .help-back-to-top a:hover,
+      .help-back-to-top a:focus-visible {
+        text-decoration: underline;
+      }
+
       h1,
       h2,
       h3,
       h4 {
-        color: #1e1a14;
+        color: var(--help-text);
       }
 
       h2,
@@ -528,8 +648,8 @@ function buildHtml(markdown, metadata) {
       pre {
         overflow-x: auto;
         padding: 1rem;
-        background: #2f261b;
-        color: #fff8ee;
+        background: var(--color-bg-sidebar, #1e293b);
+        color: var(--help-text);
         border-radius: 14px;
       }
 
@@ -549,7 +669,7 @@ function buildHtml(markdown, metadata) {
       }
 
       th {
-        background: #f1e7d8;
+        background: var(--help-bg);
       }
 
       ul,
@@ -558,10 +678,6 @@ function buildHtml(markdown, metadata) {
       }
 
       @media (max-width: 720px) {
-        body {
-          padding: 12px;
-        }
-
         main {
           padding: 20px;
         }
@@ -570,10 +686,6 @@ function buildHtml(markdown, metadata) {
   </head>
   <body>
     <main>
-      <p class="help-kicker">In-App Help</p>
-      <h1>ECUBE User Guide</h1>
-      ${updatedLabel}
-      <p class="help-lead">Task-focused guidance for signed-in ECUBE users.</p>
       ${toc}
       ${body}
     </main>

--- a/scripts/build-help.mjs
+++ b/scripts/build-help.mjs
@@ -174,6 +174,16 @@ function parseNumberedHeading(text) {
   }
 }
 
+function getRenderedHeadingLevel(markdownHeadingLevel, headingText) {
+  const numberedHeading = parseNumberedHeading(headingText)
+  if (!numberedHeading) {
+    return Math.max(1, markdownHeadingLevel - 1)
+  }
+
+  const subsectionDepth = numberedHeading.suffix ? numberedHeading.suffix.split('.').filter(Boolean).length : 0
+  return Math.min(4, subsectionDepth + 1)
+}
+
 function renumberCuratedMarkdown(markdown) {
   const lines = markdown.split(/\r?\n/)
   const headingIdMap = new Map()
@@ -364,10 +374,10 @@ function renderMarkdown(markdown) {
     if (headingMatch) {
       flushParagraph()
       closeLists()
-      const level = headingMatch[1].length
       const text = headingMatch[2].trim()
       const id = slugify(text)
-      output.push(`<h${level - 1} id="${id}">${renderInline(text)}</h${level - 1}>`)
+      const level = getRenderedHeadingLevel(headingMatch[1].length, text)
+      output.push(`<h${level} id="${id}">${renderInline(text)}</h${level}>`)
       continue
     }
 

--- a/scripts/build-help.mjs
+++ b/scripts/build-help.mjs
@@ -79,9 +79,27 @@ function renderInline(value) {
     if (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('#')) {
       return `<a href="${escapeHtml(href)}">${escapeHtml(label)}</a>`
     }
-    return escapeHtml(label)
+    return escapeHtml(formatDocReference(label, href))
   })
   return rendered
+}
+
+function formatDocReference(label, href) {
+  const candidate = label && label !== href ? label : href
+  const basename = candidate.split('/').pop() ?? candidate
+  const withoutExtension = basename.replace(/\.md$/i, '')
+  const withoutNumericPrefix = withoutExtension.replace(/^\d+[-_]?/, '')
+  const normalized = withoutNumericPrefix
+    .replace(/[-_]+/g, ' ')
+    .replace(/\bapi\b/gi, 'API')
+    .replace(/\becube\b/gi, 'ECUBE')
+    .trim()
+
+  if (!normalized) {
+    return 'related documentation'
+  }
+
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1)
 }
 
 function parseMetadata(markdown) {
@@ -92,7 +110,7 @@ function parseMetadata(markdown) {
 }
 
 function curateMarkdown(markdown) {
-  const excludedSections = new Set(['Table of Contents', '1. Installation Options'])
+  const excludedSections = new Set(['Table of Contents', '1. Installation Options', 'References'])
   const excludedSubsections = new Set(['4.1 First-Run Setup Screen'])
   const curated = []
   const lines = markdown.split(/\r?\n/)
@@ -302,9 +320,46 @@ function renderMarkdown(markdown) {
   return output.join('\n')
 }
 
+function extractHeadings(markdown) {
+  return markdown
+    .split(/\r?\n/)
+    .map((line) => line.match(/^(#{2,4})\s+(.*)$/))
+    .filter(Boolean)
+    .map((match) => ({
+      level: match[1].length - 1,
+      text: match[2].trim(),
+      id: slugify(match[2].trim()),
+    }))
+}
+
+function renderTableOfContents(headings) {
+  if (!headings.length) {
+    return ''
+  }
+
+  const items = headings
+    .map(
+      (heading) =>
+        `<li class="toc-level-${heading.level}"><a href="#${heading.id}">${escapeHtml(heading.text)}</a></li>`,
+    )
+    .join('\n')
+
+  return `<nav class="help-toc" aria-labelledby="help-toc-title">
+        <div class="help-toc-header">
+          <h2 id="help-toc-title">Quick Index</h2>
+          <p>Jump directly to a task or section.</p>
+        </div>
+        <ol>
+${items}
+        </ol>
+      </nav>`
+}
+
 function buildHtml(markdown, metadata) {
   const curated = curateMarkdown(markdown)
+  const headings = extractHeadings(curated)
   const body = renderMarkdown(curated)
+  const toc = renderTableOfContents(headings)
   const updatedLabel = metadata.updatedOn ? `<p class="help-meta">Updated: ${escapeHtml(metadata.updatedOn)}</p>` : ''
   return `<!doctype html>
 <html lang="en">
@@ -373,6 +428,57 @@ function buildHtml(markdown, metadata) {
         margin: 0.25rem 0 0;
         font-family: var(--help-ui-font);
         color: var(--help-muted);
+      }
+
+      .help-toc {
+        margin: 1.5rem 0 2rem;
+        padding: 1rem 1.25rem;
+        background: #f7f1e6;
+        border: 1px solid var(--help-border);
+        border-radius: 14px;
+      }
+
+      .help-toc-header {
+        margin-bottom: 0.75rem;
+      }
+
+      .help-toc-header h2,
+      .help-toc-header p {
+        margin: 0;
+      }
+
+      .help-toc-header p {
+        margin-top: 0.25rem;
+        font-family: var(--help-ui-font);
+        color: var(--help-muted);
+      }
+
+      .help-toc ol {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 0.35rem 1.5rem;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .help-toc li {
+        font-family: var(--help-ui-font);
+      }
+
+      .help-toc .toc-level-3,
+      .help-toc .toc-level-4 {
+        padding-left: 1rem;
+      }
+
+      .help-toc a {
+        display: inline-block;
+        text-decoration: none;
+      }
+
+      .help-toc a:hover,
+      .help-toc a:focus-visible {
+        text-decoration: underline;
       }
 
       h1,
@@ -467,7 +573,8 @@ function buildHtml(markdown, metadata) {
       <p class="help-kicker">In-App Help</p>
       <h1>ECUBE User Guide</h1>
       ${updatedLabel}
-      <p class="help-lead">Generated from docs/operations/13-user-manual.md for authenticated in-app help.</p>
+      <p class="help-lead">Task-focused guidance for signed-in ECUBE users.</p>
+      ${toc}
       ${body}
     </main>
   </body>

--- a/scripts/package-local.sh
+++ b/scripts/package-local.sh
@@ -99,10 +99,11 @@ require_cmd sha256sum
 
 if [[ "${SKIP_FRONTEND_BUILD}" == false ]]; then
   require_cmd npm
-  echo "==> Building frontend (npm ci && npm run build)"
+  echo "==> Verifying generated help and building frontend"
   (
     cd frontend
     npm ci
+    npm run build:help:check
     npm run build
   )
 else


### PR DESCRIPTION
Summary

This branch turns the ECUBE Help modal into a curated, generated in-app help experience with explicit development and packaging support. It makes the help content theme-aware, simplifies the modal chrome, improves navigation inside the help document, and documents how the generated help asset is built and kept current.

Changes included

- Added a dedicated help generator in `scripts/build-help.mjs` that curates the canonical user manual into packaged in-app help HTML.
- Updated generated help behavior to:
  - remove non-helpful manual sections from the in-app version
  - renumber curated sections
  - limit the Table of Contents to true top-level sections
  - restore a visible `Table of Contents` heading
  - add `Back to top` links at section boundaries
  - make the help document theme-aware
  - align help scrollbar styling with existing frontend precedent
- Added the packaged help asset at `frontend/public/help/manual.html` and wired frontend builds to keep it current.
- Updated `frontend/package.json` and `scripts/package-local.sh` so packaging/build flows verify or regenerate the help asset before building.
- Added a Help modal to `frontend/src/components/layout/AppHeader.vue` with:
  - a Help trigger in the app header
  - focus trapping and Escape-to-close behavior
  - iframe-based loading of the generated help asset
  - simplified modal chrome with the `Online Help` label in the non-scrolling shell
  - close action positioned in the modal footer
- Updated frontend copy in `frontend/src/i18n/locales/en.json` to support the modal help shell.
- Added and updated focused frontend tests for both the generated help asset and modal behavior.
- Added development and README documentation describing the in-app help workflow, source of truth, generator, and verification steps.
- Added agent/rules guidance so future UI work matches existing component styling patterns instead of inventing new variants.

User-facing or operator-facing effects

- Signed-in users now get a more polished in-app Help experience with a simplified modal and curated, easier-to-scan content.
- The help content now follows ECUBE theming, including scrollbar treatment and modal styling alignment with existing UI patterns.
- Operators and developers now have a documented workflow for updating the in-app help and ensuring packaging uses the current generated asset.

Validation

- `node scripts/build-help.mjs`
- `node scripts/build-help.mjs --check`
- `cd frontend && npx vitest run src/build/__tests__/helpAsset.spec.js --coverage.enabled=false`
- `cd frontend && npx vitest run src/components/layout/__tests__/AppHeader.spec.js --coverage.enabled=false`

Notes

- The branch diff also includes `node_modules/.vite/.../results.json`, which appears to be generated test output rather than intentional product behavior.