### PR TITLE
Bound startup-analysis memory for large source trees by chunking discovery and persistence

### DIFF
--- a/alembic/versions/v0_2_0.py
+++ b/alembic/versions/v0_2_0.py
@@ -138,6 +138,22 @@ def _job_coc_snapshots_table_exists(inspector: sa.Inspector) -> bool:
     return "job_chain_of_custody_snapshots" in inspector.get_table_names()
 
 
+def _startup_analysis_entries_table_exists(inspector: sa.Inspector) -> bool:
+    return "startup_analysis_entries" in inspector.get_table_names()
+
+
+def _export_jobs_has_startup_analysis_cache_present(inspector: sa.Inspector) -> bool:
+    return any(column.get("name") == "startup_analysis_cache_present" for column in inspector.get_columns("export_jobs"))
+
+
+def _export_jobs_has_startup_analysis_revision(inspector: sa.Inspector) -> bool:
+    return any(column.get("name") == "startup_analysis_revision" for column in inspector.get_columns("export_jobs"))
+
+
+def _export_files_has_startup_analysis_revision(inspector: sa.Inspector) -> bool:
+    return any(column.get("name") == "startup_analysis_revision" for column in inspector.get_columns("export_files"))
+
+
 def _create_job_coc_snapshots_table() -> None:
     op.create_table(
         "job_chain_of_custody_snapshots",
@@ -153,6 +169,25 @@ def _create_job_coc_snapshots_table() -> None:
         "ix_job_chain_of_custody_snapshots_job_id",
         "job_chain_of_custody_snapshots",
         ["job_id"],
+        unique=True,
+    )
+
+
+def _create_startup_analysis_entries_table() -> None:
+    op.create_table(
+        "startup_analysis_entries",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("job_id", sa.Integer(), sa.ForeignKey("export_jobs.id"), nullable=False),
+        sa.Column("entry_type", sa.String(), nullable=False),
+        sa.Column("relative_path", sa.String(), nullable=False),
+        sa.Column("size_bytes", sa.BigInteger(), nullable=True),
+        sa.Column("mtime_ns", sa.BigInteger(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index(
+        "ix_startup_analysis_entries_job_entry_path",
+        "startup_analysis_entries",
+        ["job_id", "entry_type", "relative_path"],
         unique=True,
     )
 
@@ -276,6 +311,20 @@ def _upgrade_legacy_project_schema(inspector: sa.Inspector, existing_tables: set
             )
 
 
+def _upgrade_startup_analysis_schema(inspector: sa.Inspector) -> None:
+    if not _export_jobs_has_startup_analysis_cache_present(inspector):
+        with op.batch_alter_table("export_jobs") as batch_op:
+            batch_op.add_column(sa.Column("startup_analysis_cache_present", sa.Boolean(), nullable=False, server_default="0"))
+    if not _export_jobs_has_startup_analysis_revision(inspector):
+        with op.batch_alter_table("export_jobs") as batch_op:
+            batch_op.add_column(sa.Column("startup_analysis_revision", sa.Integer(), nullable=False, server_default="0"))
+    if not _export_files_has_startup_analysis_revision(inspector):
+        with op.batch_alter_table("export_files") as batch_op:
+            batch_op.add_column(sa.Column("startup_analysis_revision", sa.Integer(), nullable=False, server_default="0"))
+    if not _startup_analysis_entries_table_exists(inspector):
+        _create_startup_analysis_entries_table()
+
+
 def upgrade() -> None:
     bind = op.get_bind()
     inspector = sa.inspect(bind)
@@ -292,6 +341,7 @@ def upgrade() -> None:
         _upgrade_legacy_project_schema(inspector, existing_tables)
         if "export_files" in existing_tables:
             _upgrade_legacy_export_file_project_schema(inspector)
+            _upgrade_startup_analysis_schema(inspector)
         return
 
     op.create_table(
@@ -431,6 +481,8 @@ def upgrade() -> None:
         sa.Column("startup_analysis_share_read_mbps", sa.Float(), nullable=True),
         sa.Column("startup_analysis_drive_write_mbps", sa.Float(), nullable=True),
         sa.Column("startup_analysis_estimated_duration_seconds", sa.Integer(), nullable=True),
+        sa.Column("startup_analysis_cache_present", sa.Boolean(), nullable=False, server_default="0"),
+        sa.Column("startup_analysis_revision", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("startup_analysis_entries", sa.JSON().with_variant(JSONB(), "postgresql"), nullable=True),
         sa.Column(
             "created_at",
@@ -458,9 +510,12 @@ def upgrade() -> None:
         ),
         sa.Column("error_message", sa.Text, nullable=True),
         sa.Column("retry_attempts", sa.Integer(), nullable=True, server_default="0"),
+        sa.Column("startup_analysis_revision", sa.Integer(), nullable=False, server_default="0"),
     )
     op.create_index("ix_export_files_project_id", "export_files", ["project_id"])
     op.create_index("ix_export_files_project_status", "export_files", ["project_id", "status"])
+
+    _create_startup_analysis_entries_table()
 
     op.create_table(
         "manifests",
@@ -573,6 +628,7 @@ def downgrade() -> None:
     op.execute(sa.text("DROP INDEX IF EXISTS ix_audit_logs_action_timestamp"))
     op.execute(sa.text("DROP INDEX IF EXISTS ix_audit_logs_drive_timestamp"))
     op.execute(sa.text("DROP INDEX IF EXISTS ix_audit_logs_project_timestamp"))
+    op.drop_index("ix_startup_analysis_entries_job_entry_path", table_name="startup_analysis_entries")
     op.drop_index("ix_job_chain_of_custody_snapshots_job_id", table_name="job_chain_of_custody_snapshots")
     op.drop_index("ix_export_files_project_status", table_name="export_files")
     op.drop_index("ix_export_files_project_id", table_name="export_files")
@@ -590,6 +646,7 @@ def downgrade() -> None:
     op.drop_table("audit_logs")
     op.drop_table("drive_assignments")
     op.drop_table("manifests")
+    op.drop_table("startup_analysis_entries")
     op.drop_table("export_files")
     op.drop_table("job_chain_of_custody_snapshots")
     op.drop_table("export_jobs")

--- a/app/models/jobs.py
+++ b/app/models/jobs.py
@@ -1,6 +1,6 @@
 from itertools import chain
 
-from sqlalchemy import Column, Integer, String, BigInteger, Enum, ForeignKey, DateTime, Text, JSON, Float, Index, event
+from sqlalchemy import Boolean, Column, Integer, String, BigInteger, Enum, ForeignKey, DateTime, Text, JSON, Float, Index, event
 from sqlalchemy.dialects.postgresql import JSONB, insert as postgresql_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session, relationship, validates
@@ -69,6 +69,8 @@ class ExportJob(Base):
     startup_analysis_share_read_mbps = Column(Float, nullable=True)
     startup_analysis_drive_write_mbps = Column(Float, nullable=True)
     startup_analysis_estimated_duration_seconds = Column(Integer, nullable=True)
+    startup_analysis_cache_present = Column(Boolean, default=False, nullable=False, server_default="0")
+    startup_analysis_revision = Column(Integer, default=0, nullable=False, server_default="0")
     startup_analysis_entries = Column(JSON().with_variant(JSONB(), "postgresql"), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     project = relationship(Project, back_populates="jobs")
@@ -76,6 +78,11 @@ class ExportJob(Base):
     manifests = relationship("Manifest", back_populates="job")
     assignments = relationship("DriveAssignment", back_populates="job")
     coc_snapshot = relationship("JobChainOfCustodySnapshot", back_populates="job", uselist=False)
+    startup_analysis_rows = relationship(
+        "StartupAnalysisEntry",
+        back_populates="job",
+        cascade="all, delete-orphan",
+    )
 
     @validates("project_id")
     def _normalize_project_id(self, _key, value):
@@ -84,7 +91,7 @@ class ExportJob(Base):
 
     @property
     def startup_analysis_cached(self) -> bool:
-        return self.startup_analysis_entries is not None
+        return bool(self.startup_analysis_cache_present or self.startup_analysis_entries is not None)
 
     @property
     def startup_analysis_ready(self) -> bool:
@@ -106,8 +113,26 @@ class ExportFile(Base):
     status = Column(Enum(FileStatus, native_enum=False), default=FileStatus.PENDING)
     error_message = Column(Text)
     retry_attempts = Column(Integer, default=0)
+    startup_analysis_revision = Column(Integer, default=0, nullable=False, server_default="0")
     job = relationship("ExportJob", back_populates="files")
     project = relationship(Project, back_populates="files")
+
+
+class StartupAnalysisEntry(Base):
+    __tablename__ = "startup_analysis_entries"
+    __table_args__ = (
+        Index("ix_startup_analysis_entries_job_entry_path", "job_id", "entry_type", "relative_path", unique=True),
+    )
+
+    id = Column(Integer, primary_key=True)
+    job_id = Column(Integer, ForeignKey("export_jobs.id"), nullable=False, index=True)
+    entry_type = Column(String, nullable=False)
+    relative_path = Column(String, nullable=False)
+    size_bytes = Column(BigInteger, nullable=True)
+    mtime_ns = Column(BigInteger, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    job = relationship("ExportJob", back_populates="startup_analysis_rows")
 
 
 class Manifest(Base):

--- a/app/repositories/job_repository.py
+++ b/app/repositories/job_repository.py
@@ -655,20 +655,26 @@ class StartupAnalysisEntryRepository:
             query = query.limit(limit)
         return query.all()
 
-    def add_bulk(self, entries: List[StartupAnalysisEntry]) -> None:
+    def add_bulk(self, entries: List[StartupAnalysisEntry], *, commit: bool = True) -> None:
         if not entries:
             return
         self.db.add_all(entries)
         try:
-            self.db.commit()
+            if commit:
+                self.db.commit()
+            else:
+                self.db.flush()
         except Exception:
             self.db.rollback()
             raise
 
-    def delete_by_job(self, job_id: int) -> None:
+    def delete_by_job(self, job_id: int, *, commit: bool = True) -> None:
         self.db.query(StartupAnalysisEntry).filter(StartupAnalysisEntry.job_id == job_id).delete()
         try:
-            self.db.commit()
+            if commit:
+                self.db.commit()
+            else:
+                self.db.flush()
         except Exception:
             self.db.rollback()
             raise

--- a/app/repositories/job_repository.py
+++ b/app/repositories/job_repository.py
@@ -655,6 +655,27 @@ class StartupAnalysisEntryRepository:
             query = query.limit(limit)
         return query.all()
 
+    def list_by_job_after_id(
+        self,
+        job_id: int,
+        *,
+        entry_type: str | None = None,
+        after_id: int | None = None,
+        limit: int | None = None,
+    ) -> List[StartupAnalysisEntry]:
+        query = (
+            self.db.query(StartupAnalysisEntry)
+            .filter(StartupAnalysisEntry.job_id == job_id)
+            .order_by(StartupAnalysisEntry.id)
+        )
+        if entry_type is not None:
+            query = query.filter(StartupAnalysisEntry.entry_type == entry_type)
+        if after_id is not None:
+            query = query.filter(StartupAnalysisEntry.id > after_id)
+        if limit is not None:
+            query = query.limit(limit)
+        return query.all()
+
     def add_bulk(self, entries: List[StartupAnalysisEntry], *, commit: bool = True) -> None:
         if not entries:
             return

--- a/app/repositories/job_repository.py
+++ b/app/repositories/job_repository.py
@@ -16,6 +16,7 @@ from app.models.jobs import (
     JobChainOfCustodySnapshot,
     JobStatus,
     Manifest,
+    StartupAnalysisEntry,
 )
 
 
@@ -233,6 +234,45 @@ class FileRepository:
         )
         if offset:
             query = query.offset(offset)
+        if limit is not None:
+            query = query.limit(limit)
+        return query.all()
+
+    def list_by_job_after_id(
+        self,
+        job_id: int,
+        *,
+        after_id: int | None = None,
+        limit: int | None = None,
+    ) -> List[ExportFile]:
+        query = (
+            self.db.query(ExportFile)
+            .filter(ExportFile.job_id == job_id)
+            .order_by(ExportFile.id)
+        )
+        if after_id is not None:
+            query = query.filter(ExportFile.id > after_id)
+        if limit is not None:
+            query = query.limit(limit)
+        return query.all()
+
+    def list_pending_by_job_after_id(
+        self,
+        job_id: int,
+        *,
+        after_id: int | None = None,
+        limit: int | None = None,
+    ) -> List[ExportFile]:
+        query = (
+            self.db.query(ExportFile)
+            .filter(
+                ExportFile.job_id == job_id,
+                ExportFile.status == FileStatus.PENDING,
+            )
+            .order_by(ExportFile.id)
+        )
+        if after_id is not None:
+            query = query.filter(ExportFile.id > after_id)
         if limit is not None:
             query = query.limit(limit)
         return query.all()
@@ -581,6 +621,52 @@ class FileRepository:
             .where(DriveAssignment.id == assignment_id)
             .values(file_count=DriveAssignment.file_count + 1)
         )
+        try:
+            self.db.commit()
+        except Exception:
+            self.db.rollback()
+            raise
+
+
+class StartupAnalysisEntryRepository:
+    """Persistence helpers for normalized startup-analysis entries."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def list_by_job(
+        self,
+        job_id: int,
+        *,
+        entry_type: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> List[StartupAnalysisEntry]:
+        query = (
+            self.db.query(StartupAnalysisEntry)
+            .filter(StartupAnalysisEntry.job_id == job_id)
+            .order_by(StartupAnalysisEntry.id)
+        )
+        if entry_type is not None:
+            query = query.filter(StartupAnalysisEntry.entry_type == entry_type)
+        if offset:
+            query = query.offset(offset)
+        if limit is not None:
+            query = query.limit(limit)
+        return query.all()
+
+    def add_bulk(self, entries: List[StartupAnalysisEntry]) -> None:
+        if not entries:
+            return
+        self.db.add_all(entries)
+        try:
+            self.db.commit()
+        except Exception:
+            self.db.rollback()
+            raise
+
+    def delete_by_job(self, job_id: int) -> None:
+        self.db.query(StartupAnalysisEntry).filter(StartupAnalysisEntry.job_id == job_id).delete()
         try:
             self.db.commit()
         except Exception:

--- a/app/services/copy_engine.py
+++ b/app/services/copy_engine.py
@@ -1037,17 +1037,17 @@ def _cached_startup_analysis_is_current(
         return False
 
     saw_root_directory = not source.is_dir()
-    offset = 0
+    last_directory_id: int | None = None
     while True:
-        directory_rows = startup_entry_repo.list_by_job(
+        directory_rows = startup_entry_repo.list_by_job_after_id(
             job.id,
             entry_type="directory",
+            after_id=last_directory_id,
             limit=STARTUP_ANALYSIS_BATCH_SIZE,
-            offset=offset,
         )
         if not directory_rows:
             break
-        offset += len(directory_rows)
+        last_directory_id = directory_rows[-1].id
         for directory_row in directory_rows:
             directory_path = source if directory_row.relative_path == "" else source / directory_row.relative_path
             try:

--- a/app/services/copy_engine.py
+++ b/app/services/copy_engine.py
@@ -6,15 +6,20 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Protocol, Tuple
+from typing import Any, Callable, Iterator, List, Optional, Protocol, Tuple
 
 from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.database import SessionLocal
-from app.models.jobs import ExportFile, FileStatus, JobStatus, StartupAnalysisStatus
+from app.models.jobs import ExportFile, FileStatus, JobStatus, StartupAnalysisEntry, StartupAnalysisStatus
 from app.repositories.audit_repository import AuditRepository
-from app.repositories.job_repository import DriveAssignmentRepository, FileRepository, JobRepository
+from app.repositories.job_repository import (
+    DriveAssignmentRepository,
+    FileRepository,
+    JobRepository,
+    StartupAnalysisEntryRepository,
+)
 from app.services.callback_service import deliver_callback
 from app.services.copy_worker_runtime import (
     register_active_copy_worker,
@@ -23,6 +28,10 @@ from app.services.copy_worker_runtime import (
 from app.utils.sanitize import describe_relative_paths, sanitize_error_message, validate_source_path
 
 logger = logging.getLogger(__name__)
+
+STARTUP_ANALYSIS_BATCH_SIZE = 500
+STARTUP_ANALYSIS_SAMPLE_LIMIT = 16
+COPY_PENDING_BATCH_MULTIPLIER = 4
 
 
 # ---------------------------------------------------------------------------
@@ -295,6 +304,12 @@ def _relative_path(f: Path, source: Path) -> Path:
     return f.relative_to(source) if source.is_dir() else Path(f.name)
 
 
+def _source_path_for_relative_path(source: Path, relative_path: str) -> Path:
+    if source.is_dir():
+        return source / Path(relative_path)
+    return source
+
+
 def _clear_startup_analysis_cache(job: Any) -> None:
     job.startup_analysis_status = StartupAnalysisStatus.NOT_ANALYZED
     job.startup_analysis_last_analyzed_at = None
@@ -304,10 +319,12 @@ def _clear_startup_analysis_cache(job: Any) -> None:
     job.startup_analysis_share_read_mbps = None
     job.startup_analysis_drive_write_mbps = None
     job.startup_analysis_estimated_duration_seconds = None
+    job.startup_analysis_cache_present = False
     job.startup_analysis_entries = None
 
 
 def _clear_startup_analysis_entries(job: Any) -> None:
+    job.startup_analysis_cache_present = False
     job.startup_analysis_entries = None
 
 
@@ -604,110 +621,113 @@ def _relative_directory_markers(source: Path, relative_paths: list[str]) -> dict
     return markers
 
 
-def _analyze_source_files(source: Path, files: list[Path]) -> tuple[dict[str, Path], dict[str, int], int, int, dict[str, int]]:
-    src_by_rel: dict[str, Path] = {}
-    size_by_rel: dict[str, int] = {}
+def _iter_source_tree(source_path: str) -> Iterator[tuple[str, Path]]:
+    source = Path(validate_source_path(source_path, usb_mount_base_path=settings.usb_mount_base_path))
+    try:
+        if not source.exists():
+            raise FileNotFoundError(source_path)
+        if source.is_file():
+            yield "file", source
+            return
+        if not source.is_dir():
+            raise FileNotFoundError(source_path)
+    except OSError as exc:
+        raise FileNotFoundError(source_path) from exc
 
-    for file_path in files:
-        rel = str(_relative_path(file_path, source))
-        size_bytes = file_path.stat().st_size if file_path.exists() else 0
-        src_by_rel[rel] = file_path
-        size_by_rel[rel] = size_bytes
+    scan_errors: list[OSError] = []
 
-    file_count = len(src_by_rel)
-    total_bytes = sum(size_by_rel.values())
-    directory_mtime_by_rel = _relative_directory_markers(source, list(src_by_rel.keys()))
-    return src_by_rel, size_by_rel, file_count, total_bytes, directory_mtime_by_rel
+    def _record_scan_error(exc: OSError) -> None:
+        scan_errors.append(exc)
+        logger.debug("Source scan entry became unavailable under %s: %s", source, exc)
 
+    for root, _dirs, filenames in os.walk(source, onerror=_record_scan_error):
+        root_path = Path(root)
+        yield "directory", root_path
+        for filename in filenames:
+            candidate = root_path / filename
+            try:
+                if candidate.is_file():
+                    yield "file", candidate
+            except OSError as exc:
+                _record_scan_error(exc)
 
-def _persist_startup_analysis_cache(job: Any, source: Path, files: list[Path]) -> tuple[dict[str, Path], dict[str, int], int, int]:
-    src_by_rel, size_by_rel, file_count, total_bytes, directory_mtime_by_rel = _analyze_source_files(source, files)
+    try:
+        source_still_exists = source.exists()
+    except OSError as exc:
+        _record_scan_error(exc)
+        source_still_exists = False
 
-    job.startup_analysis_file_count = file_count
-    job.startup_analysis_total_bytes = total_bytes
-    file_entries = [
-        {"relative_path": rel, "size_bytes": size_bytes}
-        for rel, size_bytes in size_by_rel.items()
-    ]
-    directory_entries = [
-        {
-            "entry_type": "directory",
-            "relative_path": rel_dir,
-            "mtime_ns": mtime_ns,
-        }
-        for rel_dir, mtime_ns in sorted(directory_mtime_by_rel.items())
-    ]
-    job.startup_analysis_entries = file_entries + directory_entries
-
-    return src_by_rel, size_by_rel, int(job.startup_analysis_file_count or 0), int(job.startup_analysis_total_bytes or 0)
+    if scan_errors:
+        if not source_still_exists:
+            raise FileNotFoundError(source_path) from scan_errors[0]
+        raise scan_errors[0]
 
 
-def _load_startup_analysis_cache(job: Any, source: Path) -> Optional[tuple[dict[str, Path], dict[str, int], int, int, dict[str, int]]]:
+def _load_legacy_startup_analysis_cache(
+    job: Any,
+) -> Optional[tuple[list[dict[str, int | str]], list[dict[str, int | str]], int, int]]:
     entries = job.startup_analysis_entries
     file_count = job.startup_analysis_file_count
     total_bytes = job.startup_analysis_total_bytes
 
-    if entries is None or file_count is None or total_bytes is None:
-        return None
-    if not isinstance(entries, list):
+    if entries is None or file_count is None or total_bytes is None or not isinstance(entries, list):
         return None
 
-    src_by_rel: dict[str, Path] = {}
-    size_by_rel: dict[str, int] = {}
-    directory_mtime_by_rel: dict[str, int] = {}
+    file_entries: list[dict[str, int | str]] = []
+    directory_entries: list[dict[str, int | str]] = []
     computed_total_bytes = 0
 
     for entry in entries:
         if not isinstance(entry, dict):
             return None
         entry_type = entry.get("entry_type", "file")
-        rel = entry.get("relative_path")
-        if not isinstance(rel, str) or not rel:
-            if entry_type == "directory" and rel == "":
-                pass
-            else:
-                return None
-        rel_path = Path(rel)
+        relative_path = entry.get("relative_path")
+        if not isinstance(relative_path, str):
+            return None
+        rel_path = Path(relative_path)
         if rel_path.is_absolute() or ".." in rel_path.parts:
             return None
         if entry_type == "directory":
             mtime_ns = entry.get("mtime_ns")
             if not isinstance(mtime_ns, int) or mtime_ns < 0:
                 return None
-            directory_mtime_by_rel[rel] = mtime_ns
+            directory_entries.append(
+                {
+                    "entry_type": "directory",
+                    "relative_path": relative_path,
+                    "mtime_ns": mtime_ns,
+                }
+            )
             continue
-
+        if not relative_path:
+            return None
         size_bytes = entry.get("size_bytes")
         if not isinstance(size_bytes, int) or size_bytes < 0:
             return None
-        src_by_rel[rel] = source / rel_path
-        size_by_rel[rel] = size_bytes
+        file_entries.append({"relative_path": relative_path, "size_bytes": size_bytes})
         computed_total_bytes += size_bytes
 
-    if len(src_by_rel) != int(file_count):
+    if len(file_entries) != int(file_count):
         return None
     if computed_total_bytes != int(total_bytes):
         return None
 
-    return src_by_rel, size_by_rel, int(file_count), int(total_bytes), directory_mtime_by_rel
+    return file_entries, directory_entries, int(file_count), int(total_bytes)
 
 
-def _cached_startup_analysis_is_current(
-    cached: tuple[dict[str, Path], dict[str, int], int, int, dict[str, int]],
+def _legacy_startup_analysis_cache_is_current(
     source: Path,
+    legacy_cache: tuple[list[dict[str, int | str]], list[dict[str, int | str]], int, int],
 ) -> bool:
-    src_by_rel, size_by_rel, file_count, total_bytes, directory_mtime_by_rel = cached
-
-    if source.is_dir() and "" not in directory_mtime_by_rel:
+    file_entries, directory_entries, file_count, total_bytes = legacy_cache
+    if len(file_entries) != file_count:
         return False
 
-    if len(src_by_rel) != file_count:
-        return False
-    if sum(size_by_rel.values()) != total_bytes:
-        return False
-
-    for rel, expected_size in size_by_rel.items():
-        file_path = src_by_rel[rel]
+    computed_total_bytes = 0
+    for entry in file_entries:
+        relative_path = str(entry["relative_path"])
+        expected_size = int(entry["size_bytes"])
+        file_path = _source_path_for_relative_path(source, relative_path)
         try:
             if not file_path.is_file():
                 return False
@@ -715,18 +735,294 @@ def _cached_startup_analysis_is_current(
                 return False
         except OSError:
             return False
+        computed_total_bytes += expected_size
 
-    for rel_dir, expected_mtime_ns in directory_mtime_by_rel.items():
-        directory_path = source if rel_dir == "" else source / rel_dir
+    if computed_total_bytes != total_bytes:
+        return False
+
+    saw_root_directory = not source.is_dir()
+    for entry in directory_entries:
+        relative_path = str(entry["relative_path"])
+        directory_path = source if relative_path == "" else source / relative_path
         try:
             if not directory_path.is_dir():
                 return False
-            if directory_path.stat().st_mtime_ns != expected_mtime_ns:
+            if directory_path.stat().st_mtime_ns != int(entry["mtime_ns"]):
                 return False
         except OSError:
             return False
+        if relative_path == "":
+            saw_root_directory = True
 
-    return True
+    return saw_root_directory
+
+
+def _persist_startup_analysis_file_batch(
+    db: Session,
+    job: Any,
+    file_batch: list[tuple[str, int]],
+    *,
+    revision: int,
+) -> None:
+    if not file_batch:
+        return
+
+    existing_rows = (
+        db.query(ExportFile)
+        .filter(
+            ExportFile.job_id == job.id,
+            ExportFile.relative_path.in_([relative_path for relative_path, _size_bytes in file_batch]),
+        )
+        .all()
+    )
+    existing_by_rel = {row.relative_path: row for row in existing_rows}
+    new_rows: list[ExportFile] = []
+
+    for relative_path, size_bytes in file_batch:
+        existing_row = existing_by_rel.get(relative_path)
+        if existing_row is None:
+            new_rows.append(
+                ExportFile(
+                    job_id=job.id,
+                    project_id=job.project_id,
+                    relative_path=relative_path,
+                    size_bytes=size_bytes,
+                    status=FileStatus.PENDING,
+                    retry_attempts=0,
+                    startup_analysis_revision=revision,
+                )
+            )
+            continue
+
+        existing_row.size_bytes = size_bytes
+        existing_row.startup_analysis_revision = revision
+        if existing_row.status != FileStatus.DONE:
+            existing_row.status = FileStatus.PENDING
+            existing_row.retry_attempts = 0
+            existing_row.error_message = None
+
+    if new_rows:
+        db.add_all(new_rows)
+
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+
+def _persist_startup_analysis_entry_batch(
+    startup_entry_repo: StartupAnalysisEntryRepository,
+    job_id: int,
+    entry_type: str,
+    entries: list[tuple[str, int]],
+) -> None:
+    startup_entry_repo.add_bulk(
+        [
+            StartupAnalysisEntry(
+                job_id=job_id,
+                entry_type=entry_type,
+                relative_path=relative_path,
+                size_bytes=value if entry_type == "file" else None,
+                mtime_ns=value if entry_type == "directory" else None,
+            )
+            for relative_path, value in entries
+        ]
+    )
+
+
+def _persist_startup_analysis_cache(
+    db: Session,
+    job: Any,
+    source: Path,
+    startup_entry_repo: StartupAnalysisEntryRepository,
+) -> tuple[int, int, list[Path]]:
+    file_batch: list[tuple[str, int]] = []
+    directory_batch: list[tuple[str, int]] = []
+    sample_files: list[Path] = []
+    file_count = 0
+    total_bytes = 0
+    revision = int(job.startup_analysis_revision or 0) + 1
+
+    job.startup_analysis_revision = revision
+    job.startup_analysis_cache_present = False
+    job.startup_analysis_entries = None
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    startup_entry_repo.delete_by_job(job.id)
+
+    for entry_type, path in _iter_source_tree(job.source_path):
+        if entry_type == "directory":
+            relative_directory = "" if path == source else str(_relative_path(path, source))
+            directory_batch.append((relative_directory, path.stat().st_mtime_ns))
+            if len(directory_batch) >= STARTUP_ANALYSIS_BATCH_SIZE:
+                _persist_startup_analysis_entry_batch(startup_entry_repo, job.id, "directory", directory_batch)
+                directory_batch = []
+            continue
+
+        relative_path = str(_relative_path(path, source))
+        size_bytes = path.stat().st_size if path.exists() else 0
+        file_batch.append((relative_path, size_bytes))
+        if len(sample_files) < STARTUP_ANALYSIS_SAMPLE_LIMIT:
+            sample_files.append(path)
+        file_count += 1
+        total_bytes += size_bytes
+
+        if len(file_batch) >= STARTUP_ANALYSIS_BATCH_SIZE:
+            _persist_startup_analysis_file_batch(db, job, file_batch, revision=revision)
+            _persist_startup_analysis_entry_batch(startup_entry_repo, job.id, "file", file_batch)
+            file_batch = []
+
+    if file_batch:
+        _persist_startup_analysis_file_batch(db, job, file_batch, revision=revision)
+        _persist_startup_analysis_entry_batch(startup_entry_repo, job.id, "file", file_batch)
+    if directory_batch:
+        _persist_startup_analysis_entry_batch(startup_entry_repo, job.id, "directory", directory_batch)
+
+    db.query(ExportFile).filter(
+        ExportFile.job_id == job.id,
+        ExportFile.startup_analysis_revision != revision,
+    ).delete(synchronize_session=False)
+
+    job.startup_analysis_file_count = file_count
+    job.startup_analysis_total_bytes = total_bytes
+    job.startup_analysis_cache_present = True
+    job.startup_analysis_entries = None
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    return file_count, total_bytes, sample_files
+
+
+def _persist_legacy_startup_analysis_cache(
+    db: Session,
+    job: Any,
+    source: Path,
+    startup_entry_repo: StartupAnalysisEntryRepository,
+    legacy_cache: tuple[list[dict[str, int | str]], list[dict[str, int | str]], int, int],
+) -> list[Path]:
+    file_entries, directory_entries, file_count, total_bytes = legacy_cache
+    revision = int(job.startup_analysis_revision or 0) + 1
+    job.startup_analysis_revision = revision
+    job.startup_analysis_cache_present = False
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    startup_entry_repo.delete_by_job(job.id)
+
+    sample_files: list[Path] = []
+    for start in range(0, len(file_entries), STARTUP_ANALYSIS_BATCH_SIZE):
+        batch_entries = file_entries[start:start + STARTUP_ANALYSIS_BATCH_SIZE]
+        file_batch = [
+            (str(entry["relative_path"]), int(entry["size_bytes"]))
+            for entry in batch_entries
+        ]
+        _persist_startup_analysis_file_batch(db, job, file_batch, revision=revision)
+        _persist_startup_analysis_entry_batch(startup_entry_repo, job.id, "file", file_batch)
+        for relative_path, _size_bytes in file_batch:
+            if len(sample_files) >= STARTUP_ANALYSIS_SAMPLE_LIMIT:
+                break
+            sample_files.append(_source_path_for_relative_path(source, relative_path))
+
+    for start in range(0, len(directory_entries), STARTUP_ANALYSIS_BATCH_SIZE):
+        batch_entries = directory_entries[start:start + STARTUP_ANALYSIS_BATCH_SIZE]
+        directory_batch = [
+            (str(entry["relative_path"]), int(entry["mtime_ns"]))
+            for entry in batch_entries
+        ]
+        _persist_startup_analysis_entry_batch(startup_entry_repo, job.id, "directory", directory_batch)
+
+    db.query(ExportFile).filter(
+        ExportFile.job_id == job.id,
+        ExportFile.startup_analysis_revision != revision,
+    ).delete(synchronize_session=False)
+
+    job.startup_analysis_file_count = file_count
+    job.startup_analysis_total_bytes = total_bytes
+    job.startup_analysis_cache_present = True
+    job.startup_analysis_entries = None
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    return sample_files
+
+
+def _cached_startup_analysis_is_current(
+    job: Any,
+    source: Path,
+    file_repo: FileRepository,
+    startup_entry_repo: StartupAnalysisEntryRepository,
+) -> bool:
+    file_count = int(job.startup_analysis_file_count or 0)
+    total_bytes = int(job.startup_analysis_total_bytes or 0)
+    revision = int(job.startup_analysis_revision or 0)
+    if file_count <= 0 or total_bytes < 0 or revision <= 0:
+        return False
+
+    validated_file_count = 0
+    validated_total_bytes = 0
+    last_file_id: int | None = None
+    while True:
+        file_rows = file_repo.list_by_job_after_id(job.id, after_id=last_file_id, limit=STARTUP_ANALYSIS_BATCH_SIZE)
+        if not file_rows:
+            break
+        last_file_id = file_rows[-1].id
+        for file_row in file_rows:
+            if int(file_row.startup_analysis_revision or 0) != revision:
+                return False
+            file_path = _source_path_for_relative_path(source, file_row.relative_path)
+            expected_size = int(file_row.size_bytes or 0)
+            try:
+                if not file_path.is_file():
+                    return False
+                if file_path.stat().st_size != expected_size:
+                    return False
+            except OSError:
+                return False
+            validated_file_count += 1
+            validated_total_bytes += expected_size
+
+    if validated_file_count != file_count or validated_total_bytes != total_bytes:
+        return False
+
+    saw_root_directory = not source.is_dir()
+    offset = 0
+    while True:
+        directory_rows = startup_entry_repo.list_by_job(
+            job.id,
+            entry_type="directory",
+            limit=STARTUP_ANALYSIS_BATCH_SIZE,
+            offset=offset,
+        )
+        if not directory_rows:
+            break
+        offset += len(directory_rows)
+        for directory_row in directory_rows:
+            directory_path = source if directory_row.relative_path == "" else source / directory_row.relative_path
+            try:
+                if not directory_path.is_dir():
+                    return False
+                if directory_path.stat().st_mtime_ns != int(directory_row.mtime_ns or 0):
+                    return False
+            except OSError:
+                return False
+            if directory_row.relative_path == "":
+                saw_root_directory = True
+
+    return saw_root_directory
 
 
 def prepare_job_startup_analysis(
@@ -741,37 +1037,56 @@ def prepare_job_startup_analysis(
         job_repo = JobRepository(db)
         file_repo = FileRepository(db)
         audit_repo = AuditRepository(db)
+        startup_entry_repo = StartupAnalysisEntryRepository(db)
 
         job = job_repo.get(job_id)
         if not job:
             raise FileNotFoundError(f"Job {job_id} not found")
 
         source = Path(job.source_path)
-        cached_startup_analysis = _load_startup_analysis_cache(job, source)
         reused_cached_analysis = False
+        sample_files: list[Path] = []
 
-        if cached_startup_analysis is None:
-            files = scan_source_files(job.source_path)
-            src_by_rel, size_by_rel, cached_file_count, cached_total_bytes = _persist_startup_analysis_cache(job, source, files)
-        elif _cached_startup_analysis_is_current(cached_startup_analysis, source):
+        if bool(job.startup_analysis_cache_present) and _cached_startup_analysis_is_current(job, source, file_repo, startup_entry_repo):
             reused_cached_analysis = True
-            src_by_rel, size_by_rel, cached_file_count, cached_total_bytes, _directory_mtime_by_rel = cached_startup_analysis
+            cached_file_count = int(job.startup_analysis_file_count or 0)
+            cached_total_bytes = int(job.startup_analysis_total_bytes or 0)
+            sample_rows = file_repo.list_by_job(job_id, limit=STARTUP_ANALYSIS_SAMPLE_LIMIT)
+            sample_files = [
+                _source_path_for_relative_path(source, file_row.relative_path)
+                for file_row in sample_rows
+            ]
         else:
-            job.startup_analysis_status = StartupAnalysisStatus.STALE
-            try:
-                job_repo.save(job)
-            except Exception:
-                logger.exception("DB commit failed while marking startup analysis stale", extra={"job_id": job_id})
-            files = scan_source_files(job.source_path)
-            logger.info(
-                "Refreshing stale startup analysis cache",
-                extra={
-                    "job_id": job_id,
-                    "cached_file_count": cached_startup_analysis[2],
-                    "current_file_count": len(files),
-                },
-            )
-            src_by_rel, size_by_rel, cached_file_count, cached_total_bytes = _persist_startup_analysis_cache(job, source, files)
+            legacy_cache = _load_legacy_startup_analysis_cache(job)
+            previous_file_count = int(job.startup_analysis_file_count or 0)
+            if job.startup_analysis_cached:
+                job.startup_analysis_status = StartupAnalysisStatus.STALE
+                try:
+                    job_repo.save(job)
+                except Exception:
+                    logger.exception("DB commit failed while marking startup analysis stale", extra={"job_id": job_id})
+
+            if legacy_cache is not None and _legacy_startup_analysis_cache_is_current(source, legacy_cache):
+                sample_files = _persist_legacy_startup_analysis_cache(db, job, source, startup_entry_repo, legacy_cache)
+                cached_file_count = int(job.startup_analysis_file_count or 0)
+                cached_total_bytes = int(job.startup_analysis_total_bytes or 0)
+                reused_cached_analysis = True
+            else:
+                cached_file_count, cached_total_bytes, sample_files = _persist_startup_analysis_cache(
+                    db,
+                    job,
+                    source,
+                    startup_entry_repo,
+                )
+                if previous_file_count > 0:
+                    logger.info(
+                        "Refreshing stale startup analysis cache",
+                        extra={
+                            "job_id": job_id,
+                            "cached_file_count": previous_file_count,
+                            "current_file_count": cached_file_count,
+                        },
+                    )
 
         benchmark_details: dict[str, Optional[float] | Optional[int] | int] = {
             "share_read_mbps": None,
@@ -782,7 +1097,7 @@ def prepare_job_startup_analysis(
         if manual:
             benchmark_details = _measure_startup_analysis_transfer_rates(
                 job,
-                [src_by_rel[rel] for rel in sorted(src_by_rel.keys())],
+                sample_files,
                 cached_total_bytes,
             )
             job.startup_analysis_share_read_mbps = benchmark_details["share_read_mbps"]
@@ -795,8 +1110,6 @@ def prepare_job_startup_analysis(
             raise ValueError("Source path contains no transferable files")
 
         existing_files = file_repo.list_by_job(job_id)
-        existing_by_rel = {ef.relative_path: ef for ef in existing_files}
-
         for ef in existing_files:
             if ef.status != FileStatus.DONE:
                 ef.status = FileStatus.PENDING
@@ -807,20 +1120,6 @@ def prepare_job_startup_analysis(
         except Exception:
             db.rollback()
             raise
-
-        new_files = [
-            ExportFile(
-                job_id=job_id,
-                relative_path=rel,
-                size_bytes=size_by_rel[rel],
-                status=FileStatus.PENDING,
-                retry_attempts=0,
-            )
-            for rel in src_by_rel
-            if rel not in existing_by_rel
-        ]
-        if new_files:
-            file_repo.add_bulk(new_files)
 
         job.file_count = cached_file_count
         job.total_bytes = cached_total_bytes
@@ -880,8 +1179,6 @@ def prepare_job_startup_analysis(
                     exc=audit_exc,
                 )
         return {
-            "src_by_rel": src_by_rel,
-            "size_by_rel": size_by_rel,
             "file_count": cached_file_count,
             "total_bytes": cached_total_bytes,
             "reused_cached_analysis": reused_cached_analysis,
@@ -1262,7 +1559,6 @@ def run_copy_job(job_id: int) -> None:
             target = Path(job.target_mount_path) if job.target_mount_path else None
 
             preparation = prepare_job_startup_analysis(job_id)
-            src_by_rel = preparation["src_by_rel"]
 
             job = job_repo.get(job_id)
             if preparation["reused_cached_analysis"]:
@@ -1278,16 +1574,6 @@ def run_copy_job(job_id: int) -> None:
                 except Exception:
                     logger.error("Failed to write audit log for JOB_STARTUP_ANALYSIS_REUSED")
 
-            committed_files = file_repo.list_by_job(job_id)
-
-            # Re-query to get stable IDs; only submit PENDING (non-DONE) files.
-            pending_files = [ef for ef in committed_files if ef.status == FileStatus.PENDING]
-            file_pairs = [
-                (src_by_rel[ef.relative_path], ef.id)
-                for ef in pending_files
-                if ef.relative_path in src_by_rel
-            ]
-
             max_retries = job.max_file_retries if job.max_file_retries is not None else settings.copy_default_max_retries
             retry_delay = float(job.retry_delay_seconds) if job.retry_delay_seconds is not None else settings.copy_default_retry_delay_seconds
 
@@ -1298,37 +1584,57 @@ def run_copy_job(job_id: int) -> None:
                 thread_name_prefix=f"copy-job-{job_id}",
             )
             try:
-                futures = {
-                    executor.submit(_process_file, ef_id, src, target, max_retries, retry_delay): ef_id
-                    for src, ef_id in file_pairs
-                }
-                for future in as_completed(futures):
-                    try:
-                        future.result()
-                    except Exception:
-                        # Worker already recorded FileStatus.ERROR in its own session;
-                        # unexpected exceptions are caught here to let other workers finish.
-                        pass
-
-                    db.expire_all()
-                    latest_job = job_repo.get(job_id)
-                    latest_started_at_key = _normalize_started_at(
-                        latest_job.started_at if latest_job else None
+                pending_after_id: int | None = None
+                batch_limit = max(1, (job.thread_count or settings.copy_default_thread_count) * COPY_PENDING_BATCH_MULTIPLIER)
+                while True:
+                    pending_files = file_repo.list_pending_by_job_after_id(
+                        job_id,
+                        after_id=pending_after_id,
+                        limit=batch_limit,
                     )
-                    if latest_job and latest_started_at_key and latest_started_at_key != run_started_at_key:
-                        for pending in futures:
-                            if not pending.done():
-                                pending.cancel()
-                        logger.info(
-                            "Skipping stale copy worker after newer resume",
-                            extra={"job_id": job_id, "started_at": str(run_started_at)},
+                    if not pending_files:
+                        break
+                    pending_after_id = pending_files[-1].id
+                    futures = {
+                        executor.submit(
+                            _process_file,
+                            ef.id,
+                            _source_path_for_relative_path(source, ef.relative_path),
+                            target,
+                            max_retries,
+                            retry_delay,
+                        ): ef.id
+                        for ef in pending_files
+                    }
+                    for future in as_completed(futures):
+                        try:
+                            future.result()
+                        except Exception:
+                            # Worker already recorded FileStatus.ERROR in its own session;
+                            # unexpected exceptions are caught here to let other workers finish.
+                            pass
+
+                        db.expire_all()
+                        latest_job = job_repo.get(job_id)
+                        latest_started_at_key = _normalize_started_at(
+                            latest_job.started_at if latest_job else None
                         )
-                        return
-                    if latest_job and latest_job.status in (JobStatus.PAUSING, JobStatus.PAUSED):
-                        pause_requested = True
-                        for pending in futures:
-                            if not pending.done():
-                                pending.cancel()
+                        if latest_job and latest_started_at_key and latest_started_at_key != run_started_at_key:
+                            for pending in futures:
+                                if not pending.done():
+                                    pending.cancel()
+                            logger.info(
+                                "Skipping stale copy worker after newer resume",
+                                extra={"job_id": job_id, "started_at": str(run_started_at)},
+                            )
+                            return
+                        if latest_job and latest_job.status in (JobStatus.PAUSING, JobStatus.PAUSED):
+                            pause_requested = True
+                            for pending in futures:
+                                if not pending.done():
+                                    pending.cancel()
+                            break
+                    if pause_requested:
                         break
 
             finally:
@@ -1382,6 +1688,9 @@ def run_copy_job(job_id: int) -> None:
                         and job.startup_analysis_cached
                     ):
                         cache_clear_details = _startup_analysis_cache_details(job)
+                        db.query(StartupAnalysisEntry).filter(
+                            StartupAnalysisEntry.job_id == job_id,
+                        ).delete(synchronize_session=False)
                         _clear_startup_analysis_entries(job)
                         cache_cleared = True
                     try:

--- a/app/services/copy_engine.py
+++ b/app/services/copy_engine.py
@@ -763,6 +763,7 @@ def _persist_startup_analysis_file_batch(
     file_batch: list[tuple[str, int]],
     *,
     revision: int,
+    commit: bool = True,
 ) -> None:
     if not file_batch:
         return
@@ -805,10 +806,18 @@ def _persist_startup_analysis_file_batch(
         db.add_all(new_rows)
 
     try:
-        db.commit()
+        if commit:
+            db.commit()
+        else:
+            db.flush()
     except Exception:
         db.rollback()
         raise
+
+    for file_row in existing_rows:
+        db.expunge(file_row)
+    for file_row in new_rows:
+        db.expunge(file_row)
 
 
 def _persist_startup_analysis_entry_batch(
@@ -816,19 +825,22 @@ def _persist_startup_analysis_entry_batch(
     job_id: int,
     entry_type: str,
     entries: list[tuple[str, int]],
+    *,
+    commit: bool = True,
 ) -> None:
-    startup_entry_repo.add_bulk(
-        [
-            StartupAnalysisEntry(
-                job_id=job_id,
-                entry_type=entry_type,
-                relative_path=relative_path,
-                size_bytes=value if entry_type == "file" else None,
-                mtime_ns=value if entry_type == "directory" else None,
-            )
-            for relative_path, value in entries
-        ]
-    )
+    startup_entries = [
+        StartupAnalysisEntry(
+            job_id=job_id,
+            entry_type=entry_type,
+            relative_path=relative_path,
+            size_bytes=value if entry_type == "file" else None,
+            mtime_ns=value if entry_type == "directory" else None,
+        )
+        for relative_path, value in entries
+    ]
+    startup_entry_repo.add_bulk(startup_entries, commit=commit)
+    for startup_entry in startup_entries:
+        startup_entry_repo.db.expunge(startup_entry)
 
 
 def _persist_startup_analysis_cache(
@@ -847,20 +859,21 @@ def _persist_startup_analysis_cache(
     job.startup_analysis_revision = revision
     job.startup_analysis_cache_present = False
     job.startup_analysis_entries = None
-    try:
-        db.commit()
-    except Exception:
-        db.rollback()
-        raise
 
-    startup_entry_repo.delete_by_job(job.id)
+    startup_entry_repo.delete_by_job(job.id, commit=False)
 
     for entry_type, path in _iter_source_tree(job.source_path):
         if entry_type == "directory":
             relative_directory = "" if path == source else str(_relative_path(path, source))
             directory_batch.append((relative_directory, path.stat().st_mtime_ns))
             if len(directory_batch) >= STARTUP_ANALYSIS_BATCH_SIZE:
-                _persist_startup_analysis_entry_batch(startup_entry_repo, job.id, "directory", directory_batch)
+                _persist_startup_analysis_entry_batch(
+                    startup_entry_repo,
+                    job.id,
+                    "directory",
+                    directory_batch,
+                    commit=False,
+                )
                 directory_batch = []
             continue
 
@@ -873,15 +886,33 @@ def _persist_startup_analysis_cache(
         total_bytes += size_bytes
 
         if len(file_batch) >= STARTUP_ANALYSIS_BATCH_SIZE:
-            _persist_startup_analysis_file_batch(db, job, file_batch, revision=revision)
-            _persist_startup_analysis_entry_batch(startup_entry_repo, job.id, "file", file_batch)
+            _persist_startup_analysis_file_batch(db, job, file_batch, revision=revision, commit=False)
+            _persist_startup_analysis_entry_batch(
+                startup_entry_repo,
+                job.id,
+                "file",
+                file_batch,
+                commit=False,
+            )
             file_batch = []
 
     if file_batch:
-        _persist_startup_analysis_file_batch(db, job, file_batch, revision=revision)
-        _persist_startup_analysis_entry_batch(startup_entry_repo, job.id, "file", file_batch)
+        _persist_startup_analysis_file_batch(db, job, file_batch, revision=revision, commit=False)
+        _persist_startup_analysis_entry_batch(
+            startup_entry_repo,
+            job.id,
+            "file",
+            file_batch,
+            commit=False,
+        )
     if directory_batch:
-        _persist_startup_analysis_entry_batch(startup_entry_repo, job.id, "directory", directory_batch)
+        _persist_startup_analysis_entry_batch(
+            startup_entry_repo,
+            job.id,
+            "directory",
+            directory_batch,
+            commit=False,
+        )
 
     db.query(ExportFile).filter(
         ExportFile.job_id == job.id,
@@ -912,13 +943,8 @@ def _persist_legacy_startup_analysis_cache(
     revision = int(job.startup_analysis_revision or 0) + 1
     job.startup_analysis_revision = revision
     job.startup_analysis_cache_present = False
-    try:
-        db.commit()
-    except Exception:
-        db.rollback()
-        raise
 
-    startup_entry_repo.delete_by_job(job.id)
+    startup_entry_repo.delete_by_job(job.id, commit=False)
 
     sample_files: list[Path] = []
     for start in range(0, len(file_entries), STARTUP_ANALYSIS_BATCH_SIZE):
@@ -927,8 +953,14 @@ def _persist_legacy_startup_analysis_cache(
             (str(entry["relative_path"]), int(entry["size_bytes"]))
             for entry in batch_entries
         ]
-        _persist_startup_analysis_file_batch(db, job, file_batch, revision=revision)
-        _persist_startup_analysis_entry_batch(startup_entry_repo, job.id, "file", file_batch)
+        _persist_startup_analysis_file_batch(db, job, file_batch, revision=revision, commit=False)
+        _persist_startup_analysis_entry_batch(
+            startup_entry_repo,
+            job.id,
+            "file",
+            file_batch,
+            commit=False,
+        )
         for relative_path, _size_bytes in file_batch:
             if len(sample_files) >= STARTUP_ANALYSIS_SAMPLE_LIMIT:
                 break
@@ -940,7 +972,13 @@ def _persist_legacy_startup_analysis_cache(
             (str(entry["relative_path"]), int(entry["mtime_ns"]))
             for entry in batch_entries
         ]
-        _persist_startup_analysis_entry_batch(startup_entry_repo, job.id, "directory", directory_batch)
+        _persist_startup_analysis_entry_batch(
+            startup_entry_repo,
+            job.id,
+            "directory",
+            directory_batch,
+            commit=False,
+        )
 
     db.query(ExportFile).filter(
         ExportFile.job_id == job.id,

--- a/app/services/job_service.py
+++ b/app/services/job_service.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from app.config import settings
 from app.exceptions import ConflictError, ECUBEException, EncodingError
 from app.models.hardware import DriveState, UsbDrive
-from app.models.jobs import DriveAssignment, ExportFile, ExportJob, JobStatus, Manifest, StartupAnalysisStatus
+from app.models.jobs import DriveAssignment, ExportFile, ExportJob, JobStatus, Manifest, StartupAnalysisEntry, StartupAnalysisStatus
 from app.models.network import MountStatus
 from app.repositories.audit_repository import AuditRepository
 from app.repositories.drive_repository import DriveRepository
@@ -639,6 +639,7 @@ def _clear_job_startup_analysis_cache(job_row: Any) -> dict[str, int]:
     job_row.startup_analysis_share_read_mbps = None
     job_row.startup_analysis_drive_write_mbps = None
     job_row.startup_analysis_estimated_duration_seconds = None
+    job_row.startup_analysis_cache_present = False
     job_row.startup_analysis_entries = None
     return details
 
@@ -652,6 +653,7 @@ def _mark_job_startup_analysis_stale(job_row: Any) -> None:
     job_row.startup_analysis_share_read_mbps = None
     job_row.startup_analysis_drive_write_mbps = None
     job_row.startup_analysis_estimated_duration_seconds = None
+    job_row.startup_analysis_cache_present = False
     job_row.startup_analysis_entries = None
 
 
@@ -667,6 +669,7 @@ def _has_persisted_startup_analysis_state(job_row: Any) -> bool:
             cast(Optional[float], job_row.startup_analysis_share_read_mbps),
             cast(Optional[float], job_row.startup_analysis_drive_write_mbps),
             cast(Optional[int], job_row.startup_analysis_estimated_duration_seconds),
+            cast(Optional[bool], job_row.startup_analysis_cache_present),
             cast(Optional[object], job_row.startup_analysis_entries),
         )
     )
@@ -812,6 +815,7 @@ def update_job(
     job_row.callback_url = body.callback_url
     if source_path_changed:
         db.query(ExportFile).filter(ExportFile.job_id == job_id).delete(synchronize_session=False)
+        db.query(StartupAnalysisEntry).filter(StartupAnalysisEntry.job_id == job_id).delete(synchronize_session=False)
         job_row.file_count = 0
         job_row.total_bytes = 0
         job_row.copied_bytes = 0
@@ -872,7 +876,8 @@ def complete_job(
 
     previous_status = current_status.value
     cache_clear_details: Optional[dict[str, int]] = None
-    if cast(Optional[object], job_row.startup_analysis_entries) is not None:
+    if bool(cast(Optional[bool], job_row.startup_analysis_cache_present) or cast(Optional[object], job_row.startup_analysis_entries) is not None):
+        db.query(StartupAnalysisEntry).filter(StartupAnalysisEntry.job_id == job_id).delete(synchronize_session=False)
         cache_clear_details = _clear_job_startup_analysis_cache(job_row)
     job_row.status = JobStatus.COMPLETED
     if cast(Optional[datetime], job_row.completed_at) is None:
@@ -962,7 +967,8 @@ def clear_job_startup_analysis_cache(
     cache_clear_details: Optional[dict[str, int]] = None
     active_drive_id: Optional[int] = None
 
-    if cast(Optional[object], job_row.startup_analysis_entries) is not None:
+    if bool(cast(Optional[bool], job_row.startup_analysis_cache_present) or cast(Optional[object], job_row.startup_analysis_entries) is not None):
+        db.query(StartupAnalysisEntry).filter(StartupAnalysisEntry.job_id == job_id).delete(synchronize_session=False)
         cache_clear_details = _clear_job_startup_analysis_cache(job_row)
         try:
             job_repo.save(job)

--- a/docs/database/ecube-schema.dbml
+++ b/docs/database/ecube-schema.dbml
@@ -142,6 +142,8 @@ Table export_jobs {
   startup_analysis_share_read_mbps float
   startup_analysis_drive_write_mbps float
   startup_analysis_estimated_duration_seconds int
+  startup_analysis_cache_present boolean [not null, default: false]
+  startup_analysis_revision int [not null, default: 0]
   startup_analysis_entries json
   created_at timestamptz
 
@@ -176,6 +178,7 @@ Table export_files {
   status file_status [default: 'PENDING']
   error_message text
   retry_attempts int [default: 0]
+  startup_analysis_revision int [not null, default: 0]
 
   indexes {
     project_id [name: 'ix_export_files_project_id']
@@ -202,6 +205,21 @@ Table manifests {
   manifest_path varchar
   format varchar [default: 'JSON']
   created_at timestamptz
+}
+
+Table startup_analysis_entries {
+  id int [pk, not null]
+  job_id int [not null]
+  entry_type varchar [not null]
+  relative_path varchar [not null]
+  size_bytes bigint
+  mtime_ns bigint
+  created_at timestamptz [not null]
+
+  indexes {
+    (job_id, entry_type, relative_path) [unique, name: 'ix_startup_analysis_entries_job_entry_path']
+    job_id [name: 'ix_startup_analysis_entries_job_id']
+  }
 }
 
 Table usb_drives {
@@ -258,5 +276,6 @@ Ref: export_files.project_id > projects.normalized_project_id
 Ref: export_jobs.project_id > projects.normalized_project_id
 Ref: job_chain_of_custody_snapshots.job_id > export_jobs.id
 Ref: manifests.job_id > export_jobs.id
+Ref: startup_analysis_entries.job_id > export_jobs.id
 Ref: usb_drives.port_id > usb_ports.id
 Ref: usb_ports.hub_id > usb_hubs.id

--- a/tests/test_copy_engine.py
+++ b/tests/test_copy_engine.py
@@ -1252,6 +1252,65 @@ def test_prepare_job_startup_analysis_persists_entries_in_batches(db, tmp_path):
     ).count() == 5
 
 
+def test_prepare_job_startup_analysis_refresh_failure_preserves_previous_cache(db, tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "file.txt").write_bytes(b"content")
+
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+
+    job = _make_job(db, str(source_dir), target_mount_path=str(target_dir))
+    job.startup_analysis_status = StartupAnalysisStatus.READY
+    job.startup_analysis_file_count = 1
+    job.startup_analysis_total_bytes = len(b"content")
+    job.startup_analysis_cache_present = True
+    job.startup_analysis_revision = 1
+    db.add(
+        ExportFile(
+            job_id=job.id,
+            relative_path="file.txt",
+            size_bytes=len(b"content"),
+            status=FileStatus.PENDING,
+            startup_analysis_revision=1,
+        )
+    )
+    db.add(
+        StartupAnalysisEntry(
+            job_id=job.id,
+            entry_type="directory",
+            relative_path="",
+            mtime_ns=source_dir.stat().st_mtime_ns,
+        )
+    )
+    db.commit()
+
+    (source_dir / "extra.txt").write_bytes(b"more")
+
+    original_persist_file_batch = copy_engine._persist_startup_analysis_file_batch
+
+    def _fail_after_first_file_batch(*args, **kwargs):
+        original_persist_file_batch(*args, **kwargs)
+        raise RuntimeError("boom")
+
+    with patch("app.services.copy_engine.SessionLocal", _session_factory(db)):
+        with patch("app.services.copy_engine._persist_startup_analysis_file_batch", side_effect=_fail_after_first_file_batch):
+            with pytest.raises(RuntimeError, match="boom"):
+                copy_engine.prepare_job_startup_analysis(job.id)
+
+    db.expire_all()
+    db.refresh(job)
+    file_rows = db.query(ExportFile).filter(ExportFile.job_id == job.id).order_by(ExportFile.id).all()
+    directory_rows = db.query(StartupAnalysisEntry).filter(StartupAnalysisEntry.job_id == job.id).all()
+
+    assert job.startup_analysis_cached is True
+    assert job.startup_analysis_revision == 1
+    assert job.startup_analysis_file_count == 1
+    assert job.startup_analysis_total_bytes == len(b"content")
+    assert [(row.relative_path, row.startup_analysis_revision) for row in file_rows] == [("file.txt", 1)]
+    assert [(row.entry_type, row.relative_path) for row in directory_rows] == [("directory", "")]
+
+
 def test_run_copy_job_accumulates_active_duration_on_resume(db, tmp_path):
     """Completed jobs retain previously accrued active duration after resume."""
     source_dir = tmp_path / "source"

--- a/tests/test_copy_engine.py
+++ b/tests/test_copy_engine.py
@@ -11,7 +11,7 @@ import pytest
 
 from app.models.audit import AuditLog
 from app.models.hardware import DriveState, UsbDrive
-from app.models.jobs import DriveAssignment, ExportFile, ExportJob, FileStatus, JobStatus, StartupAnalysisStatus
+from app.models.jobs import DriveAssignment, ExportFile, ExportJob, FileStatus, JobStatus, StartupAnalysisEntry, StartupAnalysisStatus
 from app.services import copy_engine
 
 
@@ -1016,7 +1016,7 @@ def test_prepare_job_startup_analysis_uses_specific_failure_fallback_for_unknown
     job = _make_job(db, str(source_dir), target_mount_path=str(target_dir))
 
     with patch("app.services.copy_engine.SessionLocal", _session_factory(db)):
-        with patch("app.services.copy_engine.scan_source_files", side_effect=RuntimeError("boom")):
+        with patch("app.services.copy_engine._iter_source_tree", side_effect=RuntimeError("boom")):
             with pytest.raises(RuntimeError, match="boom"):
                 copy_engine.prepare_job_startup_analysis(job.id, actor="analyst", manual=True)
 
@@ -1036,7 +1036,7 @@ def test_run_startup_analysis_logs_sanitized_failure_at_info_level(db, tmp_path,
     job = _make_job(db, str(source_dir), target_mount_path=str(target_dir))
 
     with patch("app.services.copy_engine.SessionLocal", _session_factory(db)):
-        with patch("app.services.copy_engine.scan_source_files", side_effect=RuntimeError("boom /secret/path")):
+        with patch("app.services.copy_engine._iter_source_tree", side_effect=RuntimeError("boom /secret/path")):
             with caplog.at_level(logging.INFO):
                 copy_engine.run_startup_analysis(job.id, actor="analyst")
 
@@ -1112,16 +1112,34 @@ def test_run_copy_job_refreshes_stale_startup_analysis_cache_on_completed_run_wi
 
     db.expire_all()
     db.refresh(job)
+    startup_entries = (
+        db.query(StartupAnalysisEntry)
+        .filter(StartupAnalysisEntry.job_id == job.id)
+        .order_by(StartupAnalysisEntry.entry_type, StartupAnalysisEntry.relative_path)
+        .all()
+    )
 
     assert job.status == JobStatus.COMPLETED
     assert job.startup_analysis_cached is True
     assert job.startup_analysis_file_count == 2
     assert job.startup_analysis_total_bytes == len(b"content") + len(b"more")
     file_entries = sorted(
-        [entry for entry in job.startup_analysis_entries if entry.get("entry_type", "file") == "file"],
+        [
+            {"relative_path": entry.relative_path, "size_bytes": entry.size_bytes}
+            for entry in startup_entries
+            if entry.entry_type == "file"
+        ],
         key=lambda entry: entry["relative_path"],
     )
-    directory_entries = [entry for entry in job.startup_analysis_entries if entry.get("entry_type") == "directory"]
+    directory_entries = [
+        {
+            "entry_type": entry.entry_type,
+            "relative_path": entry.relative_path,
+            "mtime_ns": entry.mtime_ns,
+        }
+        for entry in startup_entries
+        if entry.entry_type == "directory"
+    ]
 
     assert file_entries == [
         {"relative_path": "extra.txt", "size_bytes": len(b"more")},
@@ -1184,6 +1202,7 @@ def test_run_copy_job_clears_startup_analysis_cache_after_success(db, tmp_path):
 
     db.expire_all()
     db.refresh(job)
+    startup_entry_count = db.query(StartupAnalysisEntry).filter(StartupAnalysisEntry.job_id == job.id).count()
 
     audit = (
         db.query(AuditLog)
@@ -1201,8 +1220,36 @@ def test_run_copy_job_clears_startup_analysis_cache_after_success(db, tmp_path):
     assert job.startup_analysis_share_read_mbps == 120.5
     assert job.startup_analysis_drive_write_mbps == 96.25
     assert job.startup_analysis_estimated_duration_seconds == 1
+    assert startup_entry_count == 0
     assert audit is not None
     assert audit.details["reason"] == "job_completed"
+
+
+def test_prepare_job_startup_analysis_persists_entries_in_batches(db, tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    for index in range(5):
+        (source_dir / f"file-{index}.txt").write_text(f"file-{index}")
+
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+
+    job = _make_job(db, str(source_dir), target_mount_path=str(target_dir))
+
+    with patch.object(copy_engine, "STARTUP_ANALYSIS_BATCH_SIZE", 2):
+        with patch("app.services.copy_engine._persist_startup_analysis_file_batch", wraps=copy_engine._persist_startup_analysis_file_batch) as persist_file_batch:
+            copy_engine.prepare_job_startup_analysis(job.id)
+
+    db.expire_all()
+    db.refresh(job)
+
+    assert job.startup_analysis_cached is True
+    assert job.startup_analysis_file_count == 5
+    assert persist_file_batch.call_count == 3
+    assert db.query(StartupAnalysisEntry).filter(
+        StartupAnalysisEntry.job_id == job.id,
+        StartupAnalysisEntry.entry_type == "file",
+    ).count() == 5
 
 
 def test_run_copy_job_accumulates_active_duration_on_resume(db, tmp_path):

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -11,7 +11,7 @@ from sqlalchemy.pool import StaticPool
 
 from app.database import Base
 from app.models.hardware import DriveState, UsbDrive, UsbHub, UsbPort
-from app.models.jobs import DriveAssignment, ExportFile, ExportJob, FileStatus, JobStatus, Manifest
+from app.models.jobs import DriveAssignment, ExportFile, ExportJob, FileStatus, JobStatus, Manifest, StartupAnalysisEntry
 from app.models.network import MountStatus, MountType, NetworkMount
 from app.models.projects import Project
 from app.repositories.audit_repository import AuditRepository
@@ -22,6 +22,7 @@ from app.repositories.job_repository import (
     FileRepository,
     JobRepository,
     ManifestRepository,
+    StartupAnalysisEntryRepository,
 )
 from app.repositories.mount_repository import MountRepository
 
@@ -848,6 +849,28 @@ def test_bulk_list_error_messages_no_errors_returns_empty(db):
 
     result = repo.bulk_list_error_messages([j.id])
     assert j.id not in result
+
+
+def test_startup_analysis_entry_repo_list_by_job_after_id(db):
+    repo = StartupAnalysisEntryRepository(db)
+    job = _make_job(db)
+
+    first = StartupAnalysisEntry(job_id=job.id, entry_type="directory", relative_path="", mtime_ns=1)
+    second = StartupAnalysisEntry(job_id=job.id, entry_type="directory", relative_path="nested", mtime_ns=2)
+    third = StartupAnalysisEntry(job_id=job.id, entry_type="file", relative_path="file.txt", size_bytes=3)
+    db.add_all([first, second, third])
+    db.commit()
+    db.refresh(first)
+    db.refresh(second)
+
+    rows = repo.list_by_job_after_id(
+        job.id,
+        entry_type="directory",
+        after_id=first.id,
+        limit=10,
+    )
+
+    assert [(row.entry_type, row.relative_path) for row in rows] == [("directory", "nested")]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This change reworks startup analysis for large source trees so ECUBE no longer depends on one large in-memory file snapshot or one large job-row JSON cache before copy execution begins. Instead, startup-analysis discovery and persistence are chunked and database-backed, which reduces OOM risk on constrained systems while preserving cache reuse, stale refresh, copy resume behavior, and audit-safe failure handling.

## Changes included

- Replaced the heavy startup-analysis job-row cache pattern with normalized, bounded persistence:
  - added lightweight startup-analysis cache state on jobs
  - added revision tracking for persisted startup-analysis data
  - added normalized `startup_analysis_entries` storage for file and directory markers
- Refactored the copy engine startup-analysis path to:
  - stream source-tree discovery instead of materializing the full tree up front
  - persist file metadata in batches
  - persist directory marker metadata separately for stale-cache validation
  - migrate valid legacy JSON startup-analysis caches into the normalized format
- Updated copy-job execution to page pending-file work from persisted rows instead of holding a full relative-path source map in memory before dispatch
- Kept existing startup-analysis semantics intact:
  - `startup_analysis_status`, file count, total bytes, and ready/reuse behavior remain supported
  - stale-cache refresh still occurs when cached analysis is no longer current
  - cache-clear paths now remove normalized startup-analysis rows as well as job cache state
- Updated the release-scoped migration in place for v0.2.0 to add the new startup-analysis schema and corresponding downgrade cleanup

## User-facing / operator-facing effects

- Large evidence trees should be less likely to leave jobs stuck in `ANALYZING` due to startup-analysis memory spikes.
- Startup-analysis remains reusable for later job start/resume flows, but the stored cache is now database-backed rather than a large JSON blob on the job row.
- This change touches an operator-relevant workflow: startup-analysis completion, reuse, stale refresh, and cache clearing remain part of the existing job lifecycle, with audit-safe and sanitized failure logging preserved.

## Validation

- Verified copy-engine startup-analysis behavior with:
  - `.venv/bin/python -m pytest tests/test_copy_engine.py -k 'startup_analysis or reuses_cached or clears_startup_analysis_cache'`
  - Result: `12 passed`
- Verified job-surface startup-analysis behavior with:
  - `.venv/bin/python -m pytest tests/test_jobs.py -k 'startup_analysis'`
  - Result: `16 passed`
- Verified schema/migration behavior with:
  - `.venv/bin/python -m pytest tests/test_migrations.py`
  - Result: `10 passed`
- Branch diff against `main`:
  - `6 files changed, 690 insertions(+), 160 deletions(-)`