### PR TITLE
Keep mobile row action menus visible without stretching table rows/pr

### DIFF
--- a/frontend/e2e/drives.spec.js
+++ b/frontend/e2e/drives.spec.js
@@ -309,3 +309,51 @@ test('drives list and drive detail admin flows', async ({ page }) => {
 
   await expectNoCriticalA11yViolations(page)
 })
+
+test('drives mobile overflow menu stays visible without expanding the row', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await setupAuthenticatedPage(page, ['admin'])
+
+  const drive = {
+    id: 1,
+    device_identifier: '/dev/sdb',
+    display_device_label: 'SanDisk Ultra - Port 1',
+    manufacturer: 'SanDisk',
+    product_name: 'Ultra',
+    port_number: 1,
+    port_system_path: '2-1',
+    serial_number: 'SER-001',
+    filesystem_path: '/mnt/usb1',
+    filesystem_type: 'ext4',
+    capacity_bytes: 1073741824,
+    current_state: 'AVAILABLE',
+    current_project_id: null,
+    mount_path: '/mnt/ecube/1',
+  }
+
+  await routeJson(page, '**/api/drives', () => [drive])
+
+  await page.goto('/drives')
+  await expect(page.getByRole('heading', { name: 'Drives' })).toBeVisible()
+
+  const row = page.locator('tbody tr').first()
+  const rowBoxBefore = await row.boundingBox()
+
+  const toggle = page.getByLabel('SanDisk Ultra - Port 1 drive actions')
+  await toggle.click()
+
+  const popover = page.locator('.row-actions-popover').first()
+  await expect(popover).toBeVisible()
+  const popoverBox = await popover.boundingBox()
+
+  const rowBoxAfter = await row.boundingBox()
+
+  expect(rowBoxBefore).not.toBeNull()
+  expect(popoverBox).not.toBeNull()
+  expect(rowBoxAfter).not.toBeNull()
+  expect(popoverBox.x).toBeGreaterThanOrEqual(0)
+  expect(popoverBox.y).toBeGreaterThanOrEqual(0)
+  expect(popoverBox.x + popoverBox.width).toBeLessThanOrEqual(390)
+  expect(popoverBox.y + popoverBox.height).toBeLessThanOrEqual(844)
+  expect(Math.abs(rowBoxAfter.height - rowBoxBefore.height)).toBeLessThanOrEqual(1)
+})

--- a/frontend/e2e/jobs.spec.js
+++ b/frontend/e2e/jobs.spec.js
@@ -239,6 +239,53 @@ test('jobs list supports safe pause and resume flow', async ({ page }) => {
   await expectNoCriticalA11yViolations(page)
 })
 
+test('jobs mobile overflow menu stays visible without expanding the row', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await setupAuthenticatedPage(page, ['admin'])
+
+  const jobState = {
+    id: 89,
+    project_id: 'P-89',
+    evidence_number: 'EV-89',
+    status: 'RUNNING',
+    copied_bytes: 50,
+    total_bytes: 100,
+    thread_count: 2,
+    file_count: 2,
+    files_succeeded: 1,
+    active_duration_seconds: 90,
+    drive: { id: 9, port_system_path: '2-9', device_identifier: 'USB-009' },
+  }
+
+  await routeJson(page, '**/api/drives', [])
+  await routeJson(page, '**/api/mounts', [])
+  await routeJson(page, '**/api/jobs**', [jobState])
+
+  await page.goto('/jobs')
+  await expect(page.getByRole('heading', { name: 'Jobs' })).toBeVisible()
+
+  const row = page.locator('tbody tr').first()
+  const rowBoxBefore = await row.boundingBox()
+
+  const toggle = page.getByLabel('P-89 job actions')
+  await toggle.click()
+
+  const popover = page.locator('.row-actions-popover').first()
+  await expect(popover).toBeVisible()
+  const popoverBox = await popover.boundingBox()
+
+  const rowBoxAfter = await row.boundingBox()
+
+  expect(rowBoxBefore).not.toBeNull()
+  expect(popoverBox).not.toBeNull()
+  expect(rowBoxAfter).not.toBeNull()
+  expect(popoverBox.x).toBeGreaterThanOrEqual(0)
+  expect(popoverBox.y).toBeGreaterThanOrEqual(0)
+  expect(popoverBox.x + popoverBox.width).toBeLessThanOrEqual(390)
+  expect(popoverBox.y + popoverBox.height).toBeLessThanOrEqual(844)
+  expect(Math.abs(rowBoxAfter.height - rowBoxBefore.height)).toBeLessThanOrEqual(1)
+})
+
 test('jobs surfaces preparing labels during startup analysis', async ({ page }) => {
   await setupAuthenticatedPage(page, ['admin'])
 

--- a/frontend/e2e/mounts.spec.js
+++ b/frontend/e2e/mounts.spec.js
@@ -199,3 +199,38 @@ test('mounts add/edit/test/remove flow', async ({ page }) => {
 
   await expectNoCriticalA11yViolations(page)
 })
+
+test('mounts mobile overflow menu stays visible without expanding the row', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await setupAuthenticatedPage(page, ['admin'])
+
+  const mounts = [{ id: 10, type: 'SMB', remote_path: '//server/project', local_mount_point: '/smb/project', project_id: 'CASE-2026-001', status: 'MOUNTED' }]
+
+  await page.route('**/api/mounts', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mounts) })
+  })
+
+  await page.goto('/mounts')
+  await expect(page.getByRole('heading', { name: 'Mounts' })).toBeVisible()
+
+  const row = page.locator('tbody tr').first()
+  const rowBoxBefore = await row.boundingBox()
+
+  const toggle = page.getByLabel('CASE-2026-001 mount actions')
+  await toggle.click()
+
+  const popover = page.locator('.row-actions-popover').first()
+  await expect(popover).toBeVisible()
+  const popoverBox = await popover.boundingBox()
+
+  const rowBoxAfter = await row.boundingBox()
+
+  expect(rowBoxBefore).not.toBeNull()
+  expect(popoverBox).not.toBeNull()
+  expect(rowBoxAfter).not.toBeNull()
+  expect(popoverBox.x).toBeGreaterThanOrEqual(0)
+  expect(popoverBox.y).toBeGreaterThanOrEqual(0)
+  expect(popoverBox.x + popoverBox.width).toBeLessThanOrEqual(390)
+  expect(popoverBox.y + popoverBox.height).toBeLessThanOrEqual(844)
+  expect(Math.abs(rowBoxAfter.height - rowBoxBefore.height)).toBeLessThanOrEqual(1)
+})

--- a/frontend/src/views/DrivesView.vue
+++ b/frontend/src/views/DrivesView.vue
@@ -559,6 +559,10 @@ select {
 }
 
 @media (max-width: 768px) {
+  :deep(.table-scroll-wrapper) {
+    overflow: visible;
+  }
+
   .row-actions {
     display: none;
   }

--- a/frontend/src/views/JobsView.vue
+++ b/frontend/src/views/JobsView.vue
@@ -1076,6 +1076,10 @@ textarea {
 }
 
 @media (max-width: 768px) {
+  :deep(.table-scroll-wrapper) {
+    overflow: visible;
+  }
+
   .row-actions {
     display: none;
   }

--- a/frontend/src/views/MountsView.vue
+++ b/frontend/src/views/MountsView.vue
@@ -1125,6 +1125,10 @@ select {
 }
 
 @media (max-width: 768px) {
+  :deep(.table-scroll-wrapper) {
+    overflow: visible;
+  }
+
   .row-actions {
     display: none;
   }


### PR DESCRIPTION
Summary

This change makes the mobile row-action menus on the Drives, Jobs, and Mounts tables behave like true overlays instead of being clipped by the table container or expanding the row. The result is more consistent mobile behavior across the main operational list views.

Changes included

- Updated the mobile table styling in Drives, Jobs, and Mounts to allow row-action popovers to render outside the scroll wrapper.
- Kept the existing row-action pattern intact while removing the clipping behavior that hid mobile menus near the bottom of the table panel.
- Added focused Playwright coverage for each surface to verify the mobile action menu remains inside the viewport and does not increase row height when opened.
- Standardized the regression checks across:
  - Drives mobile row actions
  - Jobs mobile row actions
  - Mounts mobile row actions

User-facing effects

- Mobile users can open the row action menu on Drives, Jobs, and Mounts without the menu being cut off by the table panel.
- Opening a row action menu no longer stretches the table row to fit the menu content.
- Mobile behavior is now consistent across these three operational views.

Validation

- Focused regression run:
  - `npm run test:e2e -- --workers=1 drives.spec.js jobs.spec.js mounts.spec.js -g "mobile overflow menu stays visible without expanding the row"`
  - Result: 6 passed
- Broader surface validation:
  - `npm run test:e2e -- --workers=1 drives.spec.js jobs.spec.js mounts.spec.js`
  - Result: 48 passed