### PR TITLE
Reconcile unowned USB mounts before preserving IN_USE state/pr

### DIFF
--- a/app/services/reconciliation_service.py
+++ b/app/services/reconciliation_service.py
@@ -253,6 +253,9 @@ def _resolve_usb_drive_owner(
 
     for row in assignment_rows:
         if row.released_at is None and row.job is not None:
+            job_target = row.job.target_mount_path
+            if candidate_mount_paths and os.path.normpath(str(job_target)) not in candidate_mount_paths:
+                continue
             candidate_jobs[int(row.job.id)] = row.job
 
     if candidate_mount_paths:

--- a/app/services/reconciliation_service.py
+++ b/app/services/reconciliation_service.py
@@ -38,13 +38,14 @@ from app.infrastructure.usb_discovery import DiscoveredTopology
 from app.infrastructure import FilesystemDetector
 from app.exceptions import ConflictError
 from app.models.hardware import DriveState, UsbDrive
-from app.models.jobs import ExportJob, JobStatus
+from app.models.jobs import DriveAssignment, ExportJob, JobStatus
 from app.models.network import MountStatus, NetworkMount
 from app.models.system import ReconciliationLock
 from app.repositories.user_role_repository import UserRoleRepository
 from app.repositories.audit_repository import AuditRepository
 from app.services.mount_check_utils import check_mounted_with_configured_timeout
 from app.constants import ECUBE_GROUP_ROLE_MAP
+from app.utils.sanitize import normalize_project_id
 
 logger = logging.getLogger(__name__)
 
@@ -208,6 +209,99 @@ def _cleanup_generated_network_mount_directory(path: str) -> None:
         _cleanup_managed_mount_directory(path, "/smb")
 
 
+def _normalized_usb_mount_candidates(*paths: object) -> set[str]:
+    normalized: set[str] = set()
+    for path in paths:
+        if not isinstance(path, str):
+            continue
+        stripped = path.strip()
+        if not stripped:
+            continue
+        normalized.add(os.path.normpath(stripped))
+    return normalized
+
+
+def _missing_project_binding(project_id: object) -> bool:
+    normalized = normalize_project_id(project_id)
+    return not isinstance(normalized, str) or normalized == ""
+
+
+def _resolve_usb_drive_owner(
+    db: Session,
+    *,
+    drive_id: int,
+    candidate_mount_paths: set[str],
+) -> tuple[Optional[str], str]:
+    assignment_rows = (
+        db.query(DriveAssignment)
+        .join(ExportJob, ExportJob.id == DriveAssignment.job_id)
+        .filter(DriveAssignment.drive_id == drive_id)
+        .all()
+    )
+
+    candidate_jobs: dict[int, ExportJob] = {}
+    active_assignment_job_ids = {
+        int(row.job_id)
+        for row in assignment_rows
+        if row.released_at is None and row.job is not None
+    }
+    released_assignment_job_ids = {
+        int(row.job_id)
+        for row in assignment_rows
+        if row.released_at is not None
+    }
+
+    for row in assignment_rows:
+        if row.released_at is None and row.job is not None:
+            candidate_jobs[int(row.job.id)] = row.job
+
+    if candidate_mount_paths:
+        path_jobs = (
+            db.query(ExportJob)
+            .filter(ExportJob.target_mount_path.in_(sorted(candidate_mount_paths)))
+            .all()
+        )
+        for job in path_jobs:
+            job_id = int(job.id)
+            if job_id in released_assignment_job_ids and job_id not in active_assignment_job_ids:
+                continue
+            candidate_jobs[job_id] = job
+
+    candidate_projects = {
+        normalized_project
+        for normalized_project in (
+            normalize_project_id(job.project_id) for job in candidate_jobs.values()
+        )
+        if isinstance(normalized_project, str) and normalized_project != ""
+    }
+
+    if not candidate_projects:
+        return None, "no_relevant_owner"
+    if len(candidate_projects) == 1:
+        return next(iter(candidate_projects)), "binding_restored"
+    return None, "ambiguous_owner"
+
+
+def _release_usb_drive_without_owner(
+    drive: UsbDrive,
+    *,
+    actual_target: Optional[str],
+    drive_mount_provider: DriveMountProvider,
+    managed_root: str,
+) -> tuple[bool, str, Optional[str]]:
+    if actual_target:
+        unmount_ok, unmount_error = drive_mount_provider.unmount_drive(actual_target)
+        if not unmount_ok:
+            return False, "owner_release_failed", unmount_error
+        if _is_direct_child_of(actual_target, managed_root):
+            _cleanup_managed_mount_directory(actual_target, managed_root)
+
+    drive.current_state = DriveState.AVAILABLE
+    drive.current_project_id = None
+    drive.mount_path = None
+    return True, "owner_released", None
+
+
 def _reconcile_usb_mounts(
     db: Session,
     drive_mount_provider: DriveMountProvider,
@@ -237,11 +331,83 @@ def _reconcile_usb_mounts(
         corrected_this_drive = False
         expected_target = os.path.normpath(os.path.join(settings.usb_mount_base_path, str(drive.id)))
         actual_target = find_device_mount_point(str(drive.filesystem_path)) if drive.filesystem_path else None
+        missing_binding = drive.current_state == DriveState.IN_USE and _missing_project_binding(drive.current_project_id)
+
+        if missing_binding:
+            resolved_project_id, owner_reason = _resolve_usb_drive_owner(
+                db,
+                drive_id=int(drive.id),
+                candidate_mount_paths=_normalized_usb_mount_candidates(
+                    actual_target,
+                    expected_target,
+                    drive.mount_path,
+                ),
+            )
+            if resolved_project_id is not None:
+                drive.current_project_id = resolved_project_id
+                drive.current_state = DriveState.IN_USE
+                corrected += 1
+                corrected_this_drive = True
+                audit_entries.append({
+                    "action": "DRIVE_MOUNT_RECONCILED",
+                    "user": "system",
+                    "drive_id": drive.id,
+                    "project_id": resolved_project_id,
+                    "details": {
+                        "drive_id": drive.id,
+                        "project_id": resolved_project_id,
+                        "status": "IN_USE",
+                        "reason": owner_reason,
+                    },
+                })
+            else:
+                released, release_reason, raw_error = _release_usb_drive_without_owner(
+                    drive,
+                    actual_target=actual_target,
+                    drive_mount_provider=drive_mount_provider,
+                    managed_root=managed_root,
+                )
+                if not released:
+                    failures += 1
+                    logger.info(
+                        "Startup USB owner release failed",
+                        extra={"drive_id": drive.id, "reason": release_reason},
+                    )
+                    logger.debug(
+                        "Startup USB owner release raw error",
+                        extra={"drive_id": drive.id, "mount_point": actual_target, "raw_error": raw_error},
+                    )
+                    audit_entries.append({
+                        "action": "DRIVE_MOUNT_RECONCILED",
+                        "user": "system",
+                        "drive_id": drive.id,
+                        "details": {
+                            "drive_id": drive.id,
+                            "status": "ERROR",
+                            "reason": release_reason,
+                        },
+                    })
+                    continue
+
+                corrected += 1
+                corrected_this_drive = True
+                audit_entries.append({
+                    "action": "DRIVE_MOUNT_RECONCILED",
+                    "user": "system",
+                    "drive_id": drive.id,
+                    "details": {
+                        "drive_id": drive.id,
+                        "status": "AVAILABLE",
+                        "reason": owner_reason,
+                    },
+                })
+                continue
 
         if actual_target == expected_target:
             if drive.mount_path != expected_target:
                 drive.mount_path = expected_target
-                corrected += 1
+                if not corrected_this_drive:
+                    corrected += 1
                 audit_entries.append({
                     "action": "DRIVE_MOUNT_RECONCILED",
                     "user": "system",

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import Session
 from app.config import settings
 from app.models.audit import AuditLog
 from app.models.hardware import DriveState, UsbDrive, UsbHub, UsbPort
-from app.models.jobs import ExportJob, JobStatus
+from app.models.jobs import DriveAssignment, ExportJob, JobStatus
 from app.models.network import MountStatus, MountType, NetworkMount
 from app.models.system import ReconciliationLock
 from app.models.users import UserRole
@@ -64,11 +64,18 @@ def _make_mount(db: Session, status: MountStatus = MountStatus.MOUNTED,
     return mount
 
 
-def _make_job(db: Session, status: JobStatus = JobStatus.RUNNING) -> ExportJob:
+def _make_job(
+    db: Session,
+    status: JobStatus = JobStatus.RUNNING,
+    *,
+    project_id: str = "PROJ-001",
+    target_mount_path: str | None = None,
+) -> ExportJob:
     job = ExportJob(
-        project_id="PROJ-001",
+        project_id=project_id,
         evidence_number="EV-001",
         source_path="/data/source",
+        target_mount_path=target_mount_path,
         status=status,
     )
     db.add(job)
@@ -315,6 +322,7 @@ class TestReconcileMounts:
     def test_persisted_usb_mount_is_remounted_to_expected_slot(self, db: Session):
         drive = _make_drive(db, "USB-STARTUP", DriveState.IN_USE)
         drive.filesystem_type = "ext4"
+        drive.current_project_id = "PROJ-STARTUP"
         drive.mount_path = "/mnt/ecube/stale"
         db.commit()
         drive_provider = FakeDriveMountProvider()
@@ -332,6 +340,7 @@ class TestReconcileMounts:
     def test_in_use_usb_drive_with_cleared_mount_path_is_remounted(self, db: Session):
         drive = _make_drive(db, "USB-STARTUP-CLEARED", DriveState.IN_USE)
         drive.filesystem_type = "ext4"
+        drive.current_project_id = "PROJ-STARTUP"
         drive.mount_path = None
         db.commit()
         drive_provider = FakeDriveMountProvider()
@@ -348,6 +357,7 @@ class TestReconcileMounts:
     def test_persisted_usb_mount_outside_managed_root_is_unmounted_before_remount(self, db: Session):
         drive = _make_drive(db, "USB-STARTUP-EXTERNAL", DriveState.IN_USE)
         drive.filesystem_type = "ext4"
+        drive.current_project_id = "PROJ-STARTUP"
         drive.mount_path = "/mnt/ecube/stale"
         db.commit()
         drive_provider = FakeDriveMountProvider()
@@ -363,6 +373,7 @@ class TestReconcileMounts:
     def test_persisted_usb_mount_cleanup_and_remount_counts_once(self, db: Session):
         drive = _make_drive(db, "USB-STARTUP-MANAGED", DriveState.IN_USE)
         drive.filesystem_type = "ext4"
+        drive.current_project_id = "PROJ-STARTUP"
         drive.mount_path = "/mnt/ecube/stale"
         db.commit()
         drive_provider = FakeDriveMountProvider()
@@ -383,6 +394,160 @@ class TestReconcileMounts:
 
         assert result["usb_mounts_corrected"] == 1
         assert drive_provider.unmount_calls == ["/mnt/ecube/999"]
+
+    def test_usb_mount_restores_missing_project_binding_from_matching_job(self, db: Session):
+        drive = _make_drive(db, "USB-RECOVER", DriveState.IN_USE)
+        drive.filesystem_type = "ext4"
+        drive.current_project_id = None
+        drive.mount_path = f"{settings.usb_mount_base_path}/{drive.id}"
+        job = _make_job(
+            db,
+            project_id="PROJ-RECOVER",
+            target_mount_path=f"{settings.usb_mount_base_path}/{drive.id}",
+        )
+        db.add(DriveAssignment(drive_id=drive.id, job_id=job.id))
+        db.commit()
+
+        drive_provider = FakeDriveMountProvider({f"{settings.usb_mount_base_path}/{drive.id}": drive.filesystem_path})
+
+        with patch(
+            "app.services.reconciliation_service.find_device_mount_point",
+            return_value=f"{settings.usb_mount_base_path}/{drive.id}",
+        ):
+            result = reconcile_mounts(db, FakeMountProvider(), drive_provider)
+
+        db.refresh(drive)
+        assert result["usb_mounts_checked"] == 1
+        assert result["usb_mounts_corrected"] == 1
+        assert drive.current_state == DriveState.IN_USE
+        assert drive.current_project_id == "PROJ-RECOVER"
+        assert drive_provider.unmount_calls == []
+        assert drive_provider.mount_calls == []
+
+    def test_usb_mount_restores_missing_project_binding_when_multiple_jobs_share_one_project(self, db: Session):
+        drive = _make_drive(db, "USB-SHARED-PROJECT", DriveState.IN_USE)
+        drive.filesystem_type = "ext4"
+        drive.current_project_id = None
+        drive.mount_path = f"{settings.usb_mount_base_path}/{drive.id}"
+        job_one = _make_job(
+            db,
+            project_id="PROJ-SAME",
+            target_mount_path=f"{settings.usb_mount_base_path}/{drive.id}",
+        )
+        job_two = _make_job(
+            db,
+            project_id="PROJ-SAME",
+            target_mount_path=f"{settings.usb_mount_base_path}/{drive.id}",
+        )
+        db.add_all([
+            DriveAssignment(drive_id=drive.id, job_id=job_one.id),
+            DriveAssignment(drive_id=drive.id, job_id=job_two.id),
+        ])
+        db.commit()
+
+        drive_provider = FakeDriveMountProvider({f"{settings.usb_mount_base_path}/{drive.id}": drive.filesystem_path})
+
+        with patch(
+            "app.services.reconciliation_service.find_device_mount_point",
+            return_value=f"{settings.usb_mount_base_path}/{drive.id}",
+        ):
+            reconcile_mounts(db, FakeMountProvider(), drive_provider)
+
+        db.refresh(drive)
+        assert drive.current_state == DriveState.IN_USE
+        assert drive.current_project_id == "PROJ-SAME"
+        assert drive_provider.unmount_calls == []
+
+    def test_usb_mount_with_no_relevant_owner_is_released(self, db: Session):
+        drive = _make_drive(db, "USB-ORPHANED", DriveState.IN_USE)
+        drive.filesystem_type = "ext4"
+        drive.current_project_id = None
+        drive.mount_path = f"{settings.usb_mount_base_path}/{drive.id}"
+        db.commit()
+
+        drive_provider = FakeDriveMountProvider({f"{settings.usb_mount_base_path}/{drive.id}": drive.filesystem_path})
+
+        with patch(
+            "app.services.reconciliation_service.find_device_mount_point",
+            return_value=f"{settings.usb_mount_base_path}/{drive.id}",
+        ):
+            result = reconcile_mounts(db, FakeMountProvider(), drive_provider)
+
+        db.refresh(drive)
+        assert result["usb_mounts_checked"] == 1
+        assert result["usb_mounts_corrected"] == 1
+        assert drive.current_state == DriveState.AVAILABLE
+        assert drive.current_project_id is None
+        assert drive.mount_path is None
+        assert drive_provider.unmount_calls == [f"{settings.usb_mount_base_path}/{drive.id}"]
+        assert drive_provider.mount_calls == []
+
+    def test_usb_mount_with_conflicting_project_owners_is_released(self, db: Session):
+        drive = _make_drive(db, "USB-CONFLICT", DriveState.IN_USE)
+        drive.filesystem_type = "ext4"
+        drive.current_project_id = None
+        drive.mount_path = f"{settings.usb_mount_base_path}/{drive.id}"
+        job_one = _make_job(
+            db,
+            project_id="PROJ-A",
+            target_mount_path=f"{settings.usb_mount_base_path}/{drive.id}",
+        )
+        job_two = _make_job(
+            db,
+            project_id="PROJ-B",
+            target_mount_path=f"{settings.usb_mount_base_path}/{drive.id}",
+        )
+        db.add_all([
+            DriveAssignment(drive_id=drive.id, job_id=job_one.id),
+            DriveAssignment(drive_id=drive.id, job_id=job_two.id),
+        ])
+        db.commit()
+
+        drive_provider = FakeDriveMountProvider({f"{settings.usb_mount_base_path}/{drive.id}": drive.filesystem_path})
+
+        with patch(
+            "app.services.reconciliation_service.find_device_mount_point",
+            return_value=f"{settings.usb_mount_base_path}/{drive.id}",
+        ):
+            reconcile_mounts(db, FakeMountProvider(), drive_provider)
+
+        db.refresh(drive)
+        assert drive.current_state == DriveState.AVAILABLE
+        assert drive.current_project_id is None
+        assert drive.mount_path is None
+        assert drive_provider.unmount_calls == [f"{settings.usb_mount_base_path}/{drive.id}"]
+
+    def test_released_assignments_do_not_restore_missing_project_binding(self, db: Session):
+        drive = _make_drive(db, "USB-RELEASED-ONLY", DriveState.IN_USE)
+        drive.filesystem_type = "ext4"
+        drive.current_project_id = None
+        drive.mount_path = f"{settings.usb_mount_base_path}/{drive.id}"
+        job = _make_job(
+            db,
+            project_id="PROJ-OLD",
+            target_mount_path=f"{settings.usb_mount_base_path}/{drive.id}",
+        )
+        db.add(
+            DriveAssignment(
+                drive_id=drive.id,
+                job_id=job.id,
+                released_at=datetime.now(timezone.utc),
+            )
+        )
+        db.commit()
+
+        drive_provider = FakeDriveMountProvider({f"{settings.usb_mount_base_path}/{drive.id}": drive.filesystem_path})
+
+        with patch(
+            "app.services.reconciliation_service.find_device_mount_point",
+            return_value=f"{settings.usb_mount_base_path}/{drive.id}",
+        ):
+            reconcile_mounts(db, FakeMountProvider(), drive_provider)
+
+        db.refresh(drive)
+        assert drive.current_state == DriveState.AVAILABLE
+        assert drive.current_project_id is None
+        assert drive_provider.unmount_calls == [f"{settings.usb_mount_base_path}/{drive.id}"]
 
     def test_stale_mount_emits_audit_record(self, db: Session):
         mount = _make_mount(db, MountStatus.MOUNTED, "/mnt/audit-test")
@@ -877,6 +1042,40 @@ class TestRunManualManagedMountReconciliation:
 
         assert result["status"] == "partial"
         assert result["failure_count"] == 2
+
+    def test_manual_reconciliation_reuses_usb_ownership_recovery_logic(self, db: Session):
+        drive = _make_drive(db, "USB-MANUAL-RECOVER", DriveState.IN_USE)
+        drive.filesystem_type = "ext4"
+        drive.current_project_id = None
+        drive.mount_path = f"{settings.usb_mount_base_path}/{drive.id}"
+        job = _make_job(
+            db,
+            project_id="PROJ-MANUAL",
+            target_mount_path=f"{settings.usb_mount_base_path}/{drive.id}",
+        )
+        db.add(DriveAssignment(drive_id=drive.id, job_id=job.id))
+        db.commit()
+
+        provider = FakeMountProvider(mounted_paths=set())
+        drive_provider = FakeDriveMountProvider({f"{settings.usb_mount_base_path}/{drive.id}": drive.filesystem_path})
+
+        with patch(
+            "app.services.reconciliation_service.find_device_mount_point",
+            return_value=f"{settings.usb_mount_base_path}/{drive.id}",
+        ):
+            result = run_manual_managed_mount_reconciliation(
+                db,
+                provider,
+                drive_mount_provider=drive_provider,
+                actor="manager-user",
+            )
+
+        db.refresh(drive)
+        assert result["status"] == "ok"
+        assert result["usb_mounts_checked"] == 1
+        assert result["usb_mounts_corrected"] == 1
+        assert drive.current_state == DriveState.IN_USE
+        assert drive.current_project_id == "PROJ-MANUAL"
 
     def test_rejects_when_lock_already_held(self, db: Session):
         assert _acquire_reconciliation_lock(db) is True

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -549,6 +549,33 @@ class TestReconcileMounts:
         assert drive.current_project_id is None
         assert drive_provider.unmount_calls == [f"{settings.usb_mount_base_path}/{drive.id}"]
 
+    def test_unreleased_assignment_with_different_target_does_not_restore_binding(self, db: Session):
+        drive = _make_drive(db, "USB-STALE-ACTIVE", DriveState.IN_USE)
+        drive.filesystem_type = "ext4"
+        drive.current_project_id = None
+        drive.mount_path = f"{settings.usb_mount_base_path}/{drive.id}"
+        job = _make_job(
+            db,
+            project_id="PROJ-STALE",
+            target_mount_path="/mnt/ecube/other-drive",
+        )
+        db.add(DriveAssignment(drive_id=drive.id, job_id=job.id))
+        db.commit()
+
+        drive_provider = FakeDriveMountProvider({f"{settings.usb_mount_base_path}/{drive.id}": drive.filesystem_path})
+
+        with patch(
+            "app.services.reconciliation_service.find_device_mount_point",
+            return_value=f"{settings.usb_mount_base_path}/{drive.id}",
+        ):
+            reconcile_mounts(db, FakeMountProvider(), drive_provider)
+
+        db.refresh(drive)
+        assert drive.current_state == DriveState.AVAILABLE
+        assert drive.current_project_id is None
+        assert drive.mount_path is None
+        assert drive_provider.unmount_calls == [f"{settings.usb_mount_base_path}/{drive.id}"]
+
     def test_stale_mount_emits_audit_record(self, db: Session):
         mount = _make_mount(db, MountStatus.MOUNTED, "/mnt/audit-test")
         provider = FakeMountProvider(mounted_paths=set())


### PR DESCRIPTION
Summary

This branch tightens USB mount reconciliation so ECUBE no longer preserves a mounted drive in `IN_USE` when the drive has no valid project binding. Reconciliation now makes a deterministic system-layer decision for mounted USB drives with a missing `current_project_id`: restore the binding when persisted ownership resolves to exactly one project, or safely unmount and release the drive back to `AVAILABLE` when ownership is missing, stale, or conflicting.

Changes included

- Added USB ownership resolution in the reconciliation service using persisted `DriveAssignment` rows and matching `ExportJob.target_mount_path` values.
- Added a missing-binding guard so `IN_USE` drives with no project owner are handled before normal remount/preserve logic runs.
- Restored `current_project_id` only when candidate jobs resolve to one normalized project.
- Safely unmounted and released drives to `AVAILABLE` when no relevant owner exists or when candidate jobs conflict across projects.
- Ignored released assignments as ownership signals so stale history does not silently rebind a drive.
- Expanded reconciliation tests to cover:
  - unambiguous project recovery
  - same-project multi-job recovery
  - no-owner release
  - conflicting-owner release
  - released-assignment exclusion
  - manual reconciliation reuse of the same USB ownership logic
- Updated older USB remount tests so `IN_USE` fixtures reflect the stricter ownership invariant.

User-facing or operator-facing effects

- Operators should no longer see a USB drive remain effectively in use without a recorded owning project after reconciliation.
- Startup reconciliation and manual managed-mount reconciliation now enforce stricter project-isolation behavior for mounted USB destinations.
- Auditability improves because reconciliation either restores a deterministic owner or explicitly releases the drive instead of leaving ambiguous state behind.

Validation

- Focused backend verification passed:
  - `/home/frank/ecube/.venv/bin/python -m pytest tests/test_reconciliation.py -q`
  - Result: `65 passed in 1.39s`