### PR TITLE
Normalize project-backed audit selectors and file audit attribution

### DIFF
--- a/app/repositories/audit_repository.py
+++ b/app/repositories/audit_repository.py
@@ -141,13 +141,14 @@ class AuditRepository:
         offset: int = 0,
     ) -> List[AuditLog]:
         """Return audit log entries matching the given filters."""
+        normalized_project_id = _normalize_project_id(project_id)
         q = self.db.query(AuditLog)
         if user is not None:
             q = q.filter(AuditLog.user == user)
         if action is not None:
             q = q.filter(AuditLog.action == action)
-        if project_id is not None:
-            q = q.filter(AuditLog.project_id == project_id)
+        if normalized_project_id is not None:
+            q = q.filter(AuditLog.project_id == normalized_project_id)
         if drive_id is not None:
             q = q.filter(AuditLog.drive_id == drive_id)
         if job_id is not None:

--- a/app/routers/audit.py
+++ b/app/routers/audit.py
@@ -20,7 +20,7 @@ from app.schemas.errors import R_401, R_403, R_404, R_409, R_410, R_422
 from app.schemas.types import OptionalDatetimeQuery, OptionalIntQuery
 from app.services import audit_service
 from app.utils.client_ip import get_client_ip
-from app.utils.sanitize import normalize_project_id, sanitize_string, strict_sanitize_string
+from app.utils.sanitize import normalize_project_id, strict_sanitize_string
 
 logger = logging.getLogger(__name__)
 

--- a/app/routers/audit.py
+++ b/app/routers/audit.py
@@ -20,7 +20,7 @@ from app.schemas.errors import R_401, R_403, R_404, R_409, R_410, R_422
 from app.schemas.types import OptionalDatetimeQuery, OptionalIntQuery
 from app.services import audit_service
 from app.utils.client_ip import get_client_ip
-from app.utils.sanitize import sanitize_string, strict_sanitize_string
+from app.utils.sanitize import normalize_project_id, sanitize_string, strict_sanitize_string
 
 logger = logging.getLogger(__name__)
 
@@ -58,10 +58,10 @@ def list_audit_logs(
     **Roles:** ``admin``, ``manager``, ``auditor``
     """
     if project_id is not None:
-        sanitized: str = sanitize_string(project_id)
-        if not sanitized:
+        normalized_project_id = normalize_project_id(project_id)
+        if not isinstance(normalized_project_id, str) or not normalized_project_id:
             raise EncodingError("project_id is empty after removing invalid characters")
-        project_id = sanitized
+        project_id = normalized_project_id
 
     entries = AuditRepository(db).query(
         user=user,
@@ -98,10 +98,10 @@ def get_chain_of_custody(
             raise EncodingError("drive_sn contains invalid characters")
 
     if project_id is not None:
-        sanitized_project: str = sanitize_string(project_id)
-        if not sanitized_project:
+        normalized_project_id = normalize_project_id(project_id)
+        if not isinstance(normalized_project_id, str) or not normalized_project_id:
             raise EncodingError("project_id is empty after removing invalid characters")
-        project_id = sanitized_project
+        project_id = normalized_project_id
 
     return audit_service.get_chain_of_custody_report(
         db,

--- a/app/services/file_service.py
+++ b/app/services/file_service.py
@@ -101,6 +101,17 @@ def _file_to_item(ef: ExportFile, db: Session) -> FileCompareItem:
     )
 
 
+def _shared_project_id(*export_files: ExportFile) -> Optional[str]:
+    project_ids = {
+        export_file.project_id
+        for export_file in export_files
+        if isinstance(export_file.project_id, str) and export_file.project_id
+    }
+    if len(project_ids) != 1:
+        return None
+    return next(iter(project_ids))
+
+
 def get_file_hashes(
     file_id: int, db: Session, actor: Optional[str] = None,
     client_ip: Optional[str] = None,
@@ -130,6 +141,7 @@ def get_file_hashes(
     audit_repo.add(
         action="FILE_HASHES_RETRIEVED",
         user=actor,
+        project_id=ef.project_id,
         job_id=ef.job_id,
         details={
             "file_id": file_id,
@@ -209,9 +221,12 @@ def compare_files(
     audit_repo.add(
         action="FILE_COMPARE",
         user=actor,
+        project_id=_shared_project_id(ef_a, ef_b),
         details={
             "file_id_a": body.file_id_a,
             "file_id_b": body.file_id_b,
+            "file_a_project_id": ef_a.project_id,
+            "file_b_project_id": ef_b.project_id,
             "compare_mode": compare_mode,
             "match": match,
             "hash_match": hash_match,

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -156,6 +156,23 @@ class TestAuditFilters:
         assert len(data) == 2
         assert all(d["project_id"] == "PRJ-1" for d in data)
 
+    def test_filter_by_project_id_normalizes_case_and_whitespace(self, admin_client, db):
+        _seed_entries(
+            db,
+            [
+                {"action": "JOB_CREATED", "user": "griffin", "project_id": "PRJ-1", "details": {}},
+                {"action": "JOB_STARTED", "user": "griffin", "project_id": "PRJ-1", "details": {}},
+                {"action": "JOB_CREATED", "user": "alba", "project_id": "PRJ-2", "details": {}},
+            ],
+        )
+
+        response = admin_client.get("/audit", params={"project_id": " prj-1 "})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        assert all(d["project_id"] == "PRJ-1" for d in data)
+
     def test_filter_by_project_id_sanitizes_invalid_chars(self, admin_client, db):
         _seed_entries(
             db,

--- a/tests/test_chain_of_custody.py
+++ b/tests/test_chain_of_custody.py
@@ -158,6 +158,23 @@ class TestChainOfCustodyGet:
         assert payload["selector_mode"] == "PROJECT"
         assert [report["drive_id"] for report in payload["reports"]] == [drive_one_id, drive_two_id]
 
+    def test_project_selector_normalizes_case_and_whitespace(self, auditor_client, db):
+        drive = _seed_drive(db, device_identifier="COC-PROJECT-NORM", project_id="CASE-1")
+        drive_id = _as_int(drive.id)
+
+        _seed_audit(db, action="DRIVE_INITIALIZED", drive_id=drive_id, project_id="CASE-1", details={"drive_id": drive_id})
+
+        response = auditor_client.get(
+            "/audit/chain-of-custody",
+            params={"project_id": " case-1 "},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["selector_mode"] == "PROJECT"
+        assert payload["project_id"] == "CASE-1"
+        assert [report["drive_id"] for report in payload["reports"]] == [drive_id]
+
     def test_project_mismatch_with_drive_returns_conflict(self, auditor_client, db):
         drive = _seed_drive(db, device_identifier="COC-MISMATCH", project_id="CASE-A")
         drive_id = _as_int(drive.id)

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -145,6 +145,8 @@ def test_get_file_hashes_creates_audit_log(admin_client, db):
         .first()
     )
     assert entry is not None
+    assert entry.project_id == job.project_id
+    assert entry.job_id == job.id
     assert entry.details["file_id"] == ef.id
 
 
@@ -360,5 +362,6 @@ def test_compare_files_creates_audit_log(admin_client, db):
         db.query(AuditLog).filter(AuditLog.action == "FILE_COMPARE").first()
     )
     assert entry is not None
+    assert entry.project_id == job.project_id
     assert entry.details["file_id_a"] == ef_a.id
     assert entry.details["file_id_b"] == ef_b.id

--- a/tests/test_release_migration_tool.py
+++ b/tests/test_release_migration_tool.py
@@ -54,7 +54,7 @@ def test_release_migration_module_name_normalizes_semver() -> None:
 
 
 def test_release_migration_module_name_rejects_non_semver() -> None:
-    with pytest.raises(ReleaseMigrationError, match="must use major\.minor\.patch"):
+    with pytest.raises(ReleaseMigrationError, match=r"must use major\.minor\.patch"):
         release_migration_module_name("0.2")
 
 

--- a/tests/test_release_migration_tool.py
+++ b/tests/test_release_migration_tool.py
@@ -5,7 +5,6 @@ import pytest
 
 from app.utils.release_migration import (
     ReleaseMigrationError,
-    ReleaseMigrationResult,
     autogenerate_release_migration,
     create_release_migration,
     ensure_release_migration,


### PR DESCRIPTION
Summary

This change closes the service/API follow-through for the Project ownership refactor by making audit-facing project selectors resolve through the canonical normalized project identity and by ensuring file-level audit events carry direct project attribution. The result is that existing callers can continue using project-scoped audit and chain-of-custody paths transparently even when they submit legacy casing or whitespace, while file hash and compare actions remain safely attributable to the owning project.

Changes included

- Normalized `project_id` handling in the audit API paths so `/audit` and `/audit/chain-of-custody` resolve project-backed queries consistently for case/whitespace variants.
- Normalized repository-side audit filtering so backend callers querying audit logs by project also use the canonical project identity.
- Added direct project attribution to `FILE_HASHES_RETRIEVED` audit entries using the file’s owning project.
- Added shared-project resolution for `FILE_COMPARE` audit entries so same-project comparisons are attributed directly while still recording both file project IDs in audit details.
- Added focused regression coverage for:
  - normalized project filtering in audit log queries
  - normalized project selectors in chain-of-custody queries
  - direct project attribution in file hash and file compare audit events

User-facing or operator-facing effects

- Audit and chain-of-custody project filters now remain compatible for callers that send non-normalized project IDs such as lowercase or whitespace-padded values.
- File-related audit records are easier to attribute to the correct project under the new Project-backed ownership model.
- RBAC behavior and API contracts remain unchanged; this is a backend correctness and auditability improvement.

Validation

- `python -m pytest tests/test_audit.py tests/test_chain_of_custody.py tests/test_files.py -q`
  - Result: `66 passed`
- Editor diagnostics on the touched router, repository, service, and test files reported no errors.