### PR TITLE
Show CoC handoff failures in a modal dialog/pr

### DIFF
--- a/docs/operations/13-user-manual.md
+++ b/docs/operations/13-user-manual.md
@@ -747,8 +747,9 @@ Typical workflow:
 6. If you are an `admin` or `manager`, click `Prefill Handoff` to populate the handoff form from a selected report.
 7. Enter required handoff details (`Possessor` and `Delivery Time`) and any optional receipt fields. The delivery time picker uses your browser's local timezone; the application converts it to UTC automatically before storing.
 8. Click `Confirm Handoff`.
-9. Review the **Permanent Archive Warning** modal.
-10. Choose one of the following:
+9. If the handoff form is incomplete or the submission fails, ECUBE keeps the error inside a visible handoff-failure dialog in the active CoC workflow so you can correct the issue without scrolling back through the report.
+10. If validation succeeds, review the **Permanent Archive Warning** modal.
+11. Choose one of the following:
    - `Cancel`: closes the warning modal and does not record a handoff.
    - `Yes, archive drive`: records the handoff and archives the drive.
 

--- a/frontend/public/help/manual.html
+++ b/frontend/public/help/manual.html
@@ -824,7 +824,9 @@ Enter required handoff details (<code>Possessor</code> and <code>Delivery Time</
 </li><li>
 Click <code>Confirm Handoff</code>.
 </li><li>
-Review the <strong>Permanent Archive Warning</strong> modal.
+If the handoff form is incomplete or the submission fails, ECUBE keeps the error inside a visible handoff-failure dialog in the active CoC workflow so you can correct the issue without scrolling back through the report.
+</li><li>
+If validation succeeds, review the <strong>Permanent Archive Warning</strong> modal.
 </li><li>
 Choose one of the following:
 <ul><li>

--- a/frontend/src/components/common/ConfirmDialog.vue
+++ b/frontend/src/components/common/ConfirmDialog.vue
@@ -22,6 +22,10 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  showCancel: {
+    type: Boolean,
+    default: true,
+  },
   dangerous: {
     type: Boolean,
     default: false,
@@ -162,7 +166,7 @@ onUnmounted(() => {
           <slot />
         </div>
         <div class="dialog-actions">
-          <button class="btn" @click="close">{{ cancelLabel }}</button>
+          <button v-if="showCancel" class="btn" @click="close">{{ cancelLabel }}</button>
           <button
             class="btn"
             :class="dangerous ? 'btn-danger' : 'btn-primary'"

--- a/frontend/src/components/common/ConfirmDialog.vue
+++ b/frontend/src/components/common/ConfirmDialog.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, useSlots, watch, onUnmounted } from 'vue'
+import { computed, nextTick, onUnmounted, ref, useSlots, watch } from 'vue'
 
 const props = defineProps({
   modelValue: {
@@ -34,6 +34,8 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue', 'confirm', 'cancel'])
 const slots = useSlots()
+const dialogPanelRef = ref(null)
+const previousFocusRef = ref(null)
 
 const dialogId = `confirm-dialog-${Math.random().toString(36).slice(2, 10)}`
 const titleId = `${dialogId}-title`
@@ -55,8 +57,65 @@ function confirm() {
   emit('confirm')
 }
 
+function getFocusableElements() {
+  if (!(dialogPanelRef.value instanceof HTMLElement)) {
+    return []
+  }
+
+  return Array.from(
+    dialogPanelRef.value.querySelectorAll(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  )
+}
+
+function focusFirstElement() {
+  void nextTick(() => {
+    const [firstElement] = getFocusableElements()
+    firstElement?.focus()
+  })
+}
+
+function restorePreviousFocus() {
+  if (previousFocusRef.value instanceof HTMLElement) {
+    previousFocusRef.value.focus()
+  }
+  previousFocusRef.value = null
+}
+
+function trapFocus(event) {
+  const focusableElements = getFocusableElements()
+  if (!focusableElements.length) {
+    return
+  }
+
+  const firstElement = focusableElements[0]
+  const lastElement = focusableElements[focusableElements.length - 1]
+  const activeElement = document.activeElement
+
+  if (event.shiftKey && activeElement === firstElement) {
+    event.preventDefault()
+    lastElement.focus()
+    return
+  }
+
+  if (!event.shiftKey && activeElement === lastElement) {
+    event.preventDefault()
+    firstElement.focus()
+  }
+}
+
 function onKeydown(event) {
-  if (event.key === 'Escape' && props.modelValue) {
+  if (!props.modelValue) {
+    return
+  }
+
+  if (event.key === 'Tab') {
+    trapFocus(event)
+    return
+  }
+
+  if (event.key === 'Escape') {
     event.preventDefault()
     close()
   }
@@ -64,11 +123,18 @@ function onKeydown(event) {
 
 watch(
   () => props.modelValue,
-  (open) => {
+  (open, wasOpen) => {
     if (open) {
+      previousFocusRef.value = document.activeElement instanceof HTMLElement ? document.activeElement : null
       document.addEventListener('keydown', onKeydown)
+      focusFirstElement()
     } else {
       document.removeEventListener('keydown', onKeydown)
+      if (wasOpen) {
+        void nextTick(() => {
+          restorePreviousFocus()
+        })
+      }
     }
   },
   { immediate: true },
@@ -83,6 +149,7 @@ onUnmounted(() => {
   <teleport to="body">
     <div v-if="modelValue" class="dialog-overlay" @click.self="close">
       <div
+        ref="dialogPanelRef"
         class="dialog-panel"
         role="dialog"
         aria-modal="true"

--- a/frontend/src/components/common/__tests__/ConfirmDialog.spec.js
+++ b/frontend/src/components/common/__tests__/ConfirmDialog.spec.js
@@ -106,4 +106,70 @@ describe('ConfirmDialog', () => {
     expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([false])
     wrapper.unmount()
   })
+
+  it('traps focus inside the dialog when tabbing', async () => {
+    const wrapper = mount(ConfirmDialog, {
+      attachTo: document.body,
+      props: {
+        modelValue: true,
+        title: 'Confirm',
+        confirmLabel: 'Yes',
+        cancelLabel: 'No',
+      },
+      global: {
+        stubs: {
+          teleport: true,
+        },
+      },
+    })
+
+    await nextTick()
+
+    const buttons = wrapper.findAll('button')
+    expect(document.activeElement).toBe(buttons[0].element)
+
+    buttons[1].element.focus()
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }))
+    await nextTick()
+    expect(document.activeElement).toBe(buttons[0].element)
+
+    buttons[0].element.focus()
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true }))
+    await nextTick()
+    expect(document.activeElement).toBe(buttons[1].element)
+
+    wrapper.unmount()
+  })
+
+  it('restores focus to the triggering element when closed', async () => {
+    const trigger = document.createElement('button')
+    trigger.textContent = 'Open dialog'
+    document.body.appendChild(trigger)
+    trigger.focus()
+
+    const wrapper = mount(ConfirmDialog, {
+      attachTo: document.body,
+      props: {
+        modelValue: true,
+        title: 'Confirm',
+        confirmLabel: 'Yes',
+        cancelLabel: 'No',
+      },
+      global: {
+        stubs: {
+          teleport: true,
+        },
+      },
+    })
+
+    await nextTick()
+    await wrapper.findAll('button')[0].trigger('click')
+    await wrapper.setProps({ modelValue: false })
+    await nextTick()
+
+    expect(document.activeElement).toBe(trigger)
+
+    wrapper.unmount()
+    trigger.remove()
+  })
 })

--- a/frontend/src/components/common/__tests__/ConfirmDialog.spec.js
+++ b/frontend/src/components/common/__tests__/ConfirmDialog.spec.js
@@ -172,4 +172,26 @@ describe('ConfirmDialog', () => {
     wrapper.unmount()
     trigger.remove()
   })
+
+  it('can render a single acknowledgement action', () => {
+    const wrapper = mount(ConfirmDialog, {
+      props: {
+        modelValue: true,
+        title: 'Notice',
+        confirmLabel: 'OK',
+        cancelLabel: 'Cancel',
+        showCancel: false,
+      },
+      global: {
+        stubs: {
+          teleport: true,
+        },
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    expect(buttons).toHaveLength(1)
+    expect(buttons[0].text()).toBe('OK')
+    wrapper.unmount()
+  })
 })

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -364,6 +364,7 @@
     "handoffWarningMessage": "This action will permanently archive the drive and remove it from active circulation. All operational actions (initialization, copy jobs, eject) will be blocked, and chain-of-custody selectors will exclude the drive. Read-only history (audit logs, drive list) remains visible. This action cannot be undone.",
     "handoffWarningConfirm": "Yes, archive drive",
     "handoffWarningCancel": "Cancel",
+    "handoffErrorTitle": "Handoff Failed",
     "handoffSaved": "Custody handoff recorded.",
     "driveArchived": "This drive has been archived after handoff. The chain-of-custody report endpoint does not return reports for archived drives, but the drive remains visible in the drive list and audit log.",
     "handoffInvalid": "Drive ID, possessor, and delivery time are required.",

--- a/frontend/src/views/JobDetailView.vue
+++ b/frontend/src/views/JobDetailView.vue
@@ -2011,6 +2011,7 @@ onUnmounted(() => {
       :message="''"
       :confirm-label="t('common.actions.close')"
       :cancel-label="t('common.actions.cancel')"
+      :show-cancel="false"
       @confirm="closeCocHandoffErrorDialog"
       @cancel="closeCocHandoffErrorDialog"
     >

--- a/frontend/src/views/JobDetailView.vue
+++ b/frontend/src/views/JobDetailView.vue
@@ -83,10 +83,12 @@ const editForm = ref({
 
 const cocLoading = ref(false)
 const cocError = ref('')
+const cocHandoffError = ref('')
 const cocStatusMessage = ref('')
 const cocGeneratedAt = ref('')
 const cocReport = ref(null)
 const handoffSaving = ref(false)
+const showCocHandoffErrorDialog = ref(false)
 const cocHandoffForm = ref({
   drive_id: '',
   project_id: '',
@@ -793,10 +795,20 @@ function prepareCocHandoff(report) {
   }
 }
 
+function showCocHandoffError(message) {
+  cocHandoffError.value = message
+  showCocHandoffErrorDialog.value = true
+}
+
+function closeCocHandoffErrorDialog() {
+  showCocHandoffErrorDialog.value = false
+  cocHandoffError.value = ''
+}
+
 function submitCocHandoff() {
   const driveId = Number(cocHandoffForm.value.drive_id)
   if (!Number.isInteger(driveId) || driveId <= 0 || !cocHandoffForm.value.possessor.trim() || !cocHandoffForm.value.delivery_time) {
-    cocError.value = t('audit.handoffInvalid')
+    showCocHandoffError(t('audit.handoffInvalid'))
     return
   }
   showCocHandoffWarning.value = true
@@ -807,6 +819,8 @@ async function confirmCocHandoffSubmission() {
   showCocHandoffWarning.value = false
   handoffSaving.value = true
   cocError.value = ''
+  cocHandoffError.value = ''
+  showCocHandoffErrorDialog.value = false
   cocStatusMessage.value = ''
   try {
     await confirmJobChainOfCustodyHandoff(job.value.id, {
@@ -821,7 +835,7 @@ async function confirmCocHandoffSubmission() {
     await Promise.all([loadJobChainOfCustody(), refreshAll()])
     cocStatusMessage.value = t('audit.handoffSaved')
   } catch (err) {
-    cocError.value = buildJobError(err)
+    showCocHandoffError(buildJobError(err))
   } finally {
     handoffSaving.value = false
   }
@@ -1990,6 +2004,18 @@ onUnmounted(() => {
       @confirm="confirmCocHandoffSubmission"
       @cancel="cancelCocHandoffSubmission"
     />
+
+    <ConfirmDialog
+      v-model="showCocHandoffErrorDialog"
+      :title="t('audit.handoffErrorTitle')"
+      :message="''"
+      :confirm-label="t('common.actions.close')"
+      :cancel-label="t('common.actions.cancel')"
+      @confirm="closeCocHandoffErrorDialog"
+      @cancel="closeCocHandoffErrorDialog"
+    >
+      <p class="error-banner" role="alert" aria-live="assertive">{{ cocHandoffError }}</p>
+    </ConfirmDialog>
   </section>
 </template>
 

--- a/frontend/src/views/__tests__/JobDetailView.spec.js
+++ b/frontend/src/views/__tests__/JobDetailView.spec.js
@@ -965,6 +965,127 @@ describe('JobDetailView start action', () => {
     expect(wrapper.text()).toContain(i18n.global.t('audit.handoffSaved'))
   })
 
+  it('shows failed CoC handoff submission in a visible dialog context', async () => {
+    mocks.getJob.mockResolvedValue({
+      id: 6,
+      status: 'COMPLETED',
+      project_id: 'PROJ-001',
+      evidence_number: 'EV-006',
+      source_path: '/nfs/project-001/evidence',
+      target_mount_path: '/mnt/ecube/1',
+      thread_count: 4,
+      copied_bytes: 10,
+      total_bytes: 10,
+      file_count: 1,
+      files_succeeded: 1,
+      files_failed: 0,
+      files_timed_out: 0,
+      startup_analysis_status: 'READY',
+      drive: { id: 1, current_state: 'AVAILABLE', is_mounted: false },
+    })
+    mocks.getJobChainOfCustody.mockResolvedValue({
+      selector_mode: 'JOB',
+      project_id: 'PROJ-001',
+      snapshot_updated_at: '2026-04-28T19:30:00Z',
+      reports: [{
+        drive_id: 1,
+        drive_sn: 'SN-001',
+        drive_manufacturer: 'PNY',
+        drive_model: 'USB 3.2.1 FD',
+        project_id: 'PROJ-001',
+        custody_complete: false,
+        delivery_time: null,
+        chain_of_custody_events: [],
+        manifest_summary: [],
+      }],
+    })
+    mocks.confirmJobChainOfCustodyHandoff.mockRejectedValue({
+      response: {
+        status: 409,
+        data: { detail: 'Drive handoff could not be recorded.' },
+      },
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const openCocButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('audit.chainTitle'))
+    await openCocButton.trigger('click')
+    await flushPromises()
+
+    const prefillButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('audit.prefillHandoff'))
+    await prefillButton.trigger('click')
+    await flushPromises()
+
+    await wrapper.find(`input[aria-label="${i18n.global.t('audit.possessor')}"]`).setValue('Evidence Locker')
+    await wrapper.find(`input[aria-label="${i18n.global.t('audit.deliveryTimeLocalInput')}"]`).setValue('2026-04-28T14:00')
+
+    const confirmHandoffButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('audit.confirmHandoff'))
+    await confirmHandoffButton.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.confirm-dialog-stub').exists()).toBe(true)
+    await wrapper.find('.confirm-dialog-confirm').trigger('click')
+    await flushPromises()
+
+    const dialogTitles = wrapper.findAll('.confirm-dialog-title').map((node) => node.text())
+    expect(dialogTitles).toContain(i18n.global.t('audit.handoffErrorTitle'))
+    expect(wrapper.text()).toContain('Drive handoff could not be recorded.')
+    expect(wrapper.findAll('.confirm-dialog-stub')).toHaveLength(1)
+  })
+
+  it('shows invalid CoC handoff input in a visible dialog context', async () => {
+    mocks.getJob.mockResolvedValue({
+      id: 6,
+      status: 'COMPLETED',
+      project_id: 'PROJ-001',
+      evidence_number: 'EV-006',
+      source_path: '/nfs/project-001/evidence',
+      target_mount_path: '/mnt/ecube/1',
+      thread_count: 4,
+      copied_bytes: 10,
+      total_bytes: 10,
+      file_count: 1,
+      files_succeeded: 1,
+      files_failed: 0,
+      files_timed_out: 0,
+      startup_analysis_status: 'READY',
+      drive: { id: 1, current_state: 'AVAILABLE', is_mounted: false },
+    })
+    mocks.getJobChainOfCustody.mockResolvedValue({
+      selector_mode: 'JOB',
+      project_id: 'PROJ-001',
+      snapshot_updated_at: '2026-04-28T19:30:00Z',
+      reports: [{
+        drive_id: 1,
+        drive_sn: 'SN-001',
+        drive_manufacturer: 'PNY',
+        drive_model: 'USB 3.2.1 FD',
+        project_id: 'PROJ-001',
+        custody_complete: false,
+        delivery_time: null,
+        chain_of_custody_events: [],
+        manifest_summary: [],
+      }],
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const openCocButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('audit.chainTitle'))
+    await openCocButton.trigger('click')
+    await flushPromises()
+
+    const confirmHandoffButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('audit.confirmHandoff'))
+    await confirmHandoffButton.trigger('click')
+    await flushPromises()
+
+    const dialogTitles = wrapper.findAll('.confirm-dialog-title').map((node) => node.text())
+    expect(dialogTitles).toContain(i18n.global.t('audit.handoffErrorTitle'))
+    expect(wrapper.text()).toContain(i18n.global.t('audit.handoffInvalid'))
+    expect(mocks.confirmJobChainOfCustodyHandoff).not.toHaveBeenCalled()
+  })
+
   it('refreshes and stores the CoC snapshot from the dialog toolbar', async () => {
     mocks.getJob.mockResolvedValue({
       id: 6,


### PR DESCRIPTION
Summary

This change keeps Chain of Custody handoff failures visible inside the active Job Detail workflow instead of relying on the inline CoC banner near the top of the dialog. It matters for operator usability in an audit-sensitive flow because invalid input or a failed Confirm Handoff action now stays in the same modal context where the user is already working.

Changes included

- Updated the Job Detail CoC handoff flow to route validation failures and failed handoff submissions into a dedicated modal error dialog.
- Reused the existing shared `ConfirmDialog` pattern instead of introducing a new modal surface.
- Added a specific localized title for the handoff failure dialog.
- Added focused frontend regression coverage for:
  - invalid handoff input showing a visible dialog-scoped error
  - failed handoff submission showing a visible dialog-scoped error after the warning confirmation step

User-facing or operator-facing effects

- Operators no longer need to scroll back to the top of the Chain of Custody dialog to discover why Confirm Handoff failed.
- Error feedback now stays visible in the active modal workflow, which aligns the handoff experience with the application’s stronger floating-dialog error pattern.
- Backend handoff behavior, role restrictions, and audit workflow semantics are unchanged; this is a UI feedback and consistency fix.

Validation

- `npm run test:unit -- src/views/__tests__/JobDetailView.spec.js`
  - Result: `52 passed`
- `npx playwright test e2e/audit.spec.js --grep "job detail chain of custody report renders printable sections and CoC exports on mobile|requires warning confirmation and submits archive handoff from job detail"`
  - Result: `3 passed, 1 skipped`
- Editor diagnostics
  - Result: no errors in the changed frontend files