### PR TITLE
Require matching drive project binding for archive gatingpr

### DIFF
--- a/frontend/src/views/JobDetailView.vue
+++ b/frontend/src/views/JobDetailView.vue
@@ -116,13 +116,26 @@ const canConfirmCocHandoff = computed(() => authStore.hasAnyRole(['admin', 'mana
   && currentStatus.value !== 'ARCHIVED'
   && hasPendingCocHandoff.value)
 const currentStartupAnalysisStatus = computed(() => String(job.value?.startup_analysis_status || 'NOT_ANALYZED').toUpperCase())
+const archiveRelatedDrive = computed(() => {
+  const drive = job.value?.drive
+  if (!drive) return null
+
+  const jobProjectId = normalizeProjectId(job.value?.project_id)
+  const driveProjectId = normalizeProjectId(drive?.current_project_id)
+
+  if (!jobProjectId || !driveProjectId || driveProjectId !== jobProjectId) {
+    return null
+  }
+
+  return drive
+})
 const archiveDriveReady = computed(() => {
-  const driveState = String(job.value?.drive?.current_state || '').toUpperCase()
-  return !job.value?.drive || (driveState === 'AVAILABLE' && !job.value?.drive?.is_mounted)
+  const driveState = String(archiveRelatedDrive.value?.current_state || '').toUpperCase()
+  return !archiveRelatedDrive.value || (driveState === 'AVAILABLE' && !archiveRelatedDrive.value?.is_mounted)
 })
 const archiveBlockedByDriveEject = computed(() => canArchiveJobs.value
   && ['COMPLETED', 'FAILED'].includes(currentStatus.value)
-  && !!job.value?.drive
+  && !!archiveRelatedDrive.value
   && !archiveDriveReady.value)
 const archivePrerequisiteNotice = computed(() => (archiveBlockedByDriveEject.value ? t('jobs.archiveRequiresEject') : ''))
 const canArchive = computed(() => canArchiveJobs.value

--- a/frontend/src/views/__tests__/JobDetailView.spec.js
+++ b/frontend/src/views/__tests__/JobDetailView.spec.js
@@ -698,7 +698,7 @@ describe('JobDetailView start action', () => {
       files_failed: 0,
       files_timed_out: 0,
       startup_analysis_status: 'READY',
-      drive: { id: 1, current_state: 'AVAILABLE', is_mounted: true },
+      drive: { id: 1, current_state: 'AVAILABLE', is_mounted: true, current_project_id: 'PROJ-001' },
     })
 
     const wrapper = mountView()
@@ -708,6 +708,34 @@ describe('JobDetailView start action', () => {
     expect(archiveButton).toBeTruthy()
     expect(archiveButton.attributes('disabled')).toBeDefined()
     expect(wrapper.text()).toContain(i18n.global.t('jobs.archiveRequiresEject'))
+  })
+
+  it('does not block archive when the present drive is no longer bound to the job project', async () => {
+    mocks.getJob.mockResolvedValue({
+      id: 6,
+      status: 'COMPLETED',
+      project_id: 'PROJ-001',
+      evidence_number: 'EV-006',
+      source_path: '/nfs/project-001/evidence',
+      target_mount_path: '/mnt/ecube/1',
+      thread_count: 4,
+      copied_bytes: 10,
+      total_bytes: 10,
+      file_count: 1,
+      files_succeeded: 1,
+      files_failed: 0,
+      files_timed_out: 0,
+      startup_analysis_status: 'READY',
+      drive: { id: 1, current_state: 'AVAILABLE', is_mounted: true, current_project_id: null },
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const archiveButton = wrapper.findAll('button').find((node) => node.text() === i18n.global.t('jobs.archiveWithoutHandoff'))
+    expect(archiveButton).toBeTruthy()
+    expect(archiveButton.attributes('disabled')).toBeUndefined()
+    expect(wrapper.text()).not.toContain(i18n.global.t('jobs.archiveRequiresEject'))
   })
 
   it('enables archive after the related drive is available and unmounted', async () => {
@@ -726,7 +754,7 @@ describe('JobDetailView start action', () => {
       files_failed: 0,
       files_timed_out: 0,
       startup_analysis_status: 'READY',
-      drive: { id: 1, current_state: 'AVAILABLE', is_mounted: false },
+      drive: { id: 1, current_state: 'AVAILABLE', is_mounted: false, current_project_id: 'PROJ-001' },
     })
 
     const wrapper = mountView()


### PR DESCRIPTION
Summary

This change tightens Job Detail archive gating so the drive-based archive prerequisite only applies when the currently attached drive is still bound to the same project as the job. It fixes a stale-association case where a reformatted or re-mounted drive could keep influencing archive availability even after its project binding had effectively been cleared.

Changes included

- Added a derived `archiveRelatedDrive` check in Job Detail that only treats a drive as related when `job.drive.current_project_id` matches `job.project_id`.
- Updated the archive readiness and archive-blocked calculations to use that filtered related-drive check instead of any present `job.drive`.
- Kept the existing archive prerequisite behavior intact for the valid related-drive case: archive still stays blocked until that drive is `AVAILABLE` and unmounted.
- Extended Job Detail frontend coverage to assert both:
  - archive remains blocked when the drive is still bound to the job project and not yet eject-ready
  - archive is not blocked by a present drive whose current project binding no longer matches the job

User-facing / operator-facing effects

- Operators no longer see Archive incorrectly gated by a drive that has been reformatted or otherwise detached from the job’s project association.
- Archive behavior is now more consistent with the intended drive lifecycle: only the actually related project-bound drive can enforce the eject prerequisite.

Validation

- Focused frontend verification was run with:
  - `cd /home/frank/ecube/frontend && npx vitest run src/views/__tests__/JobDetailView.spec.js`
- Result:
  - `1` test file passed
  - `56` tests passed
- Verification covered the new regression case plus the existing archive-gating scenarios.