### PR TITLE
enhance mounts dialog with improved layout and accessibility features

### DIFF
--- a/frontend/e2e/mounts.spec.js
+++ b/frontend/e2e/mounts.spec.js
@@ -3,6 +3,7 @@ import { setupAuthenticatedPage } from './helpers/app.js'
 import { expectNoCriticalA11yViolations } from './helpers/a11y.js'
 
 test('mounts add/edit/test/remove flow', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 620 })
   await setupAuthenticatedPage(page, ['admin'])
 
   const mounts = [{ id: 10, type: 'NFS', remote_path: '10.0.0.4:/exports', local_mount_point: '/nfs/exports', project_id: 'CASE-2026-000', status: 'MOUNTED' }]
@@ -151,7 +152,9 @@ test('mounts add/edit/test/remove flow', async ({ page }) => {
 
   await editDialog.getByRole('button', { name: 'Test', exact: true }).click()
   await expect(editDialog.getByText('Share test passed. You can now save these changes.')).toBeVisible()
+  await expect(editDialog.getByRole('button', { name: 'Cancel', exact: true })).toBeInViewport()
   await expect(editDialog.getByRole('button', { name: 'Save', exact: true })).toBeEnabled()
+  await expect(editDialog.getByRole('button', { name: 'Save', exact: true })).toBeInViewport()
 
   await page.getByLabel('Remote Path').fill('//server/case-2026-001-updated')
   await expect(editDialog.getByRole('button', { name: 'Save', exact: true })).toBeDisabled()

--- a/frontend/src/views/MountsView.vue
+++ b/frontend/src/views/MountsView.vue
@@ -763,56 +763,61 @@ onBeforeUnmount(() => {
 
     <teleport to="body">
       <div v-if="showAddDialog" class="dialog-overlay">
-        <div ref="addDialogRef" class="dialog-panel" role="dialog" aria-modal="true" :aria-labelledby="addMountDialogTitleId">
-          <h2 :id="addMountDialogTitleId">{{ dialogTitle }}</h2>
-          <p v-if="dialogError" class="error-banner" role="alert" aria-live="assertive">{{ dialogError }}</p>
-          <p v-if="dialogSuccessMessage" class="success-banner" role="status" aria-live="polite">{{ dialogSuccessMessage }}</p>
-          <label for="mount-type" class="field-label">
-            {{ t('common.labels.type') }}
-            <span class="required-indicator" aria-hidden="true">*</span>
-            <span class="sr-only">required</span>
-          </label>
-          <select id="mount-type" v-model="form.type" required aria-required="true">
-            <option value="SMB">SMB</option>
-            <option value="NFS">NFS</option>
-          </select>
-          <label for="mount-remote-path" class="field-label">
-            {{ t('mounts.remotePath') }}
-            <span class="required-indicator" aria-hidden="true">*</span>
-            <span class="sr-only">required</span>
-          </label>
-          <input id="mount-remote-path" v-model="form.remote_path" type="text" required aria-required="true" />
-          <label for="mount-project-id" class="field-label">
-            {{ t('dashboard.project') }}
-            <span class="required-indicator" aria-hidden="true">*</span>
-            <span class="sr-only">required</span>
-          </label>
-          <input id="mount-project-id" v-model="form.project_id" type="text" required aria-required="true" />
-          <template v-if="form.type === 'NFS'">
-            <label for="mount-nfs-client-version">{{ t('mounts.nfsClientVersion') }}</label>
-            <select id="mount-nfs-client-version" v-model="form.nfs_client_version">
-              <option v-for="option in nfsClientVersionSelectOptions" :key="option.value || 'default'" :value="option.value">{{ option.label }}</option>
-            </select>
-            <p class="field-help">{{ t('mounts.nfsClientVersionHelp') }}</p>
-          </template>
-          <template v-if="isEditMode && dialogLocalMountPoint">
-            <label for="mount-local-path">{{ t('mounts.localMountPointInfo') }}</label>
-            <input id="mount-local-path" :value="dialogLocalMountPoint" type="text" readonly />
-          </template>
-          <div v-if="isEditMode" class="credential-header-row">
-            <span class="field-label">{{ t('mounts.storedCredentials') }}</span>
-            <button class="btn btn-secondary btn-inline" type="button" @click="clearStoredCredentials">
-              {{ t('mounts.clearStoredCredentials') }}
-            </button>
+        <div ref="addDialogRef" class="dialog-panel mount-dialog-panel" role="dialog" aria-modal="true" :aria-labelledby="addMountDialogTitleId">
+          <div class="dialog-header mount-dialog-header">
+            <h2 :id="addMountDialogTitleId">{{ dialogTitle }}</h2>
+            <p v-if="dialogError" class="error-banner" role="alert" aria-live="assertive">{{ dialogError }}</p>
+            <p v-if="dialogSuccessMessage" class="success-banner" role="status" aria-live="polite">{{ dialogSuccessMessage }}</p>
           </div>
-          <label for="mount-username">{{ t('auth.username') }}</label>
-          <input id="mount-username" v-model="form.username" type="text" autocomplete="off" @input="markCredentialFieldChanged('username')" />
-          <label for="mount-password">{{ t('auth.password') }}</label>
-          <input id="mount-password" v-model="form.password" type="password" autocomplete="new-password" @input="markCredentialFieldChanged('password')" />
-          <label for="mount-creds-file">{{ t('mounts.credentialsFile') }}</label>
-          <input id="mount-creds-file" v-model="form.credentials_file" type="text" @input="markCredentialFieldChanged('credentials_file')" />
 
-          <div class="dialog-actions">
+          <div class="dialog-body mount-dialog-scroll-region">
+            <label for="mount-type" class="field-label">
+              {{ t('common.labels.type') }}
+              <span class="required-indicator" aria-hidden="true">*</span>
+              <span class="sr-only">required</span>
+            </label>
+            <select id="mount-type" v-model="form.type" required aria-required="true">
+              <option value="SMB">SMB</option>
+              <option value="NFS">NFS</option>
+            </select>
+            <label for="mount-remote-path" class="field-label">
+              {{ t('mounts.remotePath') }}
+              <span class="required-indicator" aria-hidden="true">*</span>
+              <span class="sr-only">required</span>
+            </label>
+            <input id="mount-remote-path" v-model="form.remote_path" type="text" required aria-required="true" />
+            <label for="mount-project-id" class="field-label">
+              {{ t('dashboard.project') }}
+              <span class="required-indicator" aria-hidden="true">*</span>
+              <span class="sr-only">required</span>
+            </label>
+            <input id="mount-project-id" v-model="form.project_id" type="text" required aria-required="true" />
+            <template v-if="form.type === 'NFS'">
+              <label for="mount-nfs-client-version">{{ t('mounts.nfsClientVersion') }}</label>
+              <select id="mount-nfs-client-version" v-model="form.nfs_client_version">
+                <option v-for="option in nfsClientVersionSelectOptions" :key="option.value || 'default'" :value="option.value">{{ option.label }}</option>
+              </select>
+              <p class="field-help">{{ t('mounts.nfsClientVersionHelp') }}</p>
+            </template>
+            <template v-if="isEditMode && dialogLocalMountPoint">
+              <label for="mount-local-path">{{ t('mounts.localMountPointInfo') }}</label>
+              <input id="mount-local-path" :value="dialogLocalMountPoint" type="text" readonly />
+            </template>
+            <div v-if="isEditMode" class="credential-header-row">
+              <span class="field-label">{{ t('mounts.storedCredentials') }}</span>
+              <button class="btn btn-secondary btn-inline" type="button" @click="clearStoredCredentials">
+                {{ t('mounts.clearStoredCredentials') }}
+              </button>
+            </div>
+            <label for="mount-username">{{ t('auth.username') }}</label>
+            <input id="mount-username" v-model="form.username" type="text" autocomplete="off" @input="markCredentialFieldChanged('username')" />
+            <label for="mount-password">{{ t('auth.password') }}</label>
+            <input id="mount-password" v-model="form.password" type="password" autocomplete="new-password" @input="markCredentialFieldChanged('password')" />
+            <label for="mount-creds-file">{{ t('mounts.credentialsFile') }}</label>
+            <input id="mount-creds-file" v-model="form.credentials_file" type="text" @input="markCredentialFieldChanged('credentials_file')" />
+          </div>
+
+          <div class="dialog-actions dialog-footer">
             <button class="btn" @click="closeAddDialog">{{ t('common.actions.cancel') }}</button>
             <button
               v-if="shareDiscoveryAvailable"
@@ -1078,6 +1083,25 @@ select {
   padding: var(--space-lg);
   display: grid;
   gap: var(--space-xs);
+}
+
+.mount-dialog-panel {
+  max-height: min(85vh, 44rem);
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  overflow: hidden;
+}
+
+.mount-dialog-header,
+.dialog-footer {
+  gap: var(--space-xs);
+}
+
+.mount-dialog-scroll-region {
+  display: grid;
+  gap: var(--space-xs);
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: var(--space-2xs);
 }
 
 .share-browser-panel {

--- a/frontend/src/views/__tests__/MountsView.spec.js
+++ b/frontend/src/views/__tests__/MountsView.spec.js
@@ -765,6 +765,32 @@ describe('MountsView removal flow', () => {
     expect(saveButton().attributes('disabled')).toBeDefined()
   })
 
+  it('keeps the edit dialog footer reachable by using an internal scroll region after test success', async () => {
+    mocks.getMounts.mockResolvedValue([buildMount({ id: 42, remote_path: '//server/original-share', project_id: 'PROJ-OLD' })])
+    mocks.validateMount.mockResolvedValue(buildMount({ id: 42, status: 'MOUNTED' }))
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const editButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('common.actions.edit'))
+    expect(editButton).toBeTruthy()
+
+    await editButton.trigger('click')
+    await flushPromises()
+
+    await findDialogButton(wrapper, i18n.global.t('mounts.test')).trigger('click')
+    await flushPromises()
+
+    const dialog = wrapper.find('.mount-dialog-panel')
+    const scrollRegion = wrapper.find('.mount-dialog-scroll-region')
+    const footer = wrapper.find('.dialog-footer')
+
+    expect(dialog.exists()).toBe(true)
+    expect(scrollRegion.exists()).toBe(true)
+    expect(footer.exists()).toBe(true)
+    expect(findDialogSuccessBanner(wrapper).text()).toContain(i18n.global.t('mounts.testSuccess'))
+  })
+
   it('clears the test success banner when the edit dialog is cancelled', async () => {
     mocks.getMounts.mockResolvedValue([buildMount({ id: 42, remote_path: '//server/original-share', project_id: 'PROJ-OLD' })])
     mocks.validateMount.mockResolvedValue(buildMount({ id: 42, status: 'MOUNTED' }))


### PR DESCRIPTION
### Summary

This branch fixes a Mounts-view usability regression where the Add/Edit Share dialog could grow past the viewport after a successful `Test`, making the footer actions hard or impossible to reach on shorter screens. The update keeps the dialog within the viewport by introducing an internal scroll region while preserving the existing add/edit/test flow and accessibility behavior.

### Changes included

- Reworked the Mounts add/edit dialog layout in `frontend/src/views/MountsView.vue` into:
  - a header region for the title and validation feedback
  - a scrollable body region for the form fields
  - a pinned footer region for dialog actions
- Added viewport-safe dialog sizing:
  - capped dialog height
  - internal vertical scrolling for the form body
  - footer actions kept reachable after success feedback appears
- Kept the existing form behavior intact for:
  - add vs edit mode
  - NFS-specific fields
  - stored credential clearing
  - in-dialog validation gating before save/create
- Added focused unit coverage in `frontend/src/views/__tests__/MountsView.spec.js` to assert the edit dialog renders the internal scroll region and footer after a successful test.
- Updated Playwright coverage in `frontend/e2e/mounts.spec.js` to:
  - run the edit flow in a shorter viewport
  - verify `Cancel` and `Save` remain in the viewport after the success message is shown

### User-facing effects

- Operators editing a network share can still reach `Cancel` and `Save` after a successful validation step on shorter laptop-sized viewports.
- Success or error feedback no longer needs to push the dialog footer out of reach.
- The fix is limited to the Mounts add/edit dialog UI; it does not change backend behavior, RBAC, audit behavior, or mount-validation semantics.

### Validation

- Unit tests:
  - `cd /home/frank/ecube/frontend && npm run test:unit -- src/views/__tests__/MountsView.spec.js`
  - Result: `31 passed`
- E2E tests:
  - `cd /home/frank/ecube/frontend && npm run test:e2e -- mounts.spec.js`
  - Result: `2 passed`
- Browser-focused verification included a reduced-height viewport in Playwright to directly cover the reported overflow scenario.