### PR TITLE
Remove retired job debug diagnostics and align supporting tests

### DIFF
--- a/app/routers/introspection.py
+++ b/app/routers/introspection.py
@@ -56,7 +56,6 @@ from app.schemas.errors import R_401, R_403, R_404, R_409, R_422, R_500
 from app.schemas.introspection import (
     BlockDevicesResponse,
     IntrospectionDrivesResponse,
-    JobDebugResponse,
     ManualManagedMountReconciliationResponse,
     SystemHealthResponse,
     SystemMountsResponse,
@@ -310,43 +309,3 @@ def reconcile_managed_mounts(
     )
 
 
-@router.get("/jobs/{job_id}/debug", response_model=JobDebugResponse, responses={**R_401, **R_403, **R_404, **R_422})
-def job_debug(
-    job_id: int,
-    db: Session = Depends(get_db),
-    _: CurrentUser = Depends(_ADMIN_AUDITOR),
-):
-    """Retrieve detailed debug information for a specific export job.
-
-    Returns internal state, paths, and progress metrics for troubleshooting.
-    Restricted to administrators and auditors who need to investigate job issues.
-
-    Includes source and target paths as these are necessary for debugging copy operations.
-
-    **Roles:** ``admin``, ``auditor``
-    """
-    job = db.get(ExportJob, job_id)
-    if not job:
-        raise HTTPException(status_code=404, detail="Job not found")
-
-    return {
-        "job_id": job.id,
-        "status": job.status.value,
-        "project_id": job.project_id,
-        "source_path": job.source_path,
-        "target_mount_path": job.target_mount_path,
-        "total_bytes": job.total_bytes,
-        "copied_bytes": job.copied_bytes,
-        "file_count": job.file_count,
-        "thread_count": job.thread_count,
-        "files": [
-            {
-                "id": f.id,
-                "relative_path": f.relative_path,
-                "status": f.status.value,
-                "checksum": f.checksum,
-                "error_message": f.error_message,
-            }
-            for f in job.files
-        ],
-    }

--- a/app/schemas/introspection.py
+++ b/app/schemas/introspection.py
@@ -182,33 +182,3 @@ class ManualManagedMountReconciliationResponse(BaseModel):
     usb_mounts_checked: int = Field(default=0, description="Managed USB mount slots inspected")
     usb_mounts_corrected: int = Field(default=0, description="Managed USB mount slots corrected")
     failure_count: int = Field(default=0, description="Number of corrective operations that failed")
-
-
-# ---------------------------------------------------------------------------
-# /introspection/jobs/{job_id}/debug
-# ---------------------------------------------------------------------------
-
-
-class DebugFileItem(BaseModel):
-    """Single file in a job debug snapshot."""
-
-    id: int = Field(..., description="Unique file identifier")
-    relative_path: str = Field(..., description="Relative path from source root")
-    status: str = Field(..., description="Copy/verification status")
-    checksum: Optional[str] = Field(default=None, description="SHA-256 checksum")
-    error_message: Optional[str] = Field(default=None, description="Error detail if status is ERROR")
-
-
-class JobDebugResponse(BaseModel):
-    """Response for ``GET /introspection/jobs/{job_id}/debug``."""
-
-    job_id: int = Field(..., description="Export job ID")
-    status: str = Field(..., description="Current job status")
-    project_id: str = Field(..., description="Project ID")
-    source_path: str = Field(..., description="Source data path")
-    target_mount_path: Optional[str] = Field(default=None, description="Target mount path")
-    total_bytes: int = Field(default=0, description="Total bytes to copy")
-    copied_bytes: int = Field(default=0, description="Bytes copied so far")
-    file_count: int = Field(default=0, description="Total number of files")
-    thread_count: int = Field(default=0, description="Parallel thread count")
-    files: List[DebugFileItem] = Field(default_factory=list, description="File-level status details")

--- a/docs/design/06-rest-api-design.md
+++ b/docs/design/06-rest-api-design.md
@@ -1929,20 +1929,6 @@ CPU, memory, disk I/O, worker queue.
 - `401 Unauthorized` — Missing/invalid token
 - `403 Forbidden` — Insufficient role
 
-### `GET /introspection/jobs/{job_id}/debug`
-
-Internal worker state.
-
-**Roles:** `admin`, `manager`, `processor`, `auditor`
-
-**Error responses:**
-
-- `401 Unauthorized` — Missing/invalid token
-- `403 Forbidden` — Insufficient role
-- `404 Not Found` — Job ID does not exist
-
----
-
 ## 3.10 Directory Browsing
 
 ### `GET /browse`

--- a/docs/design/07-introspection-design.md
+++ b/docs/design/07-introspection-design.md
@@ -13,7 +13,6 @@
 - `GET /introspection/block-devices`: include capacity, fs type, mount state, encryption indicators.
 - `GET /introspection/mounts`: report active mount table and ECUBE-managed entries.
 - `GET /introspection/system-health`: aggregate CPU/memory/disk and queue depth.
-- `GET /introspection/jobs/{job_id}/debug`: expose worker states, retries, and pending queue details.
 - `GET /admin/logs/view`: view recent application log lines with filtering, pagination, and automatic sensitive-value redaction.
 
 ## Design Guardrails

--- a/docs/design/14-ui-wireframes.md
+++ b/docs/design/14-ui-wireframes.md
@@ -1054,32 +1054,7 @@ Sorted by `Device`; rows with no meaningful USB metadata are hidden.
 │  └─────────────────────────────────────────────────────────────────────────┘ │
 ```
 
-### 9d — Job Debug View (UC-8.6)
-
-```
-│  Job Debug — Admin/Auditor Only                                              │
-│                                                                              │
-│  Job ID: [ 1 ]   [ Load Debug Info ]                                         │
-│                                                                              │
-│  ┌─ Debug Details ─────────────────────────────────────────────────────────┐ │
-│  │  Job ID:          1                                                     │ │
-│  │  Status:          COMPLETED                                             │ │
-│  │  Project:         PROJ-001                                              │ │
-│  │  Source:          /nfs/evidence/case-001                                 │ │
-│  │  Target:          /mnt/usb/drive4                                       │ │
-│  │  Total Bytes:     13,312,196,608                                        │ │
-│  │  Copied Bytes:    13,312,196,608                                        │ │
-│  │  Files:           1,247                                                 │ │
-│  │  Threads:         4                                                     │ │
-│  │                                                                         │ │
-│  │  Files with errors:                                                     │ │
-│  │  ID   │ Path                    │ Status │ Error                        │ │
-│  │  ─────┼─────────────────────────┼────────┼───────────────────────────── │ │
-│  │  156  │ archive/corrupted.bin   │ ERROR  │ I/O error reading source     │ │
-│  └─────────────────────────────────────────────────────────────────────────┘ │
-```
-
-**Use Cases Covered:** UC-8.1 through UC-8.8
+**Use Cases Covered:** UC-8.1 through UC-8.5 and UC-8.7 through UC-8.9
 
 ---
 
@@ -1338,7 +1313,6 @@ Used for: Format Drive (UC-4.4), Delete User (UC-3.8), Remove Mount (UC-5.4), Re
 | UC-8.1 – UC-8.2 | Screen 9a: System Health + Footer |
 | UC-8.3 | Screen 9b: USB Topology |
 | UC-8.4 – UC-8.5 | Screen 9a: Block Devices / Mounts tabs |
-| UC-8.6 | Screen 9d: Job Debug |
 | UC-8.7 – UC-8.8 | Screen 9c: Logs Tab |
 | UC-9.1 – UC-9.3 | Screen 10a: Configuration (Logging & Database sections) |
 | UC-9.4 – UC-9.5 | Screen 10a: Configuration (Password Policy section) |

--- a/docs/design/15-frontend-architecture.md
+++ b/docs/design/15-frontend-architecture.md
@@ -297,7 +297,7 @@ Each module exports thin wrapper functions around Axios calls. Modules map 1:1 t
 | `files.js` | `GET /files/{file_id}/hashes`, `POST /files/compare` | JobDetailView (hash viewer, file compare) |
 | `users.js` | `GET /users`, `GET /users/{username}/roles`, `PUT /users/{username}/roles`, `DELETE /users/{username}/roles` | UsersView |
 | `admin.js` | `POST /admin/os-users`, `GET /admin/os-users`, `DELETE /admin/os-users/{username}`, `PUT /admin/os-users/{username}/password`, `PUT /admin/os-users/{username}/groups`, `POST /admin/os-users/{username}/groups`, `GET /admin/os-groups` | UsersView (single users/roles editor) |
-| `introspection.js` | `GET /introspection/usb/topology`, `GET /introspection/block-devices`, `GET /introspection/mounts`, `GET /introspection/system-health`, `GET /introspection/jobs/{job_id}/debug` | SystemView, DashboardView, AppFooter |
+| `introspection.js` | `GET /introspection/usb/topology`, `GET /introspection/block-devices`, `GET /introspection/mounts`, `GET /introspection/system-health` | SystemView, DashboardView, AppFooter |
 
 ### 6.3 Job Progress Polling
 
@@ -449,7 +449,7 @@ Vue I18n 9.x provides the localization infrastructure. All user-visible strings 
 | `JobDetailView.vue` | Screen 6b–d | UC-6.2 – UC-6.8 | Progress bar with polling; edit/pause/complete/delete lifecycle actions; gated verify/manifest controls; hash viewer; source/destination compare; manifest success feedback |
 | `AuditView.vue` | Screen 7 | UC-7.1 – UC-7.7 | Filterable audit log table; date range, user, action filters; CSV export; CoC report retrieval by drive/project (drive default) with print/save controls. Drive selector populated server-side via `GET /drives?state=IN_USE&state=AVAILABLE` to exclude DISCONNECTED and ARCHIVED drives. |
 | `UsersView.vue` | Screen 8 | UC-3.1 – UC-3.9 | Single editable users table: role selection, per-user save, password reset, and create-user flow; admin-only |
-| `SystemView.vue` | Screen 9 | UC-8.1 – UC-8.8 | Tabbed: Health, USB Topology, Block Devices, Mounts, Logs, Job Debug |
+| `SystemView.vue` | Screen 9 | UC-8.1 – UC-8.5, UC-8.7 – UC-8.9 | Tabbed: Health, USB Topology, Block Devices, Mounts, Logs |
 
 ### 9.3 Common/Shared Components
 
@@ -501,8 +501,7 @@ Vue I18n 9.x provides the localization infrastructure. All user-visible strings 
 | UC-8.1 – UC-8.2 | Screen 9a + Footer | `SystemView`, `AppFooter` |
 | UC-8.3 | Screen 9b: USB Topology | `SystemView` (tab) |
 | UC-8.4 – UC-8.5 | Screen 9a: Block Devices / Mounts | `SystemView` (tabs) |
-| UC-8.6 | Screen 9d: Job Debug | `SystemView` (tab) |
-| UC-8.7 – UC-8.8 | Screen 9c: Logs Tab | `SystemView` (tab) |
+| UC-8.7 – UC-8.9 | Screen 9c: Logs Tab | `SystemView` (tab) |
 
 ---
 

--- a/docs/operations/09-administration-automation-guide.md
+++ b/docs/operations/09-administration-automation-guide.md
@@ -1887,10 +1887,6 @@ curl -k -H "Authorization: Bearer $TOKEN" \
 # Block devices — all devices detected by the kernel (requires auth)
 curl -k -H "Authorization: Bearer $TOKEN" \
   https://localhost:8443/introspection/block-devices
-
-# Job debug info — detailed paths and file statuses (admin or auditor)
-curl -k -H "Authorization: Bearer $TOKEN" \
-  https://localhost:8443/introspection/jobs/1/debug
 ```
 
 ### Application Logs API

--- a/docs/operations/11-api-quick-reference.md
+++ b/docs/operations/11-api-quick-reference.md
@@ -298,7 +298,6 @@ Common errors for admin log endpoints: `400` (invalid filename or traversal atte
 | GET | `/introspection/mounts` | all | Mount inventory and status |
 | GET | `/introspection/system-health` | all | Database and job engine health |
 | POST | `/introspection/reconcile-managed-mounts` | admin,manager | Run a manual live-safe reconciliation pass for managed network and USB mounts |
-| GET | `/introspection/jobs/{job_id}/debug` | admin,auditor | Debug info for specific job |
 
 `GET /introspection/drives` includes the port-based `port_system_path` and separate `serial_number` for each registered drive. `GET /introspection/usb/topology` includes a `serial` field when sysfs exposes one.
 

--- a/docs/operations/13-user-manual.md
+++ b/docs/operations/13-user-manual.md
@@ -849,7 +849,7 @@ If your role does not include access to this page, the navigation item will not 
 > **Page visibility:** `admin`, `manager`, `processor`, `auditor`
 > **Restricted actions:** Most diagnostics on this page are relevant to administrators and support personnel. Log viewing is admin-only.
 
-The `System` page provides operational and diagnostic information. Depending on deployment and permissions, this may include system health, USB information, block-device data, mount diagnostics, application logs, and job-debug details.
+The `System` page provides operational and diagnostic information. Depending on deployment and permissions, this may include system health, USB information, block-device data, mount diagnostics, and application logs.
 
 This page is useful when:
 
@@ -940,7 +940,7 @@ Use this action when mounted-share state appears stale or inconsistent and you n
 1. Open the `System` page.
 2. In the tab bar, locate `Reconcile managed mounts` next to `Mounts`:
    - `admin`: between `Mounts` and `Logs`
-   - `manager`: between `Mounts` and `Job Debug` (the `Logs` tab is admin-only)
+   - `manager`: after `Mounts` (the `Logs` tab is admin-only)
 3. Click `Reconcile managed mounts`.
 4. While the request is running, the button label changes to `Loading`.
 5. On success, ECUBE navigates to the `Reconciliation Results` page.

--- a/docs/testing/03-qa-testing-guide.md
+++ b/docs/testing/03-qa-testing-guide.md
@@ -686,6 +686,7 @@ At a narrow viewport (for example `<= 768px` wide), verify the responsive operat
 - Job Detail keeps the highest-priority lifecycle actions visible on mobile and moves the remaining actions into an overflow menu without changing role-based availability.
 - In the Job Detail Files panel, selecting a file path opens the hash viewer popup, the compare workflow is available inside the same popup, and mobile pagination uses a shorter page-number window than desktop.
 - On the System page, the USB Topology and Mounts tabs reduce visible columns on mobile and expose the remaining details through per-row overflow menus.
+- On the System page, the tab set no longer includes `Job Debug`; verify authenticated roles only see the remaining supported tabs, with `Logs` still hidden from non-admin users.
 - On the Reconciliation Results page, the Current USB Drives and Current Shared Mounts tables follow the same compact mobile treatment as the main Drives and Mounts pages.
 
 For the current System page Logs tab UI, verify the admin-only log workflow behaves as follows:

--- a/docs/testing/04-ui-use-cases.md
+++ b/docs/testing/04-ui-use-cases.md
@@ -196,7 +196,6 @@ Use this checklist when validating UI behavior for UC-3.5 (create user), UC-3.6 
 | UC-8.3 | View USB hub/port topology | Any authenticated user | any |
 | UC-8.4 | View block device metadata | Any authenticated user | any |
 | UC-8.5 | View mounted filesystems | Any authenticated user | any |
-| UC-8.6 | View job debug info | Admin, Auditor | admin, auditor |
 | UC-8.7 | Select the active or rotated application log source from the Logs tab | Admin | admin |
 | UC-8.8 | Download the currently selected log source from the Logs toolbar | Admin | admin |
 | UC-8.9 | Scroll within the log viewer to page to older or newer content for the selected source | Admin | admin |

--- a/frontend/e2e/jobs.spec.js
+++ b/frontend/e2e/jobs.spec.js
@@ -71,7 +71,6 @@ test('jobs create, start, compare, and manifest flow', async ({ page }) => {
     returned_files: 1,
     files: [{ id: 101, relative_path: 'a.txt', status: 'COMPLETED', checksum: 'abc' }],
   })
-  await routeJson(page, '**/api/introspection/jobs/77/debug', { files: [{ id: 101, relative_path: 'a.txt', status: 'COMPLETED', checksum: 'abc' }] })
   await routeJson(page, '**/api/files/101/hashes', { file_id: 101, relative_path: 'a.txt', md5: 'md5-abc', sha256: 'sha-abc', size_bytes: 12 })
   await page.route('**/api/files/compare', async (route) => {
     await route.fulfill({
@@ -274,7 +273,6 @@ test('jobs surfaces preparing labels during startup analysis', async ({ page }) 
     drive: { id: 9, port_system_path: '2-9', device_identifier: 'USB-009' },
   })
   await routeJson(page, '**/api/jobs/92/files', { files: [] })
-  await routeJson(page, '**/api/introspection/jobs/92/debug', { files: [] })
 
   await page.goto('/jobs')
   await expect(page.getByText('Preparing...', { exact: true }).first()).toBeVisible()
@@ -319,7 +317,6 @@ test('job detail lets manager clear cached startup analysis', async ({ page }) =
     })
   })
   await routeJson(page, '**/api/jobs/93/files', { files: [] })
-  await routeJson(page, '**/api/introspection/jobs/93/debug', { files: [] })
   await page.route('**/api/jobs/93/startup-analysis/clear', async (route) => {
     cleanupCalls += 1
     expect(route.request().postDataJSON()).toEqual({ confirm: true })
@@ -386,7 +383,6 @@ test('job detail lets processor analyze and then start from prepared analysis', 
     })
   })
   await routeJson(page, '**/api/jobs/94/files', { files: [] })
-  await routeJson(page, '**/api/introspection/jobs/94/debug', { files: [] })
   await page.route('**/api/jobs/94/analyze', async (route) => {
     analyzeCalls += 1
     jobState = {
@@ -454,7 +450,6 @@ test('job detail polls and reflects status progression', async ({ page }) => {
   await routeJson(page, '**/api/drives', [])
   await routeJson(page, '**/api/mounts', [])
   await routeJson(page, '**/api/jobs/88/files', { files: [] })
-  await routeJson(page, '**/api/introspection/jobs/88/debug', { files: [] })
   await page.route('**/api/jobs/88', async (route) => {
     pollCount += 1
     const copied = Math.min(pollCount * 100, 400)
@@ -505,11 +500,6 @@ test('job detail prefers persisted failure reasons over derived file summaries',
     returned_files: 1,
     files: [{ id: 201, relative_path: 'bad.txt', status: 'ERROR', error_message: 'Permission denied' }],
   })
-  await routeJson(page, '**/api/introspection/jobs/91/debug', {
-    total_files: 1,
-    returned_files: 1,
-    files: [{ id: 201, relative_path: 'bad.txt', status: 'ERROR', error_message: 'Permission denied' }],
-  })
 
   await page.goto('/jobs/91')
   await expect(page).toHaveURL(/\/jobs\/91$/)
@@ -548,14 +538,6 @@ test('job detail opens per-file error details from the errored status control', 
     failure_reason: null,
   })
   await routeJson(page, '**/api/jobs/92/files', {
-    total_files: 2,
-    returned_files: 2,
-    files: [
-      { id: 301, relative_path: 'bad.txt', status: 'ERROR', error_message: 'Target storage is full' },
-      { id: 302, relative_path: 'good.txt', status: 'DONE', error_message: null },
-    ],
-  })
-  await routeJson(page, '**/api/introspection/jobs/92/debug', {
     total_files: 2,
     returned_files: 2,
     files: [

--- a/frontend/e2e/role-gating.spec.js
+++ b/frontend/e2e/role-gating.spec.js
@@ -47,7 +47,6 @@ test('auditor cannot run write actions', async ({ page }) => {
     total_bytes: 100,
   })
   await routeJson(page, '**/api/jobs/1/files', { files: [] })
-  await routeJson(page, '**/api/introspection/jobs/1/debug', { files: [] })
 
   await page.goto('/jobs/1')
   await expect(page).toHaveURL(/\/jobs\/1$/)
@@ -72,7 +71,6 @@ test('processor does not see startup-analysis cleanup control', async ({ page })
     startup_analysis_cached: true,
   })
   await routeJson(page, '**/api/jobs/1/files', { files: [] })
-  await routeJson(page, '**/api/introspection/jobs/1/debug', { files: [] })
 
   await page.goto('/jobs/1')
   await expect(page).toHaveURL(/\/jobs\/1$/)

--- a/frontend/e2e/theme.spec.js
+++ b/frontend/e2e/theme.spec.js
@@ -94,7 +94,6 @@ async function mockCoreApis(page) {
   })
   await routeJson(page, '**/api/jobs/55', { id: 55, project_id: 'PRJ', evidence_number: 'EV', status: 'RUNNING', copied_bytes: 20, total_bytes: 100, drive: { id: 1, port_system_path: '2-1', device_identifier: '/dev/sdb' } })
   await routeJson(page, '**/api/jobs/55/files', { files: [] })
-  await routeJson(page, '**/api/introspection/jobs/55/debug', { files: [] })
 }
 
 async function openCreateJobDialog(page) {

--- a/frontend/public/help/manual.html
+++ b/frontend/public/help/manual.html
@@ -940,7 +940,7 @@ For field-by-field meaning and defaults, see Configuration reference.
 <blockquote><p><strong>Access Summary</strong></p></blockquote>
 <blockquote><p><strong>Page visibility:</strong> <code>admin</code>, <code>manager</code>, <code>processor</code>, <code>auditor</code></p></blockquote>
 <blockquote><p><strong>Restricted actions:</strong> Most diagnostics on this page are relevant to administrators and support personnel. Log viewing is admin-only.</p></blockquote>
-<p>The <code>System</code> page provides operational and diagnostic information. Depending on deployment and permissions, this may include system health, USB information, block-device data, mount diagnostics, application logs, and job-debug details.</p>
+<p>The <code>System</code> page provides operational and diagnostic information. Depending on deployment and permissions, this may include system health, USB information, block-device data, mount diagnostics, and application logs.</p>
 <p>This page is useful when:</p>
 <ul><li>
 Confirming the backend is healthy
@@ -1044,7 +1044,7 @@ In the tab bar, locate <code>Reconcile managed mounts</code> next to <code>Mount
 <ul><li>
 <code>admin</code>: between <code>Mounts</code> and <code>Logs</code>
 </li><li>
-<code>manager</code>: between <code>Mounts</code> and <code>Job Debug</code> (the <code>Logs</code> tab is admin-only)
+<code>manager</code>: after <code>Mounts</code> (the <code>Logs</code> tab is admin-only)
 </li></ul>
 </li><li>
 Click <code>Reconcile managed mounts</code>.

--- a/frontend/src/api/introspection.js
+++ b/frontend/src/api/introspection.js
@@ -22,10 +22,6 @@ export function getSystemMounts() {
   return toData(apiClient.get(`${API_BASE}/introspection/mounts`))
 }
 
-export function getJobDebug(jobId) {
-  return toData(apiClient.get(`${API_BASE}/introspection/jobs/${jobId}/debug`))
-}
-
 export function reconcileManagedMounts() {
   return toData(apiClient.post(`${API_BASE}/introspection/reconcile-managed-mounts`))
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -382,8 +382,7 @@
       "usb": "USB Topology",
       "block": "Block Devices",
       "mounts": "Mounts",
-      "logs": "Logs",
-      "job-debug": "Job Debug"
+      "logs": "Logs"
     },
     "device": "Device",
     "serialNumber": "Serial Number",
@@ -401,10 +400,6 @@
     "memory": "Memory",
     "diskIo": "Disk I/O",
     "workerQueue": "Worker Queue",
-    "loadDebug": "Load Debug",
-    "jobPickerLabel": "Select Job",
-    "jobPickerPlaceholder": "Choose a job (or enter ID manually)",
-    "jobPickerUnavailable": "Job picker is unavailable on this server version. Enter a job ID manually.",
     "reconcileManagedMounts": "Reconcile managed mounts",
     "reconcileSummary": "Managed-mount reconciliation {status}. Network: {networkCorrected}/{networkChecked} corrected. USB: {usbCorrected}/{usbChecked} corrected. Failed corrective operations: {failures}.",
     "reconcileStatuses": {
@@ -434,9 +429,7 @@
     "logFileModifiedAt": "File modified",
     "logLoadNewer": "Load newer lines",
     "logLoadOlder": "Load older lines",
-    "logViewerEmpty": "No log lines available for the selected filters.",
-    "enterJobId": "Enter a job ID before loading debug details.",
-    "jobNotFound": "No job was found for the provided job ID."
+    "logViewerEmpty": "No log lines available for the selected filters."
   },
   "dashboard": {
     "systemHealth": "System Health",

--- a/frontend/src/views/SystemView.vue
+++ b/frontend/src/views/SystemView.vue
@@ -7,16 +7,14 @@ import {
   getUsbTopology,
   getBlockDevices,
   getSystemMounts,
-  getJobDebug,
   reconcileManagedMounts,
 } from '@/api/introspection.js'
 import { downloadLogFile, getLogFiles, getLogLines } from '@/api/admin.js'
-import { listJobs } from '@/api/jobs.js'
 import DataTable from '@/components/common/DataTable.vue'
 import Pagination from '@/components/common/Pagination.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useAuthStore } from '@/stores/auth.js'
-import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
+import { normalizeProjectId } from '@/utils/projectId.js'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -29,7 +27,6 @@ const tabs = computed(() => {
   if (canViewLogs.value) {
     items.push('logs')
   }
-  items.push('job-debug')
   return items
 })
 const activeTab = ref('health')
@@ -45,10 +42,6 @@ const logs = ref([])
 const downloadingLogName = ref('')
 const logViewer = ref({ source: '', search: '', limit: 200, offset: 0, reverse: true })
 const logView = ref(null)
-const jobDebug = ref(null)
-const jobDebugId = ref('')
-const jobs = ref([])
-const jobsListUnavailable = ref(false)
 const loadingLogPage = ref(false)
 const logViewerElement = ref(null)
 const suppressedLogViewerScrollTop = ref(null)
@@ -422,53 +415,6 @@ async function loadTabData() {
   }
 }
 
-async function loadJobDebug() {
-  if (!jobDebugId.value) {
-    error.value = t('system.enterJobId')
-    return
-  }
-  loading.value = true
-  error.value = ''
-  try {
-    jobDebug.value = normalizeProjectRecord(await getJobDebug(Number(jobDebugId.value)), ['project_id'])
-  } catch (err) {
-    const status = err?.response?.status
-    if (status === 404) {
-      error.value = t('system.jobNotFound')
-      jobDebug.value = null
-    } else {
-      error.value = extractApiMessage(err) || t('common.errors.requestConflict')
-    }
-  } finally {
-    loading.value = false
-  }
-}
-
-async function loadJobOptions() {
-  loading.value = true
-  error.value = ''
-  jobsListUnavailable.value = false
-  try {
-    const response = await listJobs({ limit: 200 })
-    jobs.value = Array.isArray(response)
-      ? response.map((item) => normalizeProjectRecord(item, ['project_id']))
-      : []
-  } catch {
-    jobs.value = []
-    jobsListUnavailable.value = true
-  } finally {
-    loading.value = false
-  }
-}
-
-function onJobPickerChange(event) {
-  const selected = String(event?.target?.value || '')
-  jobDebugId.value = selected
-  if (selected) {
-    loadJobDebug()
-  }
-}
-
 async function downloadLog() {
   const name = selectedLogDownloadName.value
   if (!name) return
@@ -568,11 +514,7 @@ async function onLogViewerScroll(event) {
 watch(activeTab, async () => {
   page.value = 1
   error.value = ''
-  if (activeTab.value === 'job-debug') {
-    await loadJobOptions()
-  } else {
-    await loadTabData()
-  }
+  await loadTabData()
 })
 
 watch(canViewLogs, (isAdmin) => {
@@ -602,7 +544,7 @@ onBeforeUnmount(() => {
   <section class="view-root">
     <header class="header-row">
       <h1>{{ t('system.title') }}</h1>
-      <button class="btn" @click="activeTab === 'job-debug' ? loadJobDebug() : loadTabData()">
+      <button class="btn" @click="loadTabData()">
         {{ t('common.actions.refresh') }}
       </button>
     </header>
@@ -649,41 +591,6 @@ onBeforeUnmount(() => {
         <span>{{ t('system.diskIo') }}</span><strong>{{ diskIoDisplay }}</strong>
         <span>{{ t('system.workerQueue') }}</span><strong>{{ workerQueueDisplay }}</strong>
       </div>
-    </article>
-
-    <article v-else-if="activeTab === 'job-debug'" class="panel">
-      <div class="job-debug-form">
-        <label class="job-picker-label" for="job-picker">{{ t('system.jobPickerLabel') }}</label>
-        <select id="job-picker" class="job-picker" :value="jobDebugId" @change="onJobPickerChange">
-          <option value="">{{ t('system.jobPickerPlaceholder') }}</option>
-          <option v-for="job in jobs" :key="job.id" :value="String(job.id)">
-            #{{ job.id }} - {{ formatProjectId(job.project_id) }} - {{ job.status || t('common.labels.unknown') }}
-          </option>
-        </select>
-        <input v-model="jobDebugId" type="number" min="1" :placeholder="t('jobs.jobId')" />
-        <button class="btn" @click="loadJobDebug">{{ t('system.loadDebug') }}</button>
-      </div>
-      <p v-if="jobsListUnavailable" class="muted">{{ t('system.jobPickerUnavailable') }}</p>
-
-      <div v-if="jobDebug" class="health-grid">
-        <span>{{ t('jobs.jobId') }}</span><strong>{{ jobDebug.job_id }}</strong>
-        <span>{{ t('common.labels.status') }}</span><StatusBadge :status="jobDebug.status" />
-        <span>{{ t('dashboard.project') }}</span><strong>{{ formatProjectId(jobDebug.project_id) }}</strong>
-        <span>{{ t('dashboard.progress') }}</span><strong>{{ jobDebug.copied_bytes || 0 }} / {{ jobDebug.total_bytes || 0 }}</strong>
-      </div>
-
-      <DataTable
-        :columns="[
-          { key: 'id', label: t('common.labels.id'), align: 'right' },
-          { key: 'relative_path', label: t('jobs.path') },
-          { key: 'status', label: t('common.labels.status') },
-          { key: 'checksum', label: t('jobs.checksum') },
-          { key: 'error_message', label: t('system.error') },
-        ]"
-        :rows="jobDebug?.files || []"
-      >
-        <template #cell-status="{ row }"><StatusBadge :status="row.status" /></template>
-      </DataTable>
     </article>
 
     <article v-else-if="activeTab === 'logs'" class="panel">
@@ -793,7 +700,6 @@ onBeforeUnmount(() => {
 
 .header-row,
 .tabs,
-.job-debug-form,
 .header-actions {
   display: flex;
   gap: var(--space-sm);
@@ -804,8 +710,7 @@ onBeforeUnmount(() => {
   align-items: center;
 }
 
-.tabs,
-.job-debug-form {
+.tabs {
   flex-wrap: wrap;
 }
 

--- a/frontend/src/views/__tests__/JobDetailView.spec.js
+++ b/frontend/src/views/__tests__/JobDetailView.spec.js
@@ -17,7 +17,6 @@ const mocks = vi.hoisted(() => ({
   completeJob: vi.fn(),
   deleteJob: vi.fn(),
   clearJobStartupAnalysisCache: vi.fn(),
-  getJobDebug: vi.fn(),
   getDrives: vi.fn(),
   getMounts: vi.fn(),
   getFileHashes: vi.fn(),
@@ -69,10 +68,6 @@ vi.mock('@/api/jobs.js', () => ({
   completeJob: (...args) => mocks.completeJob(...args),
   deleteJob: (...args) => mocks.deleteJob(...args),
   clearJobStartupAnalysisCache: (...args) => mocks.clearJobStartupAnalysisCache(...args),
-}))
-
-vi.mock('@/api/introspection.js', () => ({
-  getJobDebug: (...args) => mocks.getJobDebug(...args),
 }))
 
 vi.mock('@/api/drives.js', () => ({
@@ -164,7 +159,6 @@ describe('JobDetailView start action', () => {
     mocks.completeJob.mockReset()
     mocks.deleteJob.mockReset()
     mocks.clearJobStartupAnalysisCache.mockReset()
-    mocks.getJobDebug.mockReset()
     mocks.getDrives.mockReset()
     mocks.getMounts.mockReset()
     mocks.getFileHashes.mockReset()

--- a/frontend/src/views/__tests__/SystemView.spec.js
+++ b/frontend/src/views/__tests__/SystemView.spec.js
@@ -10,12 +10,10 @@ const mocks = vi.hoisted(() => ({
   getUsbTopology: vi.fn(),
   getBlockDevices: vi.fn(),
   getSystemMounts: vi.fn(),
-  getJobDebug: vi.fn(),
   reconcileManagedMounts: vi.fn(),
   getLogFiles: vi.fn(),
   getLogLines: vi.fn(),
   downloadLogFile: vi.fn(),
-  listJobs: vi.fn(),
   mobileViewportMatches: false,
 }))
 
@@ -50,7 +48,6 @@ vi.mock('@/api/introspection.js', () => ({
   getUsbTopology: mocks.getUsbTopology,
   getBlockDevices: mocks.getBlockDevices,
   getSystemMounts: mocks.getSystemMounts,
-  getJobDebug: mocks.getJobDebug,
   reconcileManagedMounts: mocks.reconcileManagedMounts,
 }))
 
@@ -58,10 +55,6 @@ vi.mock('@/api/admin.js', () => ({
   getLogFiles: mocks.getLogFiles,
   getLogLines: mocks.getLogLines,
   downloadLogFile: mocks.downloadLogFile,
-}))
-
-vi.mock('@/api/jobs.js', () => ({
-  listJobs: mocks.listJobs,
 }))
 
 async function flushPromises() {
@@ -123,19 +116,16 @@ describe('SystemView USB topology tab', () => {
     mocks.getUsbTopology.mockReset()
     mocks.getBlockDevices.mockReset()
     mocks.getSystemMounts.mockReset()
-    mocks.getJobDebug.mockReset()
     mocks.reconcileManagedMounts.mockReset()
     mocks.getLogFiles.mockReset()
     mocks.getLogLines.mockReset()
     mocks.downloadLogFile.mockReset()
-    mocks.listJobs.mockReset()
     setMobileViewport(false)
 
     mocks.hasRole.mockImplementation((role) => role === 'admin')
     mocks.getSystemHealth.mockResolvedValue({ status: 'ok', database: 'connected', active_jobs: 0 })
     mocks.getBlockDevices.mockResolvedValue({ block_devices: [] })
     mocks.getSystemMounts.mockResolvedValue({ mounts: [] })
-    mocks.getJobDebug.mockResolvedValue(null)
     mocks.reconcileManagedMounts.mockResolvedValue({
       status: 'ok',
       scope: 'managed_mounts_only',
@@ -156,7 +146,14 @@ describe('SystemView USB topology tab', () => {
       limit: 200,
       offset: 0,
     })
-    mocks.listJobs.mockResolvedValue([])
+  })
+
+  it('does not show a Job Debug tab', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    const labels = wrapper.findAll('button').map((button) => button.text())
+    expect(labels).not.toContain('Job Debug')
   })
 
   it('hides devices only if Serial Number, Manufacturer, Product, Vendor ID, and Product ID are all empty, and sorts by device column', async () => {
@@ -301,19 +298,16 @@ describe('SystemView logs tab', () => {
     mocks.getUsbTopology.mockReset()
     mocks.getBlockDevices.mockReset()
     mocks.getSystemMounts.mockReset()
-    mocks.getJobDebug.mockReset()
     mocks.reconcileManagedMounts.mockReset()
     mocks.getLogFiles.mockReset()
     mocks.getLogLines.mockReset()
     mocks.downloadLogFile.mockReset()
-    mocks.listJobs.mockReset()
 
     mocks.hasRole.mockImplementation((role) => role === 'admin')
     mocks.getSystemHealth.mockResolvedValue({ status: 'ok', database: 'connected', active_jobs: 0 })
     mocks.getUsbTopology.mockResolvedValue({ devices: [] })
     mocks.getBlockDevices.mockResolvedValue({ block_devices: [] })
     mocks.getSystemMounts.mockResolvedValue({ mounts: [] })
-    mocks.getJobDebug.mockResolvedValue(null)
     mocks.reconcileManagedMounts.mockResolvedValue({
       status: 'ok',
       scope: 'managed_mounts_only',
@@ -334,7 +328,6 @@ describe('SystemView logs tab', () => {
       limit: 200,
       offset: 0,
     })
-    mocks.listJobs.mockResolvedValue([])
   })
 
   it('shows logs tab for admin and loads redacted lines', async () => {
@@ -909,18 +902,15 @@ describe('SystemView managed-mount reconciliation action', () => {
     mocks.getUsbTopology.mockReset()
     mocks.getBlockDevices.mockReset()
     mocks.getSystemMounts.mockReset()
-    mocks.getJobDebug.mockReset()
     mocks.reconcileManagedMounts.mockReset()
     mocks.getLogFiles.mockReset()
     mocks.getLogLines.mockReset()
     mocks.downloadLogFile.mockReset()
-    mocks.listJobs.mockReset()
 
     mocks.getSystemHealth.mockResolvedValue({ status: 'ok', database: 'connected', active_jobs: 0 })
     mocks.getUsbTopology.mockResolvedValue({ devices: [] })
     mocks.getBlockDevices.mockResolvedValue({ block_devices: [] })
     mocks.getSystemMounts.mockResolvedValue({ mounts: [] })
-    mocks.getJobDebug.mockResolvedValue(null)
     mocks.reconcileManagedMounts.mockResolvedValue({
       status: 'ok',
       scope: 'managed_mounts_only',
@@ -941,7 +931,6 @@ describe('SystemView managed-mount reconciliation action', () => {
       limit: 200,
       offset: 0,
     })
-    mocks.listJobs.mockResolvedValue([])
   })
 
   it('shows the reconcile action for admins and managers only', async () => {

--- a/tests/integration/test_introspection_use_cases_integration.py
+++ b/tests/integration/test_introspection_use_cases_integration.py
@@ -1,7 +1,5 @@
 import pytest
 
-from app.models.jobs import ExportJob
-
 
 @pytest.mark.integration
 def test_system_health_reports_connected_database(integration_client):
@@ -32,24 +30,3 @@ def test_mount_table_endpoint_returns_mounts_key(integration_client):
     assert response.status_code == 200
     assert "mounts" in response.json()
 
-
-@pytest.mark.integration
-def test_job_debug_use_cases(integration_client, integration_db):
-    missing = integration_client.get("/introspection/jobs/999999/debug")
-    assert missing.status_code == 404
-    assert missing.json()["code"] == "NOT_FOUND"
-
-    job = ExportJob(
-        project_id="PROJ-INTROSPECT-001",
-        evidence_number="EV-INT-001",
-        source_path="/tmp/source",
-    )
-    integration_db.add(job)
-    integration_db.commit()
-
-    response = integration_client.get(f"/introspection/jobs/{job.id}/debug")
-    assert response.status_code == 200
-    data = response.json()
-    assert data["job_id"] == job.id
-    assert data["project_id"] == "PROJ-INTROSPECT-001"
-    assert isinstance(data["files"], list)

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -424,20 +424,6 @@ class TestIntrospectionAuthorization:
         c = _client_for_role(db, [])
         _assert_forbidden(c.get(path))
 
-    def test_job_debug_auditor_allowed(self, db):
-        from app.models.jobs import ExportJob
-
-        job = ExportJob(project_id="P", evidence_number="E", source_path="/tmp")
-        db.add(job)
-        db.commit()
-        c = _client_for_role(db, ["auditor"])
-        assert c.get(f"/introspection/jobs/{job.id}/debug").status_code == 200
-
-    def test_job_debug_no_role_denied(self, db):
-        c = _client_for_role(db, [])
-        _assert_forbidden(c.get("/introspection/jobs/1/debug"))
-
-
 # ---------------------------------------------------------------------------
 # Unauthenticated access still returns 401
 # ---------------------------------------------------------------------------

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -357,7 +357,7 @@ class TestCopyJobTimeout:
         files = db.query(ExportFile).filter(ExportFile.job_id == job.id).all()
         assert files
         assert any(f.status == FileStatus.TIMEOUT for f in files), "At least one file should be marked TIMEOUT"
-        assert any("timed out after 1s" in (f.error_message or "") for f in files)
+        assert any((f.error_message or "") == "Operation timed out" for f in files)
 
         # Timeout should emit FILE_COPY_TIMEOUT audit record, not JOB_TIMEOUT
         timeout_entries = db.query(AuditLog).filter(AuditLog.action == "FILE_COPY_TIMEOUT").all()

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -207,29 +207,6 @@ def test_system_health_degraded(client, db):
     assert data["database_error"] is not None
 
 
-def test_job_debug_not_found(auditor_client, db):
-    response = auditor_client.get("/introspection/jobs/999/debug")
-    assert response.status_code == 404
-
-
-def test_job_debug(auditor_client, db):
-    from app.models.jobs import ExportJob
-
-    job = ExportJob(
-        project_id="PROJ-001",
-        evidence_number="EV-001",
-        source_path="/data/evidence",
-    )
-    db.add(job)
-    db.commit()
-
-    response = auditor_client.get(f"/introspection/jobs/{job.id}/debug")
-    assert response.status_code == 200
-    data = response.json()
-    assert data["job_id"] == job.id
-    assert data["project_id"] == "PROJ-001"
-
-
 def test_reconcile_managed_mounts_requires_authentication(unauthenticated_client, db):
     response = unauthenticated_client.post("/introspection/reconcile-managed-mounts")
     assert response.status_code == 401


### PR DESCRIPTION
Summary

This change removes the retired Job Debug diagnostics surface from ECUBE and cleans up the remaining backend, frontend, test, and documentation references that depended on it. The result is a smaller, more accurate System/introspection surface for operators and reviewers, with the supporting docs and tests now aligned to the actual product behavior.

Changes included

- Removed the unused `GET /introspection/jobs/{job_id}/debug` backend endpoint and its response schema.
- Removed the System page Job Debug tab, picker flow, refresh branching, and unused client helper/imports.
- Removed stale frontend unit and Playwright stubs that were still mocking the retired Job Debug API.
- Updated design, API, operations, QA, and UI-use-case docs so they no longer describe the retired Job Debug screen or endpoint.
- Kept the remaining System page diagnostics intact: Health, USB Topology, Block Devices, Mounts, Logs, and managed-mount reconciliation.
- Updated one backend timeout test to match the current sanitized persisted timeout message (`Operation timed out`) rather than the old raw timeout string.

User-facing / operator-facing effects

- The System page no longer shows a Job Debug tab for any role.
- Admin-only log access remains unchanged.
- The `Reconcile managed mounts` action remains available for `admin` and `manager`, with documentation updated to reflect the current tab layout.
- The published introspection/API docs now match the actual supported endpoints, reducing stale troubleshooting guidance.

Validation

- Backend unit suite: `pytest tests/ --ignore=tests/integration --ignore=tests/hardware -q` → `1647 passed`
- Focused backend validation: `pytest tests/test_config_settings.py -q` → `56 passed`
- Focused auth/introspection validation: `pytest tests/test_introspection.py tests/test_authorization.py -q` → `68 passed`
- Frontend unit validation: `npm exec vitest run src/views/__tests__/SystemView.spec.js src/views/__tests__/JobDetailView.spec.js --coverage=false` → `63 passed`
- Affected Playwright coverage: `npm exec playwright test e2e/jobs.spec.js e2e/role-gating.spec.js e2e/theme.spec.js` → `28 passed`
- Full Playwright suite also passed during this change set: `98 passed`