### PR TITLE
Usb discovery bug

### DIFF
--- a/.github/prompts/pr-summary.prompt.md
+++ b/.github/prompts/pr-summary.prompt.md
@@ -8,7 +8,7 @@ agent: agent
 Create a polished pull request summary for the current ECUBE workspace changes.
 
 Your task:
-- Review the changed files, behavior changes, and any related tests or verification evidence in the current workspace.
+- Review the changed files, behavior changes, and any related tests or verification evidence in the current branch.
 - Summarize the change set in a concise, reviewer-friendly format.
 - Focus on what changed, why it matters, and how it was validated.
 

--- a/app/services/discovery_service.py
+++ b/app/services/discovery_service.py
@@ -50,6 +50,7 @@ from app.repositories.audit_repository import AuditRepository
 from app.repositories.drive_repository import DriveRepository
 from app.repositories.hardware_repository import HubRepository, PortRepository
 from app.utils.drive_identity import build_readable_device_label, mask_serial_number
+from app.utils.sanitize import normalize_project_id
 
 logger = logging.getLogger(__name__)
 
@@ -352,8 +353,17 @@ def run_discovery_sync(
 
             port_enabled = _port_is_enabled(port_id or existing.port_id)
 
-            # Mounted drives must never remain in AVAILABLE after rediscovery.
-            if port_enabled and existing.mount_path and existing.current_state != DriveState.IN_USE:
+            has_project_binding = bool(normalize_project_id(existing.current_project_id))
+
+            # Mounted drives become IN_USE on rediscovery only when they are
+            # still bound to a project. Mounted but uninitialized drives must
+            # remain AVAILABLE so discovery does not manufacture project ownership.
+            if (
+                port_enabled
+                and existing.mount_path
+                and has_project_binding
+                and existing.current_state != DriveState.IN_USE
+            ):
                 existing.current_state = DriveState.IN_USE
                 changed = True
             # Re-activate a previously disconnected drive only if the port is enabled.

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -585,7 +585,7 @@ def test_existing_tests_still_pass_with_enabled_port(db):
     assert drive.current_state == DriveState.AVAILABLE
 
 
-def test_disabled_port_drive_reconciles_to_in_use_when_reenabled_and_already_mounted(db):
+def test_disabled_port_drive_reconciles_to_available_when_reenabled_and_mounted_without_project(db):
     topology = DiscoveredTopology(
         hubs=[DiscoveredHub(system_identifier="usb1", name="Test Hub", vendor_id="1d6b", product_id="0002")],
         ports=[DiscoveredPort(
@@ -621,7 +621,52 @@ def test_disabled_port_drive_reconciles_to_in_use_when_reenabled_and_already_mou
 
     db.refresh(drive)
     assert summary["drives_updated"] == 1
+    assert drive.current_state == DriveState.AVAILABLE
+    assert drive.current_project_id is None
+    assert drive.mount_path == "/media/ecube/usb-mounted"
+
+
+def test_disabled_port_drive_reconciles_to_in_use_when_reenabled_and_mounted_with_project(db):
+    topology = DiscoveredTopology(
+        hubs=[DiscoveredHub(system_identifier="usb1", name="Test Hub", vendor_id="1d6b", product_id="0002")],
+        ports=[DiscoveredPort(
+            hub_system_identifier="usb1",
+            port_number=1,
+            system_path="1-1",
+            vendor_id="0781",
+            product_id="5583",
+            speed="5000",
+        )],
+        drives=[DiscoveredDrive(
+            device_identifier="SN-MOUNTED-BOUND",
+            port_system_path="1-1",
+            filesystem_path="/dev/sdb",
+            mount_path="/media/ecube/usb-mounted",
+            capacity_bytes=64_000_000_000,
+            manufacturer="SanDisk",
+            product_name="Ultra",
+            speed="5000",
+        )],
+    )
+
+    run_discovery_sync(db, topology_source=lambda: topology, filesystem_detector=_NULL_DETECTOR)
+
+    drive = db.query(UsbDrive).filter(UsbDrive.device_identifier == "SN-MOUNTED-BOUND").one()
+    assert drive.current_state == DriveState.DISCONNECTED
+
+    drive.current_project_id = "PROJ-BOUND"
+    db.commit()
+
+    port = db.query(UsbPort).one()
+    port.enabled = True
+    db.commit()
+
+    summary = run_discovery_sync(db, topology_source=lambda: topology, filesystem_detector=_NULL_DETECTOR)
+
+    db.refresh(drive)
+    assert summary["drives_updated"] == 1
     assert drive.current_state == DriveState.IN_USE
+    assert drive.current_project_id == "PROJ-BOUND"
     assert drive.mount_path == "/media/ecube/usb-mounted"
 
 


### PR DESCRIPTION
Summary

This branch closes a USB discovery gap that could mark a mounted drive as `IN_USE` even when it had no project binding. The change keeps discovery aligned with ECUBE’s project-isolation rules by requiring a valid `current_project_id` before rediscovery can promote a mounted drive back to `IN_USE`.

Changes included

- Updated USB discovery state promotion so a mounted drive on an enabled port only transitions to `IN_USE` when it is still project-bound.
- Kept mounted-but-uninitialized drives in `AVAILABLE`, preventing discovery from manufacturing an active owner after format or other binding-clearing flows.
- Reused the existing project ID normalization helper for the binding check, keeping the comparison consistent with the rest of the backend.
- Replaced the prior mounted-rediscovery test expectation with a regression test that asserts mounted drives without a project remain `AVAILABLE`.
- Added a companion regression test that preserves the intended behavior for mounted drives that do have a valid project binding.

Operator-facing effects

- Prevents drives from appearing reserved or active in the Drives workflow when they were mounted but never initialized to a project.
- Strengthens project isolation for USB lifecycle handling by ensuring discovery does not create invalid `IN_USE` + no-project states.
- Leaves issue 316-style reconciliation as fallback recovery, while preventing this bad state from being created in the first place.

Validation

- `python -m pytest tests/test_discovery.py -q`
  Result: `33 passed`
- `python -m pytest tests/test_reconciliation.py -q`
  Result: `66 passed`