### PR TITLE
Allow prepare eject for mounted available drives

### DIFF
--- a/app/services/drive_service.py
+++ b/app/services/drive_service.py
@@ -654,10 +654,11 @@ def prepare_eject(drive_id: int, db: Session, actor: Optional[str] = None,
     # Capture the precondition state for later validation.
     initial_state = drive.current_state
     initial_device_path = drive.filesystem_path
+    allow_available_mounted_eject = initial_state == DriveState.AVAILABLE and bool(drive.mount_path)
 
-    # Fail fast if the drive is not in the required IN_USE state.
+    # Fail fast if the drive is not in a state that supports safe ECUBE-managed unmount.
     # Don't waste time on expensive OS operations for invalid preconditions.
-    if initial_state != DriveState.IN_USE:
+    if initial_state != DriveState.IN_USE and not allow_available_mounted_eject:
         if drive.mount_path:
             raise HTTPException(
                 status_code=409,
@@ -668,13 +669,19 @@ def prepare_eject(drive_id: int, db: Session, actor: Optional[str] = None,
             detail=f"Drive is not in IN_USE state; cannot prepare eject (current state: {initial_state.value})",
         )
 
-    # Check if the drive has any jobs with incomplete files (timeouts or errors).
-    # Warn the operator before allowing eject.
+    # Check active assignments before any OS work.
+    # Mounted AVAILABLE drives can be safely unmounted only when no job still actively claims them.
     try:
         incomplete_assignments = db.query(DriveAssignment).filter(
             DriveAssignment.drive_id == drive_id,
             DriveAssignment.released_at.is_(None)  # Only active assignments
         ).all()
+
+        if allow_available_mounted_eject and incomplete_assignments:
+            raise HTTPException(
+                status_code=409,
+                detail="Drive has an active job assignment and cannot be prepared for eject while still available",
+            )
         
         incomplete_file_count = 0
         for assignment in incomplete_assignments:

--- a/docs/operations/13-user-manual.md
+++ b/docs/operations/13-user-manual.md
@@ -335,7 +335,7 @@ Every drive moves through a defined set of states. Actions available in the UI d
 | State | Meaning | Actions available |
 |-----------|-------------------------------------------------------------------------|-----------------------------------|
 | `DISCONNECTED` | Drive is known to the system but not currently accessible — either not physically present, or present on a disabled port. | Enable port when the drive is still physically detected on a known port |
-| `AVAILABLE` | Drive is present on an enabled port and ready to be formatted or assigned to a project. | Format, Initialize |
+| `AVAILABLE` | Drive is present on an enabled port and ready to be formatted or assigned to a project. If it is still mounted from a prior ECUBE-managed session, it can also be safely unmounted. | Format, Initialize, Prepare Eject when mounted |
 | `IN_USE` | Drive is assigned to a project. Jobs can target this drive. | Prepare Eject |
 | `ARCHIVED` | Drive has been permanently handed off via the Chain of Custody workflow. | None — drive is read-only. |
 
@@ -413,6 +413,8 @@ Before initializing a drive:
 ### 7.6 Prepare Eject
 
 Use `Prepare Eject` before physically removing a drive. This flushes pending writes, unmounts the filesystem, and transitions the drive to `AVAILABLE`.
+
+`Prepare Eject` is available for drives in the normal `IN_USE` workflow and for mounted `AVAILABLE` drives that have not yet been initialized into an active job assignment. This lets operators safely unmount a newly mounted drive before removing it.
 
 After a successful prepare-eject:
 

--- a/frontend/public/help/manual.html
+++ b/frontend/public/help/manual.html
@@ -410,8 +410,8 @@ Current state
 </tr>
 <tr>
 <td><code>AVAILABLE</code></td>
-<td>Drive is present on an enabled port and ready to be formatted or assigned to a project.</td>
-<td>Format, Initialize</td>
+<td>Drive is present on an enabled port and ready to be formatted or assigned to a project. If it is still mounted from a prior ECUBE-managed session, it can also be safely unmounted.</td>
+<td>Format, Initialize, Prepare Eject when mounted</td>
 </tr>
 <tr>
 <td><code>IN_USE</code></td>
@@ -494,6 +494,7 @@ If you need to assign the drive to a <em>different</em> project, format it first
 </li></ul>
 <h2 id="4-6-prepare-eject">4.6 Prepare Eject</h2>
 <p>Use <code>Prepare Eject</code> before physically removing a drive. This flushes pending writes, unmounts the filesystem, and transitions the drive to <code>AVAILABLE</code>.</p>
+<p><code>Prepare Eject</code> is available for drives in the normal <code>IN_USE</code> workflow and for mounted <code>AVAILABLE</code> drives that have not yet been initialized into an active job assignment. This lets operators safely unmount a newly mounted drive before removing it.</p>
 <p>After a successful prepare-eject:</p>
 <ul><li>
 The drive state returns to <code>AVAILABLE</code>.

--- a/tests/test_drives.py
+++ b/tests/test_drives.py
@@ -1211,7 +1211,7 @@ def test_prepare_eject_requires_in_use_state(manager_client, db):
 
 
 def test_prepare_eject_available_state_conflict(manager_client, db):
-    """Prepare-eject on AVAILABLE drive returns 409 Conflict.
+    """Prepare-eject on unmounted AVAILABLE drive returns 409 Conflict.
     
     Verifies that prepare_eject is NOT called (fast-fail optimization).
     """
@@ -1230,6 +1230,62 @@ def test_prepare_eject_available_state_conflict(manager_client, db):
     assert response.status_code == 409
     assert "not in IN_USE state" in response.json()["message"]
     # Verify prepare_eject was NOT called (fast-fail before OS operations)
+    provider.prepare_eject.assert_not_called()
+
+
+def test_prepare_eject_allows_mounted_available_drive_without_active_assignment(manager_client, db):
+    drive = UsbDrive(
+        device_identifier="USB012-MOUNTED",
+        current_state=DriveState.AVAILABLE,
+        current_project_id=None,
+        filesystem_path="/dev/sdz",
+        mount_path="/media/usb012-mounted",
+    )
+    db.add(drive)
+    db.commit()
+
+    provider = _fake_eject()
+    with patch("app.routers.drives.get_drive_eject", return_value=provider):
+        response = manager_client.post(f"/drives/{drive.id}/prepare-eject")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["current_state"] == "AVAILABLE"
+    assert data["mount_path"] is None
+    provider.prepare_eject.assert_called_once_with("/dev/sdz")
+
+
+def test_prepare_eject_available_drive_with_active_assignment_conflict(manager_client, db):
+    drive = UsbDrive(
+        device_identifier="USB012-ACTIVE",
+        current_state=DriveState.AVAILABLE,
+        current_project_id=None,
+        filesystem_path="/dev/sdy",
+        mount_path="/media/usb012-active",
+    )
+    db.add(drive)
+    db.flush()
+
+    job = ExportJob(
+        project_id="PROJ-001",
+        evidence_number="EV-USB012-ACTIVE",
+        source_path="/data/evidence",
+        status=JobStatus.RUNNING,
+    )
+    db.add(job)
+    db.flush()
+
+    db.add(DriveAssignment(drive_id=drive.id, job_id=job.id))
+    db.commit()
+
+    provider = _fake_eject()
+    with patch("app.routers.drives.get_drive_eject", return_value=provider):
+        response = manager_client.post(f"/drives/{drive.id}/prepare-eject")
+
+    assert response.status_code == 409
+    assert response.json()["message"] == (
+        "Drive has an active job assignment and cannot be prepared for eject while still available"
+    )
     provider.prepare_eject.assert_not_called()
 
 


### PR DESCRIPTION
Summary

This change updates the drive lifecycle so ECUBE can safely run Prepare Eject on a mounted AVAILABLE drive before it has been initialized into active use. It preserves the existing safety boundary by continuing to block the operation when an active assignment still owns the drive, which matters for operator workflow, hardware handling, and auditable drive state transitions.

Changes included

- Relaxed the backend prepare-eject precondition in `drive_service` to allow the specific safe case: `AVAILABLE` plus mounted.
- Kept the fast-fail behavior for unsupported states and added an explicit conflict when a mounted `AVAILABLE` drive still has an active job assignment.
- Added backend regression coverage for:
  - successful prepare-eject on a mounted `AVAILABLE` drive with no active assignment
  - preserved conflict on an unmounted `AVAILABLE` drive
  - preserved conflict when an active assignment is still present
- Updated the user manual and bundled help page so reviewers and operators see the revised drive-state/action expectations.

Operator-facing effects

- Operators can now safely unmount a newly mounted drive with `Prepare Eject` before initialization, instead of being blocked by an `IN_USE`-only precondition.
- ECUBE still prevents eject preparation when the drive is actively claimed by a job assignment, preserving drive lifecycle safety and reducing the risk of disrupting in-use media handling.

Validation

- `python -m pytest tests/test_drives.py -k prepare_eject`
  - Result: `21 passed`
- `python -m pytest tests/test_drives.py tests/integration/test_drives_use_cases_integration.py -k prepare_eject`
  - Result: `21 passed, 2 skipped, 39 deselected`