### PR TITLE
Logging consistency

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,5 +1,6 @@
+import logging
 from dataclasses import dataclass, field
-from typing import Callable, List, Optional
+from typing import Callable, List, NoReturn, Optional
 
 import jwt
 from fastapi import Depends, HTTPException, Request, status
@@ -11,6 +12,7 @@ from app.database import get_db
 from app.exceptions import AuthorizationError
 
 _bearer_scheme = HTTPBearer(auto_error=False)
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -19,6 +21,32 @@ class CurrentUser:
     username: str
     groups: List[str] = field(default_factory=list)
     roles: List[str] = field(default_factory=list)
+
+
+def _raise_authentication_http_exception(
+    request: Request,
+    *,
+    detail: str,
+    reason: str,
+    extra: Optional[dict[str, object]] = None,
+) -> NoReturn:
+    log_extra = {
+        "event_code": "AUTHENTICATION_DENIED",
+        "status_code": status.HTTP_401_UNAUTHORIZED,
+        "request_path": str(request.url.path),
+        "request_method": request.method,
+        "auth_reason": reason,
+        "role_resolver": settings.role_resolver,
+    }
+    if extra:
+        log_extra.update(extra)
+
+    logger.warning("Authentication denied", extra=log_extra)
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail=detail,
+        headers={"WWW-Authenticate": "Bearer"},
+    )
 
 
 def get_current_user(
@@ -53,17 +81,18 @@ def get_current_user(
     request.state.db = db
 
     if credentials is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+        _raise_authentication_http_exception(
+            request,
             detail="Missing authentication token",
-            headers={"WWW-Authenticate": "Bearer"},
+            reason="missing_token",
         )
 
     if credentials.scheme.lower() != "bearer":
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+        _raise_authentication_http_exception(
+            request,
             detail="Invalid authentication token",
-            headers={"WWW-Authenticate": "Bearer"},
+            reason="invalid_auth_scheme",
+            extra={"auth_scheme": credentials.scheme},
         )
 
     token = credentials.credentials
@@ -84,25 +113,25 @@ def get_current_user(
             algorithms=[settings.algorithm],
         )
     except jwt.ExpiredSignatureError:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+        _raise_authentication_http_exception(
+            request,
             detail="Token has expired",
-            headers={"WWW-Authenticate": "Bearer"},
+            reason="token_expired",
         )
     except jwt.InvalidTokenError:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+        _raise_authentication_http_exception(
+            request,
             detail="Invalid authentication token",
-            headers={"WWW-Authenticate": "Bearer"},
+            reason="token_validation_failed",
         )
 
     user_id = payload.get("sub")
     username = payload.get("username")
     if user_id is None or username is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+        _raise_authentication_http_exception(
+            request,
             detail="Invalid token payload",
-            headers={"WWW-Authenticate": "Bearer"},
+            reason="invalid_token_payload",
         )
 
     groups = payload.get("groups", [])
@@ -113,17 +142,17 @@ def get_current_user(
         roles = []
 
     if not isinstance(groups, list) or not all(isinstance(group, str) for group in groups):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+        _raise_authentication_http_exception(
+            request,
             detail="Invalid token payload",
-            headers={"WWW-Authenticate": "Bearer"},
+            reason="invalid_token_groups",
         )
 
     if not isinstance(roles, list) or not all(isinstance(role, str) for role in roles):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+        _raise_authentication_http_exception(
+            request,
             detail="Invalid token payload",
-            headers={"WWW-Authenticate": "Bearer"},
+            reason="invalid_token_roles",
         )
 
     # When the token carries no explicit roles, resolve them from group
@@ -160,18 +189,19 @@ def _get_current_user_oidc(token: str, request: Request) -> CurrentUser:
     try:
         payload = validate_token(token)
     except OidcTokenError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+        _raise_authentication_http_exception(
+            request,
             detail=str(exc),
-            headers={"WWW-Authenticate": "Bearer"},
+            reason="oidc_validation_failed",
+            extra={"error_type": type(exc).__name__},
         )
 
     user_id = payload.get("sub")
     if not user_id:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+        _raise_authentication_http_exception(
+            request,
             detail="Invalid token payload",
-            headers={"WWW-Authenticate": "Bearer"},
+            reason="invalid_token_payload",
         )
 
     # Prefer a human-readable username; fall back to the subject identifier.
@@ -183,10 +213,10 @@ def _get_current_user_oidc(token: str, request: Request) -> CurrentUser:
 
     raw_groups = payload.get(settings.oidc_group_claim_name, [])
     if not isinstance(raw_groups, list) or not all(isinstance(g, str) for g in raw_groups):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+        _raise_authentication_http_exception(
+            request,
             detail="Invalid token payload",
-            headers={"WWW-Authenticate": "Bearer"},
+            reason="invalid_token_groups",
         )
 
     groups = raw_groups
@@ -208,7 +238,8 @@ def require_roles(*allowed_roles: str) -> Callable[..., CurrentUser]:
     Returns a dependency callable that validates the current user holds at least
     one of *allowed_roles*.  Raises HTTP 403 (via :class:`AuthorizationError`)
     when the user is authenticated but lacks the required role.  Every denial is
-    recorded in the audit log with the actor identity and context.
+    recorded in application logs and, when available, the audit log with the actor
+    identity and request context.
 
     Usage::
 
@@ -229,6 +260,7 @@ def require_roles(*allowed_roles: str) -> Callable[..., CurrentUser]:
         if not any(r in current_user.roles for r in allowed_roles):
             _try_log_authorization_denied(
                 db=db,
+                actor_id=current_user.id,
                 actor=current_user.username,
                 path=str(request.url.path),
                 method=request.method,
@@ -245,6 +277,7 @@ def require_roles(*allowed_roles: str) -> Callable[..., CurrentUser]:
 
 def _try_log_authorization_denied(
     db: Optional[Session],
+    actor_id: Optional[str],
     actor: str,
     path: str,
     method: str,
@@ -252,6 +285,19 @@ def _try_log_authorization_denied(
     user_roles: List[str],
 ) -> None:
     """Best-effort audit log for role-denial events.  Never raises."""
+    logger.warning(
+        "Authorization denied",
+        extra={
+            "event_code": "AUTHORIZATION_DENIED",
+            "status_code": status.HTTP_403_FORBIDDEN,
+            "actor_id": actor_id,
+            "actor_username": actor,
+            "request_path": path,
+            "request_method": method,
+            "required_roles": sorted(required_roles),
+            "user_roles": sorted(user_roles),
+        },
+    )
     if db is None:
         return
     try:

--- a/app/main.py
+++ b/app/main.py
@@ -988,6 +988,18 @@ def _log_exception_info(
     )
 
 
+def _safe_http_exception_summary(status_code: int, code: str, detail: str) -> str:
+    default_summaries = {
+        401: "Unauthorized request",
+        403: "Forbidden request",
+        404: "Requested resource was not found",
+        409: "Request conflicts with the current resource state",
+        410: "Requested resource is no longer available",
+        413: "Request payload is too large",
+    }
+    return sanitize_error_message(detail, default_summaries.get(status_code, f"{code} request failed"))
+
+
 @app.exception_handler(AuthenticationError)
 async def authentication_error_handler(request: Request, exc: AuthenticationError) -> JSONResponse:
     trace_id = str(uuid.uuid4())
@@ -1082,11 +1094,12 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException) 
     code = code_map.get(exc.status_code, f"HTTP_{exc.status_code}")
     detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
     trace_id = str(uuid.uuid4())
+    safe_summary = _safe_http_exception_summary(exc.status_code, code, detail)
     _log_exception_info(
         request,
         status_code=exc.status_code,
         code=code,
-        summary=detail,
+        summary=safe_summary,
         trace_id=trace_id,
         extra={"error_category": "http_exception"},
     )

--- a/app/main.py
+++ b/app/main.py
@@ -963,9 +963,42 @@ def _try_log_auth_failure(request: Request, reason: str, trace_id: str) -> None:
         pass
 
 
+def _log_exception_info(
+    request: Request,
+    *,
+    status_code: int,
+    code: str,
+    summary: str,
+    trace_id: str,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    safe_context: dict[str, Any] = {
+        "status_code": status_code,
+        "error_code": code,
+        "trace_id": trace_id,
+        "request_path": request.url.path,
+        "request_method": request.method,
+        "failure_summary": summary,
+    }
+    if extra:
+        safe_context.update(extra)
+    logger.info(
+        f"Handled exception status={status_code} code={code} trace_id={trace_id} path={request.url.path}",
+        extra=safe_context,
+    )
+
+
 @app.exception_handler(AuthenticationError)
 async def authentication_error_handler(request: Request, exc: AuthenticationError) -> JSONResponse:
     trace_id = str(uuid.uuid4())
+    _log_exception_info(
+        request,
+        status_code=401,
+        code=exc.code,
+        summary=exc.message,
+        trace_id=trace_id,
+        extra={"error_category": "authentication_failure"},
+    )
     logger.warning("401 %s trace_id=%s path=%s", exc.code, trace_id, request.url.path)
     _try_log_auth_failure(request, reason=exc.message, trace_id=trace_id)
     return _error_response(401, exc.code, exc.message, trace_id)
@@ -974,6 +1007,14 @@ async def authentication_error_handler(request: Request, exc: AuthenticationErro
 @app.exception_handler(AuthorizationError)
 async def authorization_error_handler(request: Request, exc: AuthorizationError) -> JSONResponse:
     trace_id = str(uuid.uuid4())
+    _log_exception_info(
+        request,
+        status_code=403,
+        code=exc.code,
+        summary=exc.message,
+        trace_id=trace_id,
+        extra={"error_category": "authorization_failure"},
+    )
     logger.warning("403 %s trace_id=%s path=%s", exc.code, trace_id, request.url.path)
     return _error_response(403, exc.code, exc.message, trace_id)
 
@@ -981,6 +1022,14 @@ async def authorization_error_handler(request: Request, exc: AuthorizationError)
 @app.exception_handler(ConflictError)
 async def conflict_error_handler(request: Request, exc: ConflictError) -> JSONResponse:
     trace_id = str(uuid.uuid4())
+    _log_exception_info(
+        request,
+        status_code=409,
+        code=exc.code,
+        summary=exc.message,
+        trace_id=trace_id,
+        extra={"error_category": "conflict"},
+    )
     logger.warning("409 %s trace_id=%s path=%s", exc.code, trace_id, request.url.path)
     return _error_response(409, exc.code, exc.message, trace_id)
 
@@ -988,6 +1037,14 @@ async def conflict_error_handler(request: Request, exc: ConflictError) -> JSONRe
 @app.exception_handler(ECUBEException)
 async def ecube_exception_handler(request: Request, exc: ECUBEException) -> JSONResponse:
     trace_id = str(uuid.uuid4())
+    _log_exception_info(
+        request,
+        status_code=exc.status_code,
+        code=exc.code,
+        summary=exc.message,
+        trace_id=trace_id,
+        extra={"error_category": "application_exception"},
+    )
     logger.error("%d %s trace_id=%s path=%s", exc.status_code, exc.code, trace_id, request.url.path)
     return _error_response(exc.status_code, exc.code, exc.message, trace_id)
 
@@ -1000,6 +1057,14 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
         loc = " -> ".join(str(part) for part in error["loc"])
         messages.append(f"{loc}: {error['msg']}")
     detail = "; ".join(messages)
+    _log_exception_info(
+        request,
+        status_code=422,
+        code="VALIDATION_ERROR",
+        summary="Request validation failed",
+        trace_id=trace_id,
+        extra={"error_category": "validation_failure"},
+    )
     logger.info("422 VALIDATION_ERROR trace_id=%s path=%s", trace_id, request.url.path)
     return _error_response(422, "VALIDATION_ERROR", detail, trace_id)
 
@@ -1017,6 +1082,14 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException) 
     code = code_map.get(exc.status_code, f"HTTP_{exc.status_code}")
     detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
     trace_id = str(uuid.uuid4())
+    _log_exception_info(
+        request,
+        status_code=exc.status_code,
+        code=code,
+        summary=detail,
+        trace_id=trace_id,
+        extra={"error_category": "http_exception"},
+    )
     log_level = logging.WARNING if exc.status_code == 413 else logging.INFO
     logger.log(log_level, "%d %s trace_id=%s path=%s", exc.status_code, code, trace_id, request.url.path)
     if exc.status_code == 401:
@@ -1037,6 +1110,14 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException) 
 async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     trace_id = str(uuid.uuid4())
     if is_encoding_error(exc):
+        _log_exception_info(
+            request,
+            status_code=422,
+            code="ENCODING_ERROR",
+            summary="Request contains invalid characters.",
+            trace_id=trace_id,
+            extra={"error_category": "encoding_error"},
+        )
         logger.warning("422 ENCODING_ERROR trace_id=%s path=%s", trace_id, request.url.path, exc_info=exc)
         return _error_response(422, "ENCODING_ERROR", "Request contains invalid characters.", trace_id)
     classification = _classify_unhandled_exception(exc)
@@ -1067,10 +1148,9 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
             "detail": classification["detail"],
         },
     )
-    logger.error(
+    logger.exception(
         f"Unhandled exception trace_id={trace_id} path={request.url.path}",
         extra=safe_context,
-        exc_info=exc,
     )
     return _error_response(500, "INTERNAL_ERROR", "An unexpected error occurred.", trace_id)
 

--- a/app/routers/database_setup.py
+++ b/app/routers/database_setup.py
@@ -257,6 +257,7 @@ def _require_admin_or_initial_setup(
         if not any(r == "admin" for r in current_user.roles):
             _try_log_authorization_denied(
                 db=db,
+                actor_id=current_user.id,
                 actor=current_user.username,
                 path=str(request.url.path),
                 method=request.method,
@@ -280,6 +281,7 @@ def _require_admin_or_initial_setup(
             # Authenticated but not admin — definitive denial (403, not 503)
             _try_log_authorization_denied(
                 db=db,
+                actor_id=current_user.id,
                 actor=current_user.username,
                 path=str(request.url.path),
                 method=request.method,

--- a/app/session.py
+++ b/app/session.py
@@ -228,17 +228,28 @@ async def _try_redis_backend() -> "object | None":
     try:
         import redis.asyncio as aioredis  # optional dependency
     except ImportError:
-        logger.exception(
-            "SESSION_BACKEND=redis but the 'redis' package is not installed; "
-            "falling back to cookie-based sessions"
+        logger.warning(
+            "Redis session backend package missing; falling back to cookie-based sessions",
+            extra={
+                "event_code": "SESSION_BACKEND_FALLBACK",
+                "backend": "redis",
+                "fallback_backend": "cookie",
+                "reason": "redis_package_missing",
+            },
         )
         return None
 
     url = settings.redis_url
     if not url:
-        logger.error(
-            "SESSION_BACKEND=redis but REDIS_URL is not set; "
-            "falling back to cookie-based sessions"
+        logger.warning(
+            "Redis session backend configuration missing (REDIS_URL); falling back to cookie-based sessions",
+            extra={
+                "event_code": "SESSION_BACKEND_FALLBACK",
+                "backend": "redis",
+                "fallback_backend": "cookie",
+                "reason": "redis_url_missing",
+                "missing_setting": "REDIS_URL",
+            },
         )
         return None
 
@@ -252,19 +263,44 @@ async def _try_redis_backend() -> "object | None":
             socket_keepalive=settings.redis_socket_keepalive,
         )
         await client.ping()
-        logger.info("Redis session backend connected: %s", safe_url)
+        logger.info(
+            "Redis session backend connected",
+            extra={
+                "event_code": "SESSION_BACKEND_CONNECTED",
+                "backend": "redis",
+                "redis_url": safe_url,
+            },
+        )
         return client
-    except Exception:
+    except Exception as exc:
         # Close the client if it was created, to avoid leaking connections.
         if client is not None:
             try:
                 await client.aclose()
             except Exception:
                 pass
-        logger.exception(
-            "Redis session backend unavailable (url=%s); "
-            "falling back to cookie-based sessions",
-            safe_url,
+        logger.warning(
+            "Redis session backend unavailable; falling back to cookie-based sessions",
+            extra={
+                "event_code": "SESSION_BACKEND_FALLBACK",
+                "backend": "redis",
+                "fallback_backend": "cookie",
+                "reason": "redis_unavailable",
+                "redis_url": safe_url,
+                "error_type": type(exc).__name__,
+            },
+        )
+        logger.debug(
+            "Redis session backend failure detail",
+            extra={
+                "event_code": "SESSION_BACKEND_FALLBACK",
+                "backend": "redis",
+                "fallback_backend": "cookie",
+                "reason": "redis_unavailable",
+                "redis_url": safe_url,
+                "error_type": type(exc).__name__,
+            },
+            exc_info=exc,
         )
         return None
 

--- a/docs/development/04-backend-logging-taxonomy.md
+++ b/docs/development/04-backend-logging-taxonomy.md
@@ -1,0 +1,25 @@
+## Backend Logging Taxonomy
+
+Use stable message strings plus structured context in `extra` for backend application logs. Keep operator-safe summaries at `INFO`, `WARNING`, and `ERROR`. Reserve raw exception detail, host paths, provider text, and traceback context for `DEBUG`.
+
+Severity mapping:
+
+- `DEBUG`: Diagnostic detail that helps an engineer explain a failure after a safe higher-level event already exists. Include remediation hints, raw exception context, redacted dependency targets, and traceback data only here.
+- `INFO`: Normal lifecycle and successful state transitions such as backend selection, reconciliation completion, job lifecycle progress, or other expected operational milestones.
+- `WARNING`: Denials, fail-closed responses, and recoverable degradation. This includes authentication or authorization denials, validation-style request rejections that matter operationally, and dependency fallback paths such as Redis session failover to signed cookies.
+- `ERROR`: Unhandled request failures, 5xx responses, and unrecoverable backend faults that require operator investigation.
+
+Recommended shared context fields:
+
+- `event_code`: Stable machine-readable event label such as `AUTHENTICATION_DENIED` or `SESSION_BACKEND_FALLBACK`.
+- `trace_id`: Request correlation identifier when the log is tied to an API error response.
+- `request_path` and `request_method`: Request surface for API denials and failures.
+- `status_code`: HTTP status code when relevant.
+- Domain identifiers such as `job_id`, `drive_id`, `mount_id`, `actor_id`, or `project_id` when they are already safe to expose in standard logs.
+
+Current ticket coverage:
+
+- Auth token validation failures emit `WARNING` logs with `AUTHENTICATION_DENIED` context.
+- Role-based access denials emit `WARNING` logs with `AUTHORIZATION_DENIED` context.
+- Redis session fallback emits a safe `WARNING` plus a `DEBUG` diagnostic record.
+- Global unhandled exception handling in `app/main.py` continues to emit safe `INFO` and `ERROR` logs plus `DEBUG` remediation detail for 5xx paths.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,6 @@
 """Tests for bearer token authentication dependency (app/auth.py)."""
 
+import logging
 import time
 
 import jwt
@@ -76,6 +77,24 @@ def test_missing_token_returns_401(auth_client):
     response = auth_client.get("/protected")
     assert response.status_code == 401
     assert "missing" in response.json()["detail"].lower()
+
+
+def test_missing_token_emits_warning_log(auth_client, caplog):
+    caplog.set_level(logging.WARNING, logger="app.auth")
+
+    response = auth_client.get("/protected")
+
+    assert response.status_code == 401
+    warning_record = next(
+        record
+        for record in caplog.records
+        if record.name == "app.auth" and record.levelname == "WARNING"
+    )
+    assert warning_record.getMessage() == "Authentication denied"
+    assert warning_record.event_code == "AUTHENTICATION_DENIED"
+    assert warning_record.auth_reason == "missing_token"
+    assert warning_record.request_path == "/protected"
+    assert warning_record.request_method == "GET"
 
 
 def test_invalid_token_returns_401(auth_client):

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -8,6 +8,7 @@ Verifies that:
 - Unauthenticated requests still receive HTTP 401.
 """
 
+import logging
 import time
 from unittest.mock import MagicMock, patch
 
@@ -106,6 +107,27 @@ def _assert_forbidden(response) -> None:
     assert body.get("code") == "FORBIDDEN"
     assert "message" in body
     assert "trace_id" in body
+
+
+def test_role_denial_emits_warning_log(db, caplog):
+    caplog.set_level(logging.WARNING, logger="app.auth")
+
+    c = _client_for_role(db, [])
+    response = c.get("/drives")
+
+    _assert_forbidden(response)
+    warning_record = next(
+        record
+        for record in caplog.records
+        if record.name == "app.auth"
+        and record.levelname == "WARNING"
+        and getattr(record, "event_code", None) == "AUTHORIZATION_DENIED"
+    )
+    assert warning_record.getMessage() == "Authorization denied"
+    assert warning_record.request_path == "/drives"
+    assert warning_record.request_method == "GET"
+    assert warning_record.required_roles == ["admin", "auditor", "manager", "processor"]
+    assert warning_record.user_roles == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -97,6 +97,27 @@ def test_401_custom_exception_schema(client, exception_routes):
     assert "Token has expired" in data["message"]
 
 
+def test_401_custom_exception_emits_sanitized_info_log(exception_routes, caplog):
+    caplog.set_level(logging.INFO, logger="app.main")
+
+    with TestClient(app, raise_server_exceptions=False) as safe_client:
+        response = safe_client.get("/test-exceptions/401-custom")
+
+    data = response.json()
+    info_record = next(
+        record
+        for record in caplog.records
+        if record.levelname == "INFO"
+        and getattr(record, "error_code", None) == "TOKEN_EXPIRED"
+    )
+
+    assert response.status_code == 401
+    assert info_record.trace_id == data["trace_id"]
+    assert info_record.request_path == "/test-exceptions/401-custom"
+    assert info_record.request_method == "GET"
+    assert info_record.failure_summary == "Token has expired"
+
+
 def test_401_http_exception_schema(client, exception_routes):
     response = client.get("/test-exceptions/401-http")
     assert response.status_code == 401
@@ -136,6 +157,26 @@ def test_409_custom_exception_schema(client, exception_routes):
     assert "Drive already assigned" in data["message"]
 
 
+def test_409_custom_exception_emits_sanitized_info_log(exception_routes, caplog):
+    caplog.set_level(logging.INFO, logger="app.main")
+
+    with TestClient(app, raise_server_exceptions=False) as safe_client:
+        response = safe_client.get("/test-exceptions/409-custom")
+
+    data = response.json()
+    info_record = next(
+        record
+        for record in caplog.records
+        if record.levelname == "INFO"
+        and getattr(record, "error_code", None) == "DRIVE_CONFLICT"
+    )
+
+    assert response.status_code == 409
+    assert info_record.trace_id == data["trace_id"]
+    assert info_record.failure_summary == "Drive already assigned"
+    assert info_record.error_category == "conflict"
+
+
 def test_409_http_exception_schema(client, exception_routes):
     response = client.get("/test-exceptions/409-http")
     assert response.status_code == 409
@@ -166,6 +207,26 @@ def test_500_ecube_exception_schema(client, exception_routes):
     _assert_error_schema(data, expected_code="INTERNAL_ERROR")
 
 
+def test_500_ecube_exception_emits_sanitized_info_log(exception_routes, caplog):
+    caplog.set_level(logging.INFO, logger="app.main")
+
+    with TestClient(app, raise_server_exceptions=False) as safe_client:
+        response = safe_client.get("/test-exceptions/500-ecube")
+
+    data = response.json()
+    info_record = next(
+        record
+        for record in caplog.records
+        if record.levelname == "INFO"
+        and getattr(record, "error_category", None) == "application_exception"
+    )
+
+    assert response.status_code == 500
+    assert info_record.trace_id == data["trace_id"]
+    assert info_record.error_code == "INTERNAL_ERROR"
+    assert info_record.failure_summary == "Something went wrong internally"
+
+
 def test_500_unhandled_exception_sanitized(exception_routes):
     """Unhandled exceptions must not leak internals and must return 500.
 
@@ -186,7 +247,7 @@ def test_500_unhandled_exception_sanitized(exception_routes):
 
 def test_500_unhandled_exception_preserves_traceback_logging(exception_routes, caplog):
     """Unhandled exceptions should still emit an error log with traceback context."""
-    caplog.set_level(logging.ERROR, logger="app.main")
+    caplog.set_level(logging.INFO, logger="app.main")
 
     with TestClient(app, raise_server_exceptions=False) as safe_client:
         response = safe_client.get("/test-exceptions/500-unhandled")
@@ -206,6 +267,17 @@ def test_500_unhandled_exception_preserves_traceback_logging(exception_routes, c
     assert error_record.exc_info is not None
     assert error_record.exc_info[0] is RuntimeError
     assert str(error_record.exc_info[1]) == "Completely unexpected failure"
+
+    info_record = next(
+        record
+        for record in caplog.records
+        if record.levelname == "INFO"
+        and getattr(record, "error_category", None) == "unexpected_backend_error"
+    )
+
+    assert info_record.trace_id == data["trace_id"]
+    assert info_record.request_path == "/test-exceptions/500-unhandled"
+    assert "Completely unexpected failure" not in info_record.getMessage()
 
 
 def test_500_unhandled_schema_drift_emits_safe_classified_logs(exception_routes, caplog):
@@ -311,6 +383,24 @@ def test_existing_404_schema(client):
     assert response.status_code == 404
     data = response.json()
     _assert_error_schema(data, expected_code="NOT_FOUND")
+
+
+def test_existing_404_emits_sanitized_info_log(client, caplog):
+    caplog.set_level(logging.INFO, logger="app.main")
+
+    response = client.get("/jobs/999999")
+
+    data = response.json()
+    info_record = next(
+        record
+        for record in caplog.records
+        if record.levelname == "INFO"
+        and getattr(record, "error_code", None) == "NOT_FOUND"
+    )
+
+    assert response.status_code == 404
+    assert info_record.trace_id == data["trace_id"]
+    assert info_record.request_path == "/jobs/999999"
 
 
 def test_existing_isolation_violation_schema(manager_client, db):

--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -29,6 +29,16 @@ def exception_routes(client):  # noqa: F811 – shadow outer client intentionall
     def raise_401_http():
         raise HTTPException(status_code=401, detail="Missing bearer token")
 
+    @router.get("/401-http-unsafe")
+    def raise_401_http_unsafe():
+        raise HTTPException(
+            status_code=401,
+            detail=(
+                "Failed to fetch OIDC discovery document from "
+                "'https://issuer.example/.well-known/openid-configuration': network error"
+            ),
+        )
+
     @router.get("/403-custom")
     def raise_403_custom():
         raise AuthorizationError("Insufficient role", code="INSUFFICIENT_ROLE")
@@ -124,6 +134,28 @@ def test_401_http_exception_schema(client, exception_routes):
     data = response.json()
     _assert_error_schema(data, expected_code="UNAUTHORIZED")
     assert "Missing bearer token" in data["message"]
+
+
+def test_401_http_exception_info_log_sanitizes_unsafe_detail(exception_routes, caplog):
+    caplog.set_level(logging.INFO, logger="app.main")
+
+    with TestClient(app, raise_server_exceptions=False) as safe_client:
+        response = safe_client.get("/test-exceptions/401-http-unsafe")
+
+    data = response.json()
+    info_record = next(
+        record
+        for record in caplog.records
+        if record.levelname == "INFO"
+        and getattr(record, "error_code", None) == "UNAUTHORIZED"
+        and getattr(record, "request_path", None) == "/test-exceptions/401-http-unsafe"
+    )
+
+    assert response.status_code == 401
+    assert info_record.trace_id == data["trace_id"]
+    assert info_record.failure_summary == "Unauthorized request"
+    assert "issuer.example" not in info_record.getMessage()
+    assert "issuer.example" not in str(getattr(info_record, "failure_summary", ""))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session_management.py
+++ b/tests/test_session_management.py
@@ -202,10 +202,16 @@ class TestGracefulRedisFailover:
 
         import asyncio
         with patch("builtins.__import__", side_effect=_block_redis):
-            with caplog.at_level(logging.WARNING):
+            with caplog.at_level(logging.WARNING, logger="app.session"):
                 result = asyncio.run(_try_redis_backend())
         assert result is None
-        assert "not installed" in caplog.text
+        warning_record = next(
+            record
+            for record in caplog.records
+            if record.name == "app.session" and record.levelno == logging.WARNING
+        )
+        assert "package missing" in warning_record.getMessage()
+        assert warning_record.reason == "redis_package_missing"
 
     def test_fallback_when_redis_url_not_set(self, caplog):
         pytest.importorskip("redis", reason="redis package required for this test")
@@ -215,10 +221,16 @@ class TestGracefulRedisFailover:
         with patch("app.session.settings") as mock_settings:
             mock_settings.session_backend = "redis"
             mock_settings.redis_url = None
-            with caplog.at_level(logging.WARNING):
+            with caplog.at_level(logging.WARNING, logger="app.session"):
                 result = asyncio.run(_try_redis_backend())
         assert result is None
-        assert "REDIS_URL" in caplog.text
+        warning_record = next(
+            record
+            for record in caplog.records
+            if record.name == "app.session" and record.levelno == logging.WARNING
+        )
+        assert warning_record.missing_setting == "REDIS_URL"
+        assert warning_record.reason == "redis_url_missing"
 
     def test_fallback_when_redis_connection_fails(self, caplog):
         pytest.importorskip("redis", reason="redis package required for this test")
@@ -235,11 +247,24 @@ class TestGracefulRedisFailover:
                 mock_settings.redis_url = "redis://localhost:6379/0"
                 mock_settings.redis_connection_timeout = 5
                 mock_settings.redis_socket_keepalive = True
-                with caplog.at_level(logging.WARNING):
+                with caplog.at_level(logging.DEBUG, logger="app.session"):
                     result = asyncio.run(_try_redis_backend())
 
         assert result is None
-        assert "unavailable" in caplog.text
+        warning_record = next(
+            record
+            for record in caplog.records
+            if record.name == "app.session" and record.levelno == logging.WARNING
+        )
+        debug_record = next(
+            record
+            for record in caplog.records
+            if record.name == "app.session" and record.levelno == logging.DEBUG
+        )
+        assert "unavailable" in warning_record.getMessage()
+        assert warning_record.reason == "redis_unavailable"
+        assert debug_record.getMessage() == "Redis session backend failure detail"
+        assert debug_record.exc_info is not None
         mock_client.aclose.assert_awaited_once()
 
     def test_init_session_backend_redis_fallback(self, caplog):


### PR DESCRIPTION
Summary

This branch standardizes backend exception and security-related logging so ECUBE emits safer, more consistent operational records without losing troubleshooting depth. It tightens how authentication failures, authorization denials, Redis session fallback, and centralized exception handlers are logged, and adds focused tests plus a logging taxonomy note to make the new behavior explicit for future changes.

Changes included

- Added structured `WARNING` logs for authentication failures in `app/auth.py`, including stable fields such as `event_code`, `status_code`, `request_path`, `request_method`, and safe failure reasons.
- Added structured `WARNING` logs for role-based authorization denials before the existing best-effort audit write, so RBAC failures are visible in application logs as well as audit records.
- Updated centralized exception handlers in `app/main.py` to emit sanitized `INFO` records for handled 4xx and 5xx responses with request-scoped context and safe summaries.
- Switched unexpected exception logging in the global catch-all from a plain error call to `logger.exception(...)` so stack traces remain available for debugging while the safe `INFO` classification stays operator-safe.
- Reclassified Redis session backend fallback in `app/session.py` as recoverable degradation: missing package, missing `REDIS_URL`, and runtime unavailability now log as structured `WARNING` events, with detailed failure context moved to `DEBUG`.
- Added `docs/development/04-backend-logging-taxonomy.md` to define the intended `DEBUG`/`INFO`/`WARNING`/`ERROR` contract and the recommended structured context fields.

User-facing / operator-facing effects

- Security and RBAC-related denials are now easier to audit in standard application logs without exposing raw token/provider details or other unsafe host information.
- Operators get clearer visibility into when ECUBE degrades from Redis-backed sessions to cookie-backed sessions, while engineers still retain a debug trail for root-cause analysis.
- Centralized API exception handling now produces a consistent safe `INFO` log for handled failures and a stack-bearing exception log for unexpected bugs, improving incident triage without leaking internal details to clients.

Validation

- `/home/frank/ecube/.venv/bin/python -m pytest tests/test_auth.py tests/test_authorization.py tests/test_session_management.py -q` → `136 passed`
- `/home/frank/ecube/.venv/bin/python -m pytest tests/test_exception_handlers.py -q` → `22 passed`
- Added focused caplog assertions in `tests/test_auth.py`, `tests/test_authorization.py`, `tests/test_session_management.py`, and `tests/test_exception_handlers.py` to verify the new structured warning/info logging behavior and traceback-preserving exception logging.
- No broader integration or end-to-end verification is evidenced in the branch diff; additional full-suite coverage would still be needed if this change is considered high-risk.