### PR TITLE
Gate drive CoC prompt on stored reportsr

### DIFF
--- a/frontend/src/views/DriveDetailView.vue
+++ b/frontend/src/views/DriveDetailView.vue
@@ -4,7 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth.js'
 import { getDrives, formatDrive, initializeDrive, mountDrive, prepareEjectDrive, refreshDrives } from '@/api/drives.js'
-import { listAllJobs, listJobs } from '@/api/jobs.js'
+import { getJobChainOfCustody, listAllJobs, listJobs } from '@/api/jobs.js'
 import { getMounts } from '@/api/mounts.js'
 import { enablePort } from '@/api/admin.js'
 import { normalizeErrorMessage } from '@/api/client.js'
@@ -14,7 +14,7 @@ import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import DirectoryBrowser from '@/components/browse/DirectoryBrowser.vue'
 import { formatDriveIdentity } from '@/utils/driveIdentity.js'
 import { normalizeProjectId, normalizeProjectRecord } from '@/utils/projectId.js'
-import { buildDriveJobMap, buildProjectEvidenceMap, getDriveJob, getProjectEvidence } from '@/utils/projectEvidence.js'
+import { buildDriveJobMap, buildProjectEvidenceMap, getDriveJob, getProjectEvidence, getProjectEvidenceJobId } from '@/utils/projectEvidence.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -28,6 +28,7 @@ const error = ref('')
 const infoMessage = ref('')
 const warnMessage = ref('')
 const currentProjectEvidenceNumber = ref('')
+const relatedJobId = ref(null)
 
 function clearBanners() {
   error.value = ''
@@ -156,12 +157,17 @@ async function loadDrive() {
 
     const drives = driveResult.value || []
     const jobs = jobResult.status === 'fulfilled' ? (jobResult.value || []) : []
+    const jobsByDrive = buildDriveJobMap(jobs)
+    const evidenceByProject = buildProjectEvidenceMap(jobs)
     const next = drives.find((item) => item.id === driveId.value) || null
     drive.value = next ? normalizeProjectRecord(next, ['current_project_id']) : null
-    const assignedJob = drive.value ? getDriveJob(drive.value.id, buildDriveJobMap(jobs)) : null
+    const assignedJob = drive.value ? getDriveJob(drive.value.id, jobsByDrive) : null
     currentProjectEvidenceNumber.value = drive.value
-      ? assignedJob?.evidenceNumber || getProjectEvidence(drive.value.current_project_id, buildProjectEvidenceMap(jobs))
+      ? assignedJob?.evidenceNumber || getProjectEvidence(drive.value.current_project_id, evidenceByProject)
       : ''
+    relatedJobId.value = drive.value
+      ? assignedJob?.jobId || getProjectEvidenceJobId(drive.value.current_project_id, evidenceByProject)
+      : null
     if (!drive.value) {
       error.value = t('drives.notFound')
     }
@@ -169,6 +175,20 @@ async function loadDrive() {
     error.value = t('common.errors.networkError')
   } finally {
     loading.value = false
+  }
+}
+
+async function shouldShowCocPromptForJob(jobId) {
+  const normalizedJobId = Number(jobId)
+  if (!Number.isInteger(normalizedJobId) || normalizedJobId <= 0) {
+    return false
+  }
+
+  try {
+    await getJobChainOfCustody(normalizedJobId)
+    return false
+  } catch (err) {
+    return err?.response?.status === 404
   }
 }
 
@@ -414,6 +434,7 @@ async function openPrepareEjectDialog() {
 
 async function runPrepareEject(confirmIncomplete = false) {
   if (!drive.value) return
+  const targetJobId = relatedJobId.value
   saving.value = true
   clearBanners()
   showEjectDialog.value = false
@@ -428,7 +449,7 @@ async function runPrepareEject(confirmIncomplete = false) {
       ['current_project_id'],
     )
     infoMessage.value = t('drives.ejectSuccess')
-    showCocPrompt.value = true
+    showCocPrompt.value = await shouldShowCocPromptForJob(targetJobId)
   } catch (err) {
     const status = err?.response?.status
     const detail = normalizeErrorMessage(err?.response?.data, null)
@@ -459,13 +480,13 @@ async function runPrepareEject(confirmIncomplete = false) {
 }
 
 function openChainOfCustody() {
-  if (!drive.value) return
-  const query = {
-    coc: '1',
-    drive_id: String(drive.value.id),
-  }
-  if (drive.value.current_project_id) query.project_id = drive.value.current_project_id
-  router.push({ name: 'audit', query })
+  const targetJobId = Number(relatedJobId.value)
+  if (!Number.isInteger(targetJobId) || targetJobId <= 0) return
+  router.push({
+    name: 'job-detail',
+    params: { id: targetJobId },
+    query: { coc: '1' },
+  })
 }
 
 onMounted(loadDrive)

--- a/frontend/src/views/JobDetailView.vue
+++ b/frontend/src/views/JobDetailView.vue
@@ -966,6 +966,10 @@ function openCocDialog() {
   void loadJobChainOfCustody()
 }
 
+function shouldOpenCocFromRoute() {
+  return route.query?.coc === '1'
+}
+
 function closeFileErrorDialog() {
   showFileErrorDialog.value = false
 }
@@ -1566,6 +1570,9 @@ onMounted(async () => {
   window.addEventListener('afterprint', handleAfterPrint)
   currentTimeMs.value = Date.now()
   await refreshAll()
+  if (shouldOpenCocFromRoute()) {
+    openCocDialog()
+  }
   if (!isTerminalStatus(job.value?.status)) {
     jobPoller.start()
   }

--- a/frontend/src/views/__tests__/DriveDetailView.spec.js
+++ b/frontend/src/views/__tests__/DriveDetailView.spec.js
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   hasAnyRole: vi.fn(),
   push: vi.fn(),
   getDrives: vi.fn(),
+  getJobChainOfCustody: vi.fn(),
   listAllJobs: vi.fn(),
   listJobs: vi.fn(),
   getMounts: vi.fn(),
@@ -39,6 +40,7 @@ vi.mock('@/api/drives.js', () => ({
 }))
 
 vi.mock('@/api/jobs.js', () => ({
+  getJobChainOfCustody: (...args) => mocks.getJobChainOfCustody(...args),
   listAllJobs: (...args) => mocks.listAllJobs(...args),
   listJobs: (...args) => mocks.listJobs(...args),
 }))
@@ -101,6 +103,7 @@ describe('DriveDetailView mount workflow', () => {
     mocks.hasAnyRole.mockReset()
     mocks.push.mockReset()
     mocks.getDrives.mockReset()
+    mocks.getJobChainOfCustody.mockReset()
     mocks.listAllJobs.mockReset()
     mocks.listJobs.mockReset()
     mocks.getMounts.mockReset()
@@ -114,6 +117,7 @@ describe('DriveDetailView mount workflow', () => {
     mocks.hasAnyRole.mockReturnValue(true)
     mocks.getDrives.mockResolvedValue([buildDrive()])
     mocks.listAllJobs.mockResolvedValue([])
+    mocks.getJobChainOfCustody.mockResolvedValue({ selector_mode: 'JOB', reports: [] })
     mocks.listJobs.mockResolvedValue([])
     mocks.getMounts.mockResolvedValue([
       { id: 1, status: 'MOUNTED', project_id: 'PROJ-007' },
@@ -443,6 +447,64 @@ describe('DriveDetailView mount workflow', () => {
 
     expect(mocks.prepareEjectDrive).toHaveBeenNthCalledWith(2, 7, { confirm_incomplete: true })
     expect(wrapper.text()).toContain(i18n.global.t('drives.ejectSuccess'))
+  })
+
+  it('suppresses the CoC prompt after prepare eject when a stored job CoC snapshot already exists', async () => {
+    mocks.getDrives.mockResolvedValue([buildDrive({ current_state: 'IN_USE' })])
+    mocks.listAllJobs.mockResolvedValue([
+      { id: 44, project_id: 'PROJ-007', evidence_number: 'EV-007', drive: { id: 7 } },
+    ])
+    mocks.prepareEjectDrive.mockResolvedValue(buildDrive({ current_state: 'AVAILABLE', mount_path: null }))
+    mocks.getJobChainOfCustody.mockResolvedValue({ selector_mode: 'JOB', reports: [{}] })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const ejectButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('drives.prepareEject'))
+    expect(ejectButton).toBeTruthy()
+
+    await ejectButton.trigger('click')
+    await flushPromises()
+    await wrapper.find('.confirm-dialog-confirm').trigger('click')
+    await flushPromises()
+
+    expect(mocks.getJobChainOfCustody).toHaveBeenCalledWith(44)
+    expect(wrapper.text()).toContain(i18n.global.t('drives.ejectSuccess'))
+    expect(wrapper.text()).not.toContain(i18n.global.t('drives.cocPrompt'))
+    expect(wrapper.findAll('button').some((node) => node.text() === i18n.global.t('drives.openCocReport'))).toBe(false)
+  })
+
+  it('shows the CoC prompt when the related job has no stored snapshot and routes Open CoC Report to job detail', async () => {
+    mocks.getDrives.mockResolvedValue([buildDrive({ current_state: 'IN_USE' })])
+    mocks.listAllJobs.mockResolvedValue([
+      { id: 44, project_id: 'PROJ-007', evidence_number: 'EV-007', drive: { id: 7 } },
+    ])
+    mocks.prepareEjectDrive.mockResolvedValue(buildDrive({ current_state: 'AVAILABLE', mount_path: null }))
+    mocks.getJobChainOfCustody.mockRejectedValue({ response: { status: 404 } })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const ejectButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('drives.prepareEject'))
+    expect(ejectButton).toBeTruthy()
+
+    await ejectButton.trigger('click')
+    await flushPromises()
+    await wrapper.find('.confirm-dialog-confirm').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain(i18n.global.t('drives.cocPrompt'))
+
+    const openCocButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('drives.openCocReport'))
+    expect(openCocButton).toBeTruthy()
+
+    await openCocButton.trigger('click')
+
+    expect(mocks.push).toHaveBeenCalledWith({
+      name: 'job-detail',
+      params: { id: 44 },
+      query: { coc: '1' },
+    })
   })
 
   it('blocks prepare eject when the drive has an active running job', async () => {

--- a/frontend/src/views/__tests__/JobDetailView.spec.js
+++ b/frontend/src/views/__tests__/JobDetailView.spec.js
@@ -33,6 +33,11 @@ const mocks = vi.hoisted(() => ({
   mobileViewportMatches: false,
 }))
 
+const routeState = vi.hoisted(() => ({
+  params: { id: '6' },
+  query: {},
+}))
+
 function setMobileViewport(matches) {
   mocks.mobileViewportMatches = matches
 }
@@ -48,7 +53,7 @@ Object.defineProperty(window, 'matchMedia', {
 })
 
 vi.mock('vue-router', () => ({
-  useRoute: () => ({ params: { id: '6' } }),
+  useRoute: () => routeState,
   useRouter: () => ({ push: (...args) => mocks.routerPush(...args) }),
 }))
 
@@ -197,6 +202,8 @@ describe('JobDetailView start action', () => {
     mocks.pollerStop.mockReset()
     mocks.pollerTick = null
     setMobileViewport(false)
+    routeState.params = { id: '6' }
+    routeState.query = {}
 
     mocks.hasAnyRole.mockReturnValue(true)
     mocks.getJob.mockResolvedValue({
@@ -271,6 +278,27 @@ describe('JobDetailView start action', () => {
     expect(mocks.startJob).toHaveBeenCalledWith(6, { thread_count: 4 })
     expect(wrapper.text()).toContain('body: Field required')
     expect(wrapper.text()).not.toContain(i18n.global.t('common.errors.requestConflict'))
+  })
+
+  it('opens the job-scoped CoC dialog on initial load when requested by route query', async () => {
+    routeState.query = { coc: '1' }
+    mocks.getJobChainOfCustody.mockResolvedValue({
+      selector_mode: 'JOB',
+      project_id: 'PROJ-001',
+      snapshot_updated_at: '2026-04-29T09:15:00Z',
+      reports: [{
+        drive_id: 5,
+        evidence_number: 'EV-006',
+        chain_of_custody_events: [],
+      }],
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(mocks.getJobChainOfCustody).toHaveBeenCalledWith(6)
+    expect(wrapper.find('#job-coc-title').exists()).toBe(true)
+    expect(wrapper.text()).toContain('job-coc-report-5|JOB|PROJ-001|EV-006|casey|2026-04-29T09:15:00Z')
   })
 
   it('shows startup-analysis status details and starts analysis for eligible jobs', async () => {


### PR DESCRIPTION
Summary

This change tightens the drive closeout workflow after prepare-eject so operators are only prompted to generate a Chain of Custody report when the related job does not already have a stored CoC snapshot. It also fixes the follow-up action so `Open CoC Report` takes the operator into the job-scoped CoC workflow instead of the Audit page.

Changes included

- Updated `DriveDetailView` to resolve the related job for the selected drive and check for an existing stored job CoC snapshot after a successful prepare-eject.
- Suppressed the post-eject CoC banner when a stored snapshot already exists for the related job.
- Changed `Open CoC Report` to route to the related job detail view with a CoC-open query flag instead of navigating to Audit.
- Updated `JobDetailView` to recognize the route query flag and automatically open the job-scoped Chain of Custody dialog on load.
- Added focused frontend tests covering:
  - prompt suppression when a stored CoC report already exists
  - prompt display when no stored CoC snapshot exists
  - corrected `Open CoC Report` navigation target
  - automatic opening of the job CoC dialog from route state

User-facing / operator-facing effects

- Operators no longer see a misleading CoC generation prompt after prepare-eject when the job already has a stored report.
- The closeout flow now stays in the job workflow, which is the correct place to review or continue Chain of Custody actions.
- This specifically improves an operator-facing drive lifecycle path tied to safe media removal and CoC closeout.

Validation

- `cd frontend && npx vitest run src/views/__tests__/DriveDetailView.spec.js src/views/__tests__/JobDetailView.spec.js`
- Result: 2 test files passed, 76 tests passed
- Files changed in the commit:
  - `frontend/src/views/DriveDetailView.vue`
  - `frontend/src/views/JobDetailView.vue`
  - `frontend/src/views/__tests__/DriveDetailView.spec.js`
  - `frontend/src/views/__tests__/JobDetailView.spec.js`