### PR TITLE
Add missing database indexes for jobs, files, assignments, manifests, and audit query paths

### DIFF
--- a/alembic/versions/v0_2_0.py
+++ b/alembic/versions/v0_2_0.py
@@ -273,6 +273,60 @@ def _ensure_export_files_project_indexes() -> None:
     op.execute(sa.text("CREATE INDEX IF NOT EXISTS ix_export_files_project_status ON export_files (project_id, status)"))
 
 
+def _ensure_release_hot_path_indexes() -> None:
+    op.execute(sa.text("CREATE INDEX IF NOT EXISTS ix_export_jobs_status_created_id ON export_jobs (status, created_at, id)"))
+    op.execute(sa.text("CREATE INDEX IF NOT EXISTS ix_export_jobs_created_id ON export_jobs (created_at, id)"))
+    op.execute(sa.text("CREATE INDEX IF NOT EXISTS ix_export_files_job_id ON export_files (job_id)"))
+    op.execute(sa.text("CREATE INDEX IF NOT EXISTS ix_export_files_job_status ON export_files (job_id, status)"))
+    op.execute(sa.text("CREATE INDEX IF NOT EXISTS ix_export_files_job_id_id ON export_files (job_id, id)"))
+    op.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS ix_drive_assignments_job_released_assigned_id "
+            "ON drive_assignments (job_id, released_at, assigned_at, id)"
+        )
+    )
+    op.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS ix_drive_assignments_drive_released_assigned_id "
+            "ON drive_assignments (drive_id, released_at, assigned_at, id)"
+        )
+    )
+    op.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS ix_manifests_job_created_id "
+            "ON manifests (job_id, created_at, id)"
+        )
+    )
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_audit_logs_action_timestamp"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_audit_logs_project_timestamp"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_audit_logs_drive_timestamp"))
+    op.execute(sa.text("CREATE INDEX IF NOT EXISTS ix_audit_logs_timestamp_id ON audit_logs (timestamp, id)"))
+    op.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS ix_audit_logs_project_timestamp_id "
+            "ON audit_logs (project_id, timestamp, id)"
+        )
+    )
+    op.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS ix_audit_logs_job_timestamp_id "
+            "ON audit_logs (job_id, timestamp, id)"
+        )
+    )
+    op.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS ix_audit_logs_drive_timestamp_id "
+            "ON audit_logs (drive_id, timestamp, id)"
+        )
+    )
+    op.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS ix_audit_logs_action_drive_project_timestamp_id "
+            "ON audit_logs (action, drive_id, project_id, timestamp, id)"
+        )
+    )
+
+
 def _upgrade_legacy_export_file_project_schema(inspector: sa.Inspector) -> None:
     if not _export_files_has_project_id(inspector):
         with op.batch_alter_table("export_files") as batch_op:
@@ -342,6 +396,9 @@ def upgrade() -> None:
         if "export_files" in existing_tables:
             _upgrade_legacy_export_file_project_schema(inspector)
             _upgrade_startup_analysis_schema(inspector)
+        required_tables = {"export_jobs", "export_files", "drive_assignments", "manifests", "audit_logs"}
+        if required_tables.issubset(existing_tables):
+            _ensure_release_hot_path_indexes()
         return
 
     op.create_table(
@@ -573,6 +630,8 @@ def upgrade() -> None:
         ),
     )
 
+    _ensure_release_hot_path_indexes()
+
     op.create_table(
         "user_roles",
         sa.Column("id", sa.Integer(), primary_key=True),
@@ -605,30 +664,20 @@ def upgrade() -> None:
         sa.CheckConstraint("id = 1", name="ck_single_reconciliation_lock"),
     )
 
-    op.execute(
-        sa.text(
-            "CREATE INDEX IF NOT EXISTS ix_audit_logs_project_timestamp "
-            "ON audit_logs (project_id, timestamp DESC)"
-        )
-    )
-    op.execute(
-        sa.text(
-            "CREATE INDEX IF NOT EXISTS ix_audit_logs_drive_timestamp "
-            "ON audit_logs (drive_id, timestamp DESC)"
-        )
-    )
-    op.execute(
-        sa.text(
-            "CREATE INDEX IF NOT EXISTS ix_audit_logs_action_timestamp "
-            "ON audit_logs (action, timestamp DESC)"
-        )
-    )
-
-
 def downgrade() -> None:
-    op.execute(sa.text("DROP INDEX IF EXISTS ix_audit_logs_action_timestamp"))
-    op.execute(sa.text("DROP INDEX IF EXISTS ix_audit_logs_drive_timestamp"))
-    op.execute(sa.text("DROP INDEX IF EXISTS ix_audit_logs_project_timestamp"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_audit_logs_action_drive_project_timestamp_id"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_audit_logs_drive_timestamp_id"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_audit_logs_job_timestamp_id"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_audit_logs_project_timestamp_id"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_audit_logs_timestamp_id"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_manifests_job_created_id"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_drive_assignments_drive_released_assigned_id"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_drive_assignments_job_released_assigned_id"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_export_files_job_id_id"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_export_files_job_status"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_export_files_job_id"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_export_jobs_created_id"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_export_jobs_status_created_id"))
     op.drop_index("ix_startup_analysis_entries_job_entry_path", table_name="startup_analysis_entries")
     op.drop_index("ix_job_chain_of_custody_snapshots_job_id", table_name="job_chain_of_custody_snapshots")
     op.drop_index("ix_export_files_project_status", table_name="export_files")

--- a/app/models/audit.py
+++ b/app/models/audit.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, JSON
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, JSON, Index
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import validates
 from sqlalchemy.sql import func
@@ -8,6 +8,14 @@ from app.utils.sanitize import normalize_project_id
 
 class AuditLog(Base):
     __tablename__ = "audit_logs"
+    __table_args__ = (
+        Index("ix_audit_logs_timestamp_id", "timestamp", "id"),
+        Index("ix_audit_logs_project_timestamp_id", "project_id", "timestamp", "id"),
+        Index("ix_audit_logs_job_timestamp_id", "job_id", "timestamp", "id"),
+        Index("ix_audit_logs_drive_timestamp_id", "drive_id", "timestamp", "id"),
+        Index("ix_audit_logs_action_drive_project_timestamp_id", "action", "drive_id", "project_id", "timestamp", "id"),
+    )
+
     id = Column(Integer, primary_key=True)
     timestamp = Column(DateTime(timezone=True), server_default=func.now())
     user = Column(String)

--- a/app/models/jobs.py
+++ b/app/models/jobs.py
@@ -41,6 +41,11 @@ class StartupAnalysisStatus(str, enum.Enum):
 
 class ExportJob(Base):
     __tablename__ = "export_jobs"
+    __table_args__ = (
+        Index("ix_export_jobs_status_created_id", "status", "created_at", "id"),
+        Index("ix_export_jobs_created_id", "created_at", "id"),
+    )
+
     id = Column(Integer, primary_key=True)
     project_id = Column(String, ForeignKey("projects.normalized_project_id"), nullable=False, index=True)
     evidence_number = Column(String, nullable=False)
@@ -101,6 +106,9 @@ class ExportJob(Base):
 class ExportFile(Base):
     __tablename__ = "export_files"
     __table_args__ = (
+        Index("ix_export_files_job_id", "job_id"),
+        Index("ix_export_files_job_status", "job_id", "status"),
+        Index("ix_export_files_job_id_id", "job_id", "id"),
         Index("ix_export_files_project_status", "project_id", "status"),
     )
 
@@ -137,6 +145,10 @@ class StartupAnalysisEntry(Base):
 
 class Manifest(Base):
     __tablename__ = "manifests"
+    __table_args__ = (
+        Index("ix_manifests_job_created_id", "job_id", "created_at", "id"),
+    )
+
     id = Column(Integer, primary_key=True)
     job_id = Column(Integer, ForeignKey("export_jobs.id"), nullable=False)
     manifest_path = Column(String)
@@ -147,6 +159,11 @@ class Manifest(Base):
 
 class DriveAssignment(Base):
     __tablename__ = "drive_assignments"
+    __table_args__ = (
+        Index("ix_drive_assignments_job_released_assigned_id", "job_id", "released_at", "assigned_at", "id"),
+        Index("ix_drive_assignments_drive_released_assigned_id", "drive_id", "released_at", "assigned_at", "id"),
+    )
+
     id = Column(Integer, primary_key=True)
     drive_id = Column(Integer, ForeignKey("usb_drives.id"), nullable=False)
     job_id = Column(Integer, ForeignKey("export_jobs.id"), nullable=False)

--- a/docs/database/ecube-schema.dbml
+++ b/docs/database/ecube-schema.dbml
@@ -148,7 +148,9 @@ Table export_jobs {
   created_at timestamptz
 
   indexes {
+    (created_at, id) [name: 'ix_export_jobs_created_id']
     project_id [name: 'ix_export_jobs_project_id']
+    (status, created_at, id) [name: 'ix_export_jobs_status_created_id']
   }
 }
 
@@ -181,6 +183,9 @@ Table export_files {
   startup_analysis_revision int [not null, default: 0]
 
   indexes {
+    job_id [name: 'ix_export_files_job_id']
+    (job_id, id) [name: 'ix_export_files_job_id_id']
+    (job_id, status) [name: 'ix_export_files_job_status']
     project_id [name: 'ix_export_files_project_id']
     (project_id, status) [name: 'ix_export_files_project_status']
   }
@@ -205,6 +210,10 @@ Table manifests {
   manifest_path varchar
   format varchar [default: 'JSON']
   created_at timestamptz
+
+  indexes {
+    (job_id, created_at, id) [name: 'ix_manifests_job_created_id']
+  }
 }
 
 Table startup_analysis_entries {
@@ -256,6 +265,14 @@ Table audit_logs {
   job_id int
   details json
   client_ip varchar(45)
+
+  indexes {
+    (action, drive_id, project_id, timestamp, id) [name: 'ix_audit_logs_action_drive_project_timestamp_id']
+    (drive_id, timestamp, id) [name: 'ix_audit_logs_drive_timestamp_id']
+    (job_id, timestamp, id) [name: 'ix_audit_logs_job_timestamp_id']
+    (project_id, timestamp, id) [name: 'ix_audit_logs_project_timestamp_id']
+    (timestamp, id) [name: 'ix_audit_logs_timestamp_id']
+  }
 }
 
 Table drive_assignments {
@@ -266,6 +283,11 @@ Table drive_assignments {
   copied_bytes bigint [not null, default: 0]
   assigned_at timestamptz
   released_at timestamptz
+
+  indexes {
+    (drive_id, released_at, assigned_at, id) [name: 'ix_drive_assignments_drive_released_assigned_id']
+    (job_id, released_at, assigned_at, id) [name: 'ix_drive_assignments_job_released_assigned_id']
+  }
 }
 
 Ref: audit_logs.drive_id > usb_drives.id

--- a/docs/design/05-data-model.md
+++ b/docs/design/05-data-model.md
@@ -128,8 +128,12 @@ This makes `user_roles` the day-to-day control plane while preserving OS-group f
 - Foreign keys enforce hub→port→drive and job→file relationships.
 - `usb_hubs.system_identifier` and `usb_ports.system_path` carry **unique constraints**, ensuring each hub and port maps to exactly one row. The discovery upsert logic relies on these keys for stable identity across sync cycles.
 - Enumerated statuses should be constrained by check/enum types.
-- Index by `project_id`, `status`, and recent timestamps for UI queries.
-- CoC retrieval performance should be supported by indexes on audit query paths, including composite indexes on (`audit_logs.project_id`, `audit_logs.timestamp`), (`audit_logs.drive_id`, `audit_logs.timestamp`), and (`audit_logs.action`, `audit_logs.timestamp`).
+- Index the current hot paths explicitly rather than relying on broad generic coverage.
+- `export_jobs` should support job-list and health queries with indexes on `project_id`, (`status`, `created_at`, `id`), and (`created_at`, `id`).
+- `export_files` should support job-file listing, grouped counts, and status-scoped file summaries with indexes on `project_id`, (`project_id`, `status`), `job_id`, (`job_id`, `status`), and (`job_id`, `id`).
+- `drive_assignments` should support active assignment lookups with composite indexes on (`job_id`, `released_at`, `assigned_at`, `id`) and (`drive_id`, `released_at`, `assigned_at`, `id`).
+- `manifests` should support per-job manifest retrieval with an index on (`job_id`, `created_at`, `id`).
+- CoC and audit retrieval performance should be supported by indexes on audit query paths, including (`audit_logs.timestamp`, `audit_logs.id`), (`audit_logs.project_id`, `audit_logs.timestamp`, `audit_logs.id`), (`audit_logs.job_id`, `audit_logs.timestamp`, `audit_logs.id`), (`audit_logs.drive_id`, `audit_logs.timestamp`, `audit_logs.id`), and the chain-of-custody handoff lifecycle filter (`audit_logs.action`, `audit_logs.drive_id`, `audit_logs.project_id`, `audit_logs.timestamp`, `audit_logs.id`).
 
 ## Physical Schema Reference (Current ORM)
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -45,6 +45,13 @@ def migrated_engine(sqlite_db_path):
     engine.dispose()
 
 
+def _index_columns_by_name(inspector, table_name):
+    return {
+        index["name"]: tuple(index.get("column_names") or ())
+        for index in inspector.get_indexes(table_name)
+    }
+
+
 def test_upgrade_head_on_sqlite(migrated_engine):
     """upgrade() must run to HEAD without errors on SQLite and create all tables."""
     inspector = inspect(migrated_engine)
@@ -163,9 +170,19 @@ def test_audit_log_has_project_and_drive_columns_and_indexes(migrated_engine):
     assert "project_id" in columns
     assert "drive_id" in columns
 
-    index_names = {idx["name"] for idx in inspector.get_indexes("audit_logs")}
-    assert "ix_audit_logs_project_timestamp" in index_names
-    assert "ix_audit_logs_drive_timestamp" in index_names
+    indexes = _index_columns_by_name(inspector, "audit_logs")
+    assert indexes["ix_audit_logs_timestamp_id"] == ("timestamp", "id")
+    assert indexes["ix_audit_logs_project_timestamp_id"] == ("project_id", "timestamp", "id")
+    assert indexes["ix_audit_logs_job_timestamp_id"] == ("job_id", "timestamp", "id")
+    assert indexes["ix_audit_logs_drive_timestamp_id"] == ("drive_id", "timestamp", "id")
+    assert indexes["ix_audit_logs_action_drive_project_timestamp_id"] == (
+        "action",
+        "drive_id",
+        "project_id",
+        "timestamp",
+        "id",
+    )
+    assert "ix_audit_logs_action_timestamp" not in indexes
 
 
 def test_export_jobs_project_id_references_projects(migrated_engine):
@@ -199,9 +216,38 @@ def test_export_files_project_id_references_projects(migrated_engine):
         for fk in export_file_fks
     )
 
-    index_names = {idx["name"] for idx in inspector.get_indexes("export_files")}
-    assert "ix_export_files_project_id" in index_names
-    assert "ix_export_files_project_status" in index_names
+    indexes = _index_columns_by_name(inspector, "export_files")
+    assert indexes["ix_export_files_project_id"] == ("project_id",)
+    assert indexes["ix_export_files_project_status"] == ("project_id", "status")
+    assert indexes["ix_export_files_job_id"] == ("job_id",)
+    assert indexes["ix_export_files_job_status"] == ("job_id", "status")
+    assert indexes["ix_export_files_job_id_id"] == ("job_id", "id")
+
+
+def test_release_hot_path_indexes_are_present(migrated_engine):
+    inspector = inspect(migrated_engine)
+
+    export_job_indexes = _index_columns_by_name(inspector, "export_jobs")
+    assert export_job_indexes["ix_export_jobs_project_id"] == ("project_id",)
+    assert export_job_indexes["ix_export_jobs_status_created_id"] == ("status", "created_at", "id")
+    assert export_job_indexes["ix_export_jobs_created_id"] == ("created_at", "id")
+
+    drive_assignment_indexes = _index_columns_by_name(inspector, "drive_assignments")
+    assert drive_assignment_indexes["ix_drive_assignments_job_released_assigned_id"] == (
+        "job_id",
+        "released_at",
+        "assigned_at",
+        "id",
+    )
+    assert drive_assignment_indexes["ix_drive_assignments_drive_released_assigned_id"] == (
+        "drive_id",
+        "released_at",
+        "assigned_at",
+        "id",
+    )
+
+    manifest_indexes = _index_columns_by_name(inspector, "manifests")
+    assert manifest_indexes["ix_manifests_job_created_id"] == ("job_id", "created_at", "id")
 
 
 def test_upgrade_head_backfills_projects_from_legacy_export_jobs(sqlite_db_path):


### PR DESCRIPTION
### Summary
This branch adds the missing database indexes for ECUBE’s verified hot-path queries without changing API behavior or data model semantics. The work is intentionally scoped to the unreleased `v0_2_0` release migration, ORM schema metadata, schema documentation, and migration coverage so fresh installs and rebuilt test/dev databases all converge on the same index set.

### Changes included
- Added hot-path indexes for job list and health query patterns on `export_jobs` using `(status, created_at, id)` and `(created_at, id)`.
- Added job-scoped file query indexes on `export_files` for `job_id`, `(job_id, status)`, and `(job_id, id)` while preserving the existing project-based file indexes.
- Added active-assignment lookup indexes on `drive_assignments` for `(job_id, released_at, assigned_at, id)` and `(drive_id, released_at, assigned_at, id)`.
- Added per-job manifest retrieval indexing on `manifests` with `(job_id, created_at, id)`.
- Replaced the older broad audit index shapes with the verified audit/query-path set on `audit_logs`:
  - `(timestamp, id)`
  - `(project_id, timestamp, id)`
  - `(job_id, timestamp, id)`
  - `(drive_id, timestamp, id)`
  - `(action, drive_id, project_id, timestamp, id)` for current chain-of-custody handoff/report filters
- Updated the release-scoped migration in place rather than creating a new Alembic revision, including support for both fresh installs and legacy upgrade paths that already have the core tables.
- Updated the tracked DBML schema and data-model design doc so the source-controlled schema description matches the implemented index strategy.
- Expanded migration tests to assert the new index set explicitly and to verify the superseded `audit_logs(action, timestamp)` index is no longer present.

### User-facing / operator-facing effects
- No API contract, RBAC, or UI workflow changes.
- No changes to audit payload content or chain-of-custody semantics.
- Expected operational impact is lower scan cost on job listing, job file listing/counting, manifest lookup, active drive assignment lookup, and filtered audit / chain-of-custody query paths.

### Validation
- `pytest tests/test_migrations.py -q`
  - Result: `11 passed`
- `pytest tests/test_jobs.py::test_list_jobs_returns_created_jobs tests/test_jobs.py::test_get_job_files_supports_page_navigation tests/test_audit.py::TestAuditFilters::test_combined_filters -q`
  - Result: `3 passed`
- Schema docs regenerated from ORM metadata:
  - `docs/database/ecube-schema.dbml`
- Design docs updated to reflect the implemented hot-path index strategy:
  - `docs/design/05-data-model.md`

### Review notes
- This branch touches database performance and audit query paths, but it does not change trusted-system behavior, authorization rules, or operator-visible outputs.
- Query-plan or timing measurements were not captured in this branch; functional and migration verification are present, but performance benchmarking would still be an optional follow-up if reviewers want before/after evidence.