### PR TITLE
Fix fresh-install USB mount failures on Ubuntu

### DIFF
--- a/app/infrastructure/drive_mount.py
+++ b/app/infrastructure/drive_mount.py
@@ -16,8 +16,66 @@ from app.config import settings
 from app.infrastructure.device_path import validate_device_path
 from app.infrastructure.filesystem_detection import LinuxFilesystemDetector
 from app.infrastructure.mount_info import find_device_mount_point
+from app.utils.sanitize import sanitize_error_message
 
 logger = logging.getLogger(__name__)
+
+
+def _classify_drive_mount_failure(raw_error: object, *, phase: str) -> tuple[str, str]:
+    raw_text = "" if raw_error is None else str(raw_error).strip()
+    lowered = raw_text.lower()
+    default_messages = {
+        "mount_root_prepare": "Managed mount root is unavailable",
+        "mount_timeout": "Mount operation timed out",
+        "mount_command": "Mount command failed",
+        "mount_os_error": "Mount operation failed unexpectedly",
+        "mount_access_repair": "Mount succeeded but post-mount access repair failed",
+    }
+    safe_summary = sanitize_error_message(raw_error, default_messages.get(phase, "Mount operation failed"))
+
+    if phase == "mount_root_prepare":
+        if any(token in lowered for token in ("permission denied", "access denied", "not authorized")):
+            return "managed_mount_root_inaccessible", safe_summary
+        if "no such file" in lowered or "not found" in lowered:
+            return "managed_mount_root_missing", safe_summary
+        return "managed_mount_root_unavailable", safe_summary
+
+    if phase == "mount_timeout":
+        return "mount_timeout", safe_summary
+
+    if phase == "mount_access_repair":
+        return "post_mount_access_repair_failure", safe_summary
+
+    if "unknown filesystem type" in lowered or "wrong fs type" in lowered or "bad superblock" in lowered:
+        return "missing_filesystem_runtime", safe_summary
+    if any(token in lowered for token in ("permission denied", "access denied", "not authorized")):
+        return "mount_permission_failure", safe_summary
+    if "no such file" in lowered or "not found" in lowered:
+        return "mount_target_unavailable", safe_summary
+
+    if phase == "mount_os_error":
+        return "mount_runtime_error", safe_summary
+    return "mount_command_failure", safe_summary
+
+
+def _log_drive_mount_safe_warning(
+    message: str,
+    *,
+    phase: str,
+    mount_point: str,
+    raw_error: object,
+    returncode: int | None = None,
+) -> None:
+    failure_category, failure_summary = _classify_drive_mount_failure(raw_error, phase=phase)
+    extra = {
+        "failure_category": failure_category,
+        "failure_summary": failure_summary,
+        "mount_phase": phase,
+        "mount_slot": os.path.basename(mount_point.rstrip("/")),
+    }
+    if returncode is not None:
+        extra["returncode"] = returncode
+    logger.warning(message, extra=extra)
 
 
 def _log_drive_mount_debug_failure(
@@ -203,6 +261,18 @@ class LinuxDriveMount:
         try:
             os.makedirs(mount_point, exist_ok=True)
         except OSError as exc:
+            _log_drive_mount_safe_warning(
+                "Drive mount root preparation failed",
+                phase="mount_root_prepare",
+                mount_point=mount_point,
+                raw_error=exc,
+            )
+            _log_drive_mount_debug_failure(
+                "Drive mount root preparation details",
+                device_path=mountable,
+                mount_point=mount_point,
+                raw_error=exc,
+            )
             return False, f"failed to create mount point {mount_point}: {exc}"
 
         mount_command = [
@@ -220,11 +290,11 @@ class LinuxDriveMount:
                 timeout=settings.subprocess_timeout_seconds,
             )
         except subprocess.TimeoutExpired:
-            logger.warning(
-                "Drive mount timed out: device_name=%s mount_slot=%s timeout=%ss",
-                os.path.basename(mountable),
-                os.path.basename(mount_point.rstrip("/")),
-                settings.subprocess_timeout_seconds,
+            _log_drive_mount_safe_warning(
+                "Drive mount timed out",
+                phase="mount_timeout",
+                mount_point=mount_point,
+                raw_error=f"mount timed out after {settings.subprocess_timeout_seconds}s",
             )
             _log_drive_mount_debug_failure(
                 "Drive mount timeout details",
@@ -235,12 +305,12 @@ class LinuxDriveMount:
             return False, f"mount timed out after {settings.subprocess_timeout_seconds}s"
         except subprocess.CalledProcessError as exc:
             stderr = (exc.stderr or b"").decode(errors="replace").strip()
-            logger.warning(
-                "Drive mount command failed: device_name=%s mount_slot=%s returncode=%s reason=%s",
-                os.path.basename(mountable),
-                os.path.basename(mount_point.rstrip("/")),
-                exc.returncode,
-                stderr or "mount command failed",
+            _log_drive_mount_safe_warning(
+                "Drive mount command failed",
+                phase="mount_command",
+                mount_point=mount_point,
+                raw_error=stderr or exc,
+                returncode=exc.returncode,
             )
             _log_drive_mount_debug_failure(
                 "Drive mount raw error",
@@ -264,11 +334,11 @@ class LinuxDriveMount:
                 msg += f": {stderr}"
             return False, msg
         except OSError as exc:
-            logger.warning(
-                "Drive mount OS error: device_name=%s mount_slot=%s reason=%s",
-                os.path.basename(mountable),
-                os.path.basename(mount_point.rstrip("/")),
-                str(exc),
+            _log_drive_mount_safe_warning(
+                "Drive mount OS error",
+                phase="mount_os_error",
+                mount_point=mount_point,
+                raw_error=exc,
             )
             _log_drive_mount_debug_failure(
                 "Drive mount OS error details",
@@ -281,13 +351,14 @@ class LinuxDriveMount:
         writable, access_error = _ensure_mount_point_writable(mount_point)
         if not writable:
             cleanup_ok, cleanup_error = self.unmount_drive(mount_point)
-            logger.warning(
-                "Drive mount access repair failed: device_name=%s mount_slot=%s cleanup_ok=%s reason=%s cleanup_reason=%s",
-                os.path.basename(mountable),
-                os.path.basename(mount_point.rstrip("/")),
-                cleanup_ok,
-                access_error or "mount target is not writable",
-                cleanup_error or "",
+            _log_drive_mount_safe_warning(
+                "Drive mount access repair failed",
+                phase="mount_access_repair",
+                mount_point=mount_point,
+                raw_error=(
+                    f"access_error={access_error or 'mount target is not writable'}; "
+                    f"cleanup_error={cleanup_error or ''}"
+                ),
             )
             _log_drive_mount_debug_failure(
                 "Drive mount access repair details",

--- a/docs/operations/01-installation.md
+++ b/docs/operations/01-installation.md
@@ -108,7 +108,7 @@ The ECUBE service depends on several non-standard OS packages for USB formatting
 | `usbutils` | Provides `lsusb` and USB enumeration support. |
 | `util-linux` | Provides core block and session utilities such as `lsblk`, `blkid`, and `runuser`. |
 
-On minimal Ubuntu installs, also install `linux-modules-extra-$(uname -r)` so the native exFAT kernel module is available at runtime. On Ubuntu 20.04 hosts using the 5.4 kernel series, install `exfat-fuse` instead of the native module package.
+On minimal Ubuntu installs, ECUBE now attempts to install `linux-modules-extra-$(uname -r)` when that package is available so the native exFAT kernel module is present at runtime. On Ubuntu 20.04 hosts using the 5.4 kernel series, install `exfat-fuse` instead of the native module package.
 
 ```bash
 sudo apt-get update
@@ -145,15 +145,16 @@ sudo ./install.sh
 The installer will:
 
 1. Run pre-flight checks (OS, disk space, ports, Python 3.11).
-2. Install required host runtime packages for USB formatting, USB discovery, and NFS/SMB mount support (`exfatprogs`, `nfs-common`, `cifs-utils`, `smbclient`, `usbutils`, and `util-linux`) on supported Debian/Ubuntu systems.
+2. Install required host runtime packages for USB formatting, USB discovery, and NFS/SMB mount support (`exfatprogs`, `nfs-common`, `cifs-utils`, `smbclient`, `usbutils`, and `util-linux`) on supported Debian/Ubuntu systems, and on Ubuntu also install the current-kernel `linux-modules-extra-*` package when apt provides it.
 3. Create the `ecube` system user and add it to required host groups (`plugdev`, `dialout`, and `shadow` when present).
-4. Install `/etc/sudoers.d/ecube-user-mgmt` with narrowly scoped `NOPASSWD` rules for setup OS user/group management, mount/unmount operations, and selected drive filesystem commands.
-5. Install `/etc/pam.d/ecube` PAM configuration for local and domain user authentication (detects SSSD at install time and installs an SSSD-enabled or local-only variant accordingly).
-6. Set up a Python virtual environment in `<install-dir>/venv`.
-7. Generate a self-signed TLS certificate (skipped with `--no-tls`).
-8. Write `<install-dir>/.env` with a random `SECRET_KEY`, empty `SETUP_DEFAULT_ADMIN_USERNAME` (populated later by the superuser creation step), and runtime defaults. `DATABASE_URL` is left empty and configured later via the setup wizard.
-9. Write and start the `ecube.service` systemd unit.
-10. Deploy the pre-built frontend to `<install-dir>/www` so FastAPI serves the SPA directly (no separate web server required).
+4. Prepare the managed mount roots used by ECUBE (`/nfs`, `/smb`, and the configured USB mount base path, default `/mnt/ecube`) with service-account ownership and runtime-safe permissions.
+5. Install `/etc/sudoers.d/ecube-user-mgmt` with narrowly scoped `NOPASSWD` rules for setup OS user/group management, mount/unmount operations, and selected drive filesystem commands.
+6. Install `/etc/pam.d/ecube` PAM configuration for local and domain user authentication (detects SSSD at install time and installs an SSSD-enabled or local-only variant accordingly).
+7. Set up a Python virtual environment in `<install-dir>/venv`.
+8. Generate a self-signed TLS certificate (skipped with `--no-tls`).
+9. Write `<install-dir>/.env` with a random `SECRET_KEY`, empty `SETUP_DEFAULT_ADMIN_USERNAME` (populated later by the superuser creation step), and runtime defaults. `DATABASE_URL` is left empty and configured later via the setup wizard.
+10. Write and start the `ecube.service` systemd unit.
+11. Deploy the pre-built frontend to `<install-dir>/www` so FastAPI serves the SPA directly (no separate web server required).
 11. Optionally configure `ufw` firewall rules.
 
 At the end it prints a summary with the UI URL, API URL, and service management commands.

--- a/docs/operations/01-installation.md
+++ b/docs/operations/01-installation.md
@@ -147,7 +147,7 @@ The installer will:
 1. Run pre-flight checks (OS, disk space, ports, Python 3.11).
 2. Install required host runtime packages for USB formatting, USB discovery, and NFS/SMB mount support (`exfatprogs`, `nfs-common`, `cifs-utils`, `smbclient`, `usbutils`, and `util-linux`) on supported Debian/Ubuntu systems, and on Ubuntu also install the current-kernel `linux-modules-extra-*` package when apt provides it.
 3. Create the `ecube` system user and add it to required host groups (`plugdev`, `dialout`, and `shadow` when present).
-4. Prepare the managed mount roots used by ECUBE (`/nfs`, `/smb`, and the configured USB mount base path, default `/mnt/ecube`) with service-account ownership and runtime-safe permissions.
+4. Prepare the managed mount roots used by ECUBE (`/nfs`, `/smb`, and the configured USB mount base path, default `/mnt/ecube`) with service-account ownership and runtime-safe permissions. On first install, set `USB_MOUNT_BASE_PATH` in the installer environment if you need a non-default USB mount root so the generated `.env` and prepared directories stay aligned.
 5. Install `/etc/sudoers.d/ecube-user-mgmt` with narrowly scoped `NOPASSWD` rules for setup OS user/group management, mount/unmount operations, and selected drive filesystem commands.
 6. Install `/etc/pam.d/ecube` PAM configuration for local and domain user authentication (detects SSSD at install time and installs an SSSD-enabled or local-only variant accordingly).
 7. Set up a Python virtual environment in `<install-dir>/venv`.

--- a/docs/operations/02-manual-installation.md
+++ b/docs/operations/02-manual-installation.md
@@ -157,7 +157,7 @@ The ECUBE service depends on several non-standard OS packages for USB formatting
 | `usbutils` | Provides `lsusb` and USB enumeration support. |
 | `util-linux` | Provides core block and session utilities such as `lsblk`, `blkid`, and `runuser`. |
 
-On minimal Ubuntu installs, also install `linux-modules-extra-$(uname -r)` so the native exFAT kernel module is available at runtime. On Ubuntu 20.04 hosts using the 5.4 kernel series, install `exfat-fuse` instead of the native module package.
+On minimal Ubuntu installs, ensure `linux-modules-extra-$(uname -r)` is installed so the native exFAT kernel module is available at runtime. On Ubuntu 20.04 hosts using the 5.4 kernel series, install `exfat-fuse` instead of the native module package.
 
 ```bash
 sudo apt-get update
@@ -173,13 +173,13 @@ sudo apt-get install -y \
 
 ```bash
 sudo useradd --system --create-home --home-dir /opt/ecube --shell /usr/sbin/nologin ecube
-sudo mkdir -p /opt/ecube /var/lib/ecube /var/log/ecube /nfs /smb
+sudo mkdir -p /opt/ecube /var/lib/ecube /var/log/ecube /nfs /smb /mnt/ecube
 sudo chown -R ecube:ecube /opt/ecube /var/lib/ecube /var/log/ecube
-sudo chown ecube:ecube /nfs /smb
+sudo chown ecube:ecube /nfs /smb /mnt/ecube
 sudo chmod 750 /opt/ecube
 sudo chmod 700 /var/lib/ecube
 sudo chmod 750 /var/log/ecube
-sudo chmod 755 /nfs /smb
+sudo chmod 755 /nfs /smb /mnt/ecube
 
 # Optional hardware groups when present on the host
 getent group plugdev >/dev/null && sudo usermod -aG plugdev ecube
@@ -189,7 +189,7 @@ getent group dialout >/dev/null && sudo usermod -aG dialout ecube
 getent group shadow >/dev/null && sudo usermod -aG shadow ecube
 ```
 
-The managed mount roots (`/nfs` and `/smb`) must be owned by the `ecube` service account. Runtime mount requests can use narrowly scoped sudo to create missing leaf folders and repair ownership under these roots.
+The managed mount roots (`/nfs`, `/smb`, and the configured USB mount base path, default `/mnt/ecube`) must be owned by the `ecube` service account. Runtime mount requests can use narrowly scoped sudo to create missing leaf folders and repair ownership under these roots.
 
 The `shadow` group membership allows the non-root `ecube` service process to
 perform local PAM (`pam_unix`) authentication consistently on hosts where

--- a/install.sh
+++ b/install.sh
@@ -1110,6 +1110,14 @@ _configured_usb_mount_base_path() {
     warn "Ignoring non-absolute USB_MOUNT_BASE_PATH from ${env_file}: ${configured_path}"
   fi
 
+  if [[ -n "${USB_MOUNT_BASE_PATH:-}" ]]; then
+    if [[ "${USB_MOUNT_BASE_PATH}" == /* ]]; then
+      printf '%s' "${USB_MOUNT_BASE_PATH}"
+      return 0
+    fi
+    warn "Ignoring non-absolute USB_MOUNT_BASE_PATH from installer environment: ${USB_MOUNT_BASE_PATH}"
+  fi
+
   printf '%s' "/mnt/ecube"
 }
 
@@ -2011,6 +2019,9 @@ _write_env_file() {
     secret_key="$(openssl rand -hex 32)"
   fi
 
+  local usb_mount_root
+  usb_mount_root="$(_configured_usb_mount_base_path)"
+
   if [[ "${DRY_RUN}" != true ]]; then
     cat > "${env_file}" <<EOF
 # ECUBE environment configuration
@@ -2022,6 +2033,9 @@ SETUP_DEFAULT_ADMIN_USERNAME=
 
 # Set to true if a reverse proxy sits in front of uvicorn.
 TRUST_PROXY_HEADERS=false
+
+# Base directory for managed USB drive mount points.
+USB_MOUNT_BASE_PATH=${usb_mount_root}
 
 # Path to the pre-built frontend served by FastAPI (standalone mode).
 SERVE_FRONTEND_PATH=${INSTALL_DIR}/www

--- a/install.sh
+++ b/install.sh
@@ -1098,14 +1098,51 @@ run() {
   fi
 }
 
+_configured_usb_mount_base_path() {
+  local env_file="${INSTALL_DIR}/.env"
+  local configured_path=""
+
+  if configured_path="$(_extract_env_value "${env_file}" "USB_MOUNT_BASE_PATH" 2>/dev/null)"; then
+    if [[ "${configured_path}" == /* ]]; then
+      printf '%s' "${configured_path}"
+      return 0
+    fi
+    warn "Ignoring non-absolute USB_MOUNT_BASE_PATH from ${env_file}: ${configured_path}"
+  fi
+
+  printf '%s' "/mnt/ecube"
+}
+
 _ensure_runtime_host_packages() {
   local packages=(exfatprogs nfs-common cifs-utils smbclient usbutils util-linux)
   local missing_packages=()
+  local kernel_extra_package=""
+  local apt_index_updated=false
   local package
+
+  _update_runtime_package_index() {
+    if [[ "${apt_index_updated}" == true ]]; then
+      return 0
+    fi
+    run apt-get update -qq
+    apt_index_updated=true
+  }
 
   if [[ "${ID}" != "ubuntu" && "${ID}" != "debian" && "${ID_LIKE:-}" != *"debian"* ]]; then
     warn "Skipping runtime mount package installation on unsupported OS family '${ID}'."
     return 0
+  fi
+
+  if [[ "${ID}" == "ubuntu" ]]; then
+    kernel_extra_package="linux-modules-extra-$(uname -r)"
+    if ! dpkg -s "${kernel_extra_package}" >/dev/null 2>&1; then
+      _update_runtime_package_index
+      if apt-cache show "${kernel_extra_package}" >/dev/null 2>&1; then
+        packages+=("${kernel_extra_package}")
+      else
+        warn "Runtime package '${kernel_extra_package}' is not available in apt. exFAT USB mounts may fail until it is installed manually if your host kernel requires it."
+      fi
+    fi
   fi
 
   for package in "${packages[@]}"; do
@@ -1120,9 +1157,24 @@ _ensure_runtime_host_packages() {
   fi
 
   info "Installing runtime host packages: ${missing_packages[*]}"
-  run apt-get update -qq
+  _update_runtime_package_index
   run apt-get install -y "${missing_packages[@]}"
   ok "Runtime host packages installed: ${missing_packages[*]}"
+}
+
+_prepare_managed_mount_roots() {
+  local usb_mount_root
+  usb_mount_root="$(_configured_usb_mount_base_path)"
+  local roots=(/nfs /smb)
+
+  if [[ ! " ${roots[*]} " =~ " ${usb_mount_root} " ]]; then
+    roots+=("${usb_mount_root}")
+  fi
+
+  run mkdir -p "${roots[@]}"
+  run chown ecube:ecube "${roots[@]}"
+  run chmod 755 "${roots[@]}"
+  ok "Managed mount roots prepared: ${roots[*]}"
 }
 
 # Run a command as the ecube user, dropping privileges from root.
@@ -1843,12 +1895,10 @@ install_backend() {
   run chown -R ecube:ecube /var/log/ecube
   run chmod 750 /var/log/ecube
 
-  # 4c. Managed network mount roots used for auto-generated mountpoints.
+  # 4c. Managed mount roots used for network shares and direct USB mounts.
   # Must be service-account owned so mountpoint create/remove does not rely on
   # root-owned directories.
-  run mkdir -p /nfs /smb
-  run chown ecube:ecube /nfs /smb
-  run chmod 755 /nfs /smb
+  _prepare_managed_mount_roots
 
   # 5. Python virtual environment
   # Run venv creation and pip installs as the ecube user so all files under

--- a/tests/test_drive_mount.py
+++ b/tests/test_drive_mount.py
@@ -4,6 +4,7 @@ These tests exercise the path-safety checks (absolute, direct-child of
 usb_mount_base_path) without actually calling mount(8).
 """
 
+import logging
 import subprocess
 
 from unittest.mock import patch
@@ -176,7 +177,7 @@ def test_mount_drive_fails_when_mount_point_remains_unwritable():
 
 
 def test_mount_drive_logs_raw_debug_error(caplog):
-    """Debug logs should retain the unsanitized mount helper error text."""
+    """Warning logs should stay sanitized while debug logs retain the raw helper error text."""
     dm = LinuxDriveMount()
     with patch("app.infrastructure.drive_mount.settings") as mock_settings:
         mock_settings.usb_mount_base_path = _BASE
@@ -194,20 +195,83 @@ def test_mount_drive_logs_raw_debug_error(caplog):
                             side_effect=subprocess.CalledProcessError(
                                 returncode=32,
                                 cmd=["/bin/mount"],
-                                stderr=b"mount: /dev/sdb: permission denied while mounting /mnt/ecube/7",
+                                stderr=b"mount: unknown filesystem type 'exfat' while mounting /mnt/ecube/7",
                             ),
                         ):
                             with caplog.at_level("DEBUG"):
                                 ok, err = dm.mount_drive(_VALID_DEVICE, f"{_BASE}/7")
 
     assert ok is False
-    assert "permission denied" in (err or "")
-    messages = [record.getMessage() for record in caplog.records]
-    assert any("Drive mount command failed" in message for message in messages)
+    assert "unknown filesystem type" in (err or "")
+    warning_records = [record for record in caplog.records if record.levelno == logging.WARNING]
+    debug_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.DEBUG]
+
+    assert any(record.getMessage() == "Drive mount command failed" for record in warning_records)
+    assert any(getattr(record, "failure_category", None) == "missing_filesystem_runtime" for record in warning_records)
+    assert any(getattr(record, "failure_summary", None) == "Filesystem type is not supported by the host" for record in warning_records)
+    assert all("/dev/sdb" not in record.getMessage() for record in warning_records)
+    assert all("/mnt/ecube/7" not in record.getMessage() for record in warning_records)
     assert any(
         "Drive mount raw error" in message
         and "/dev/sdb" in message
         and "/mnt/ecube/7" in message
-        and "permission denied while mounting /mnt/ecube/7" in message
-        for message in messages
+        and "unknown filesystem type 'exfat' while mounting /mnt/ecube/7" in message
+        for message in debug_messages
     )
+
+
+def test_mount_drive_logs_managed_mount_root_failure_with_safe_warning(caplog):
+    """Mount-root preparation failures should log a safe normal-level classification and raw debug detail."""
+    dm = LinuxDriveMount()
+    with patch("app.infrastructure.drive_mount.settings") as mock_settings:
+        mock_settings.usb_mount_base_path = _BASE
+        mock_settings.sysfs_block_path = "/sys/block"
+        mock_settings.mount_binary_path = "/bin/mount"
+        mock_settings.use_sudo = False
+        mock_settings.subprocess_timeout_seconds = 10
+        mock_settings.procfs_mounts_path = "/proc/mounts"
+        with patch("os.path.realpath", side_effect=lambda p: p):
+            with patch("app.infrastructure.drive_mount.validate_device_path", return_value=True):
+                with patch("os.makedirs", side_effect=PermissionError("[Errno 13] Permission denied: '/mnt/ecube/7'")):
+                    with caplog.at_level("DEBUG"):
+                        ok, err = dm.mount_drive(_VALID_DEVICE, f"{_BASE}/7")
+
+    assert ok is False
+    assert "failed to create mount point" in (err or "")
+    warning_records = [record for record in caplog.records if record.levelno == logging.WARNING]
+    debug_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.DEBUG]
+
+    assert any(record.getMessage() == "Drive mount root preparation failed" for record in warning_records)
+    assert any(getattr(record, "failure_category", None) == "managed_mount_root_inaccessible" for record in warning_records)
+    assert any(getattr(record, "failure_summary", None) == "Permission or authentication failure" for record in warning_records)
+    assert any("Drive mount root preparation details" in message and "/mnt/ecube/7" in message for message in debug_messages)
+
+
+def test_mount_drive_logs_access_repair_failure_with_safe_warning(caplog):
+    """Post-mount access repair failures should be classifiable without leaking raw details at warning level."""
+    dm = LinuxDriveMount()
+    with patch("app.infrastructure.drive_mount.settings") as mock_settings:
+        mock_settings.usb_mount_base_path = _BASE
+        mock_settings.sysfs_block_path = "/sys/block"
+        mock_settings.mount_binary_path = "/bin/mount"
+        mock_settings.use_sudo = True
+        mock_settings.subprocess_timeout_seconds = 10
+        mock_settings.procfs_mounts_path = "/proc/mounts"
+        with patch("os.path.realpath", side_effect=lambda p: p):
+            with patch("app.infrastructure.drive_mount.validate_device_path", return_value=True):
+                with patch("os.makedirs"):
+                    with patch("os.geteuid", return_value=1234):
+                        with patch("os.getegid", return_value=5678):
+                            with patch("os.access", return_value=False):
+                                with patch("subprocess.run"):
+                                    with caplog.at_level("DEBUG"):
+                                        ok, err = dm.mount_drive(_VALID_DEVICE, f"{_BASE}/7")
+
+    assert ok is False
+    assert "not writable" in (err or "")
+    warning_records = [record for record in caplog.records if record.levelno == logging.WARNING]
+    debug_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.DEBUG]
+
+    assert any(record.getMessage() == "Drive mount access repair failed" for record in warning_records)
+    assert any(getattr(record, "failure_category", None) == "post_mount_access_repair_failure" for record in warning_records)
+    assert any("Drive mount access repair details" in message and "/mnt/ecube/7" in message for message in debug_messages)

--- a/tests/test_install_runtime_prep.py
+++ b/tests/test_install_runtime_prep.py
@@ -118,3 +118,69 @@ def test_prepare_managed_mount_roots_honors_usb_mount_base_path_from_env(tmp_pat
     assert "mkdir -p /nfs /smb /srv/ecube-usb" in commands
     assert "chown ecube:ecube /nfs /smb /srv/ecube-usb" in commands
     assert "chmod 755 /nfs /smb /srv/ecube-usb" in commands
+
+
+def test_prepare_managed_mount_roots_honors_installer_environment_before_env_exists(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    command_log = tmp_path / "commands.log"
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+
+    for command in ("mkdir", "chown", "chmod"):
+        (fake_bin / command).write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            f"printf '{command} %s\\n' \"$*\" >> \"${{COMMAND_LOG:?}}\"\n",
+            encoding="utf-8",
+        )
+        (fake_bin / command).chmod(0o755)
+
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "COMMAND_LOG": str(command_log),
+        "LOG_FILE": str(tmp_path / "install.log"),
+        "USB_MOUNT_BASE_PATH": "/srv/ecube-usb",
+    }
+    result = _run_install_function(
+        tmp_path,
+        f"INSTALL_DIR={install_dir}\nDRY_RUN=false\n_prepare_managed_mount_roots\n",
+        env,
+    )
+
+    assert result.returncode == 0, f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    commands = command_log.read_text(encoding="utf-8")
+    assert "mkdir -p /nfs /smb /srv/ecube-usb" in commands
+    assert "chown ecube:ecube /nfs /smb /srv/ecube-usb" in commands
+    assert "chmod 755 /nfs /smb /srv/ecube-usb" in commands
+
+
+def test_write_env_file_persists_configured_usb_mount_base_path(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+
+    (fake_bin / "chown").write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    (fake_bin / "chown").chmod(0o755)
+
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "USB_MOUNT_BASE_PATH": "/srv/ecube-usb",
+    }
+    result = _run_install_function(
+        tmp_path,
+        f"INSTALL_DIR={install_dir}\nLOG_FILE={tmp_path / 'install.log'}\nDRY_RUN=false\n_write_env_file\n",
+        env,
+    )
+
+    assert result.returncode == 0, f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    env_text = (install_dir / ".env").read_text(encoding="utf-8")
+    assert "USB_MOUNT_BASE_PATH=/srv/ecube-usb\n" in env_text

--- a/tests/test_install_runtime_prep.py
+++ b/tests/test_install_runtime_prep.py
@@ -1,0 +1,120 @@
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def _run_install_function(tmp_path: Path, script_body: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    repo_root = Path(__file__).resolve().parent.parent
+    script = textwrap.dedent(
+        f"""
+        set -euo pipefail
+        cd {repo_root}
+        source ./install.sh
+        {script_body}
+        """
+    )
+    return subprocess.run(
+        ["bash", "-lc", script],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_ensure_runtime_host_packages_adds_kernel_extras_when_available(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    apt_log = tmp_path / "apt.log"
+
+    (fake_bin / "dpkg").write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    (fake_bin / "dpkg").chmod(0o755)
+    (fake_bin / "apt-cache").write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "if [[ \"${1:-}\" == show && \"${2:-}\" == \"linux-modules-extra-6.8.0-test\" ]]; then\n"
+        "  printf 'Package: %s\\n' \"$2\"\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    (fake_bin / "apt-cache").chmod(0o755)
+    (fake_bin / "apt-get").write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "printf '%s\\n' \"$*\" >> \"${APT_LOG:?}\"\n",
+        encoding="utf-8",
+    )
+    (fake_bin / "apt-get").chmod(0o755)
+    (fake_bin / "uname").write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "if [[ \"${1:-}\" == -r ]]; then\n"
+        "  printf '6.8.0-test\\n'\n"
+          "else\n"
+        "  /usr/bin/uname \"$@\"\n"
+        "fi\n",
+        encoding="utf-8",
+    )
+    (fake_bin / "uname").chmod(0o755)
+
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "APT_LOG": str(apt_log),
+        "LOG_FILE": str(tmp_path / "install.log"),
+    }
+    result = _run_install_function(
+        tmp_path,
+        "ID=ubuntu\nID_LIKE=debian\nDRY_RUN=false\n_ensure_runtime_host_packages\n",
+        env,
+    )
+
+    assert result.returncode == 0, f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    apt_commands = apt_log.read_text(encoding="utf-8")
+    assert "update -qq" in apt_commands
+    assert "install -y" in apt_commands
+    assert "exfatprogs" in apt_commands
+    assert "linux-modules-extra-6.8.0-test" in apt_commands
+
+
+def test_prepare_managed_mount_roots_honors_usb_mount_base_path_from_env(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    command_log = tmp_path / "commands.log"
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+    (install_dir / ".env").write_text("USB_MOUNT_BASE_PATH=/srv/ecube-usb\n", encoding="utf-8")
+
+    for command in ("mkdir", "chown", "chmod"):
+        (fake_bin / command).write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            f"printf '{command} %s\\n' \"$*\" >> \"${{COMMAND_LOG:?}}\"\n",
+            encoding="utf-8",
+        )
+        (fake_bin / command).chmod(0o755)
+
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "COMMAND_LOG": str(command_log),
+        "LOG_FILE": str(tmp_path / "install.log"),
+    }
+    result = _run_install_function(
+        tmp_path,
+        f"INSTALL_DIR={install_dir}\nDRY_RUN=false\n_prepare_managed_mount_roots\n",
+        env,
+    )
+
+    assert result.returncode == 0, f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    commands = command_log.read_text(encoding="utf-8")
+    assert "mkdir -p /nfs /smb /srv/ecube-usb" in commands
+    assert "chown ecube:ecube /nfs /smb /srv/ecube-usb" in commands
+    assert "chmod 755 /nfs /smb /srv/ecube-usb" in commands


### PR DESCRIPTION
## Summary

This change hardens fresh Ubuntu ECUBE installs so USB mounts work reliably on first use. It closes the gap between formatting support and runtime mount support by provisioning the missing host dependencies and managed mount root, and it improves trusted-system logging so operators can distinguish mount-root, filesystem-runtime, mount-command, and post-mount access-repair failures without exposing raw host paths at normal log levels.

## Changes Included

- Installer runtime prep:
  - `install.sh` now refreshes apt metadata once and, on Ubuntu, installs `linux-modules-extra-$(uname -r)` when that package is available.
  - The installer now prepares the managed USB mount base path in addition to `/nfs` and `/smb`, using the configured `USB_MOUNT_BASE_PATH` from `.env` when present and defaulting to `/mnt/ecube`.
  - Managed mount roots are created with `ecube:ecube` ownership and runtime-safe permissions so direct USB mounts do not fail on a fresh host because the base directory is missing.

- Trusted hardware/runtime diagnostics:
  - `app/infrastructure/drive_mount.py` now classifies USB mount failures into safe operator-facing categories such as:
    - managed mount root unavailable/inaccessible
    - missing filesystem runtime support
    - mount timeout or mount command failure
    - post-mount access repair failure
  - Warning-level logs now carry safe structured fields like `failure_category`, `failure_summary`, and `mount_phase` instead of raw stderr or raw host paths.
  - Debug logs still retain the raw device/path details needed for troubleshooting hardware and host-runtime issues.

- Tests and docs:
  - Added `tests/test_install_runtime_prep.py` to cover Ubuntu kernel-extra package installation and `USB_MOUNT_BASE_PATH`-aware mount-root preparation.
  - Extended `tests/test_drive_mount.py` to verify sanitized warning logs and raw debug logs for filesystem-runtime failures, mount-root preparation failures, and access-repair failures.
  - Updated installation/operator docs to match the new installer behavior and the requirement that the managed USB mount root is prepared as part of setup.

## Operator-Facing Effects

- Fresh Ubuntu installs are less likely to fail when mounting exFAT USB media after formatting.
- ECUBE now prepares the direct USB mount root during installation instead of assuming `/mnt/ecube` already exists.
- Mount failures are easier to triage from normal logs without leaking raw device nodes or absolute paths, which is important for trusted system-layer hardware workflows.

## Validation

- Focused backend validation passed:
  - `cd /home/frank/ecube && /home/frank/ecube/.venv/bin/python -m pytest tests/test_drive_mount.py tests/test_install_runtime_prep.py`
  - Result: `14 passed`
- Editor diagnostics on the touched Python files reported no errors.