### PR TITLE
Add startup analysis batch size configuration and related updates

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -257,7 +257,9 @@ class Settings(BaseSettings):
     # ---------------------------------------------------------------------------
 
     #: Batch size for startup-analysis discovery, persistence, and validation.
-    startup_analysis_batch_size: int = Field(default=500, ge=1)
+    #: The upper bound keeps operator tuning from reintroducing unbounded
+    #: startup-analysis memory growth on large source trees.
+    startup_analysis_batch_size: int = Field(default=500, ge=1, le=5000)
 
     #: Chunk size in bytes for file copy and checksum computation.
     copy_chunk_size_bytes: int = 1_048_576

--- a/app/config.py
+++ b/app/config.py
@@ -256,6 +256,9 @@ class Settings(BaseSettings):
     # Copy engine tuning
     # ---------------------------------------------------------------------------
 
+    #: Batch size for startup-analysis discovery, persistence, and validation.
+    startup_analysis_batch_size: int = Field(default=500, ge=1)
+
     #: Chunk size in bytes for file copy and checksum computation.
     copy_chunk_size_bytes: int = 1_048_576
 

--- a/app/schemas/configuration.py
+++ b/app/schemas/configuration.py
@@ -44,7 +44,7 @@ class ConfigurationUpdateRequest(StrictIntMixin, BaseModel):
     db_pool_size: Optional[StrictInt] = Field(default=None, ge=1, le=100)
     db_pool_max_overflow: Optional[StrictInt] = Field(default=None, ge=0, le=200)
     db_pool_recycle_seconds: Optional[StrictInt] = Field(default=None, ge=-1)
-    startup_analysis_batch_size: Optional[StrictInt] = Field(default=None, ge=1)
+    startup_analysis_batch_size: Optional[StrictInt] = Field(default=None, ge=1, le=5000)
     copy_job_timeout: Optional[StrictInt] = Field(default=None, ge=0)
     job_detail_files_page_size: Optional[StrictInt] = Field(default=None, ge=20, le=100)
     callback_default_url: Optional[StrictSafeStr] = Field(

--- a/app/schemas/configuration.py
+++ b/app/schemas/configuration.py
@@ -44,6 +44,7 @@ class ConfigurationUpdateRequest(StrictIntMixin, BaseModel):
     db_pool_size: Optional[StrictInt] = Field(default=None, ge=1, le=100)
     db_pool_max_overflow: Optional[StrictInt] = Field(default=None, ge=0, le=200)
     db_pool_recycle_seconds: Optional[StrictInt] = Field(default=None, ge=-1)
+    startup_analysis_batch_size: Optional[StrictInt] = Field(default=None, ge=1)
     copy_job_timeout: Optional[StrictInt] = Field(default=None, ge=0)
     job_detail_files_page_size: Optional[StrictInt] = Field(default=None, ge=20, le=100)
     callback_default_url: Optional[StrictSafeStr] = Field(

--- a/app/services/configuration_service.py
+++ b/app/services/configuration_service.py
@@ -75,6 +75,7 @@ _EDITABLE_FIELDS: Dict[str, _FieldSpec] = {
     "db_pool_size": _FieldSpec("DB_POOL_SIZE", False, _serialize_plain),
     "db_pool_max_overflow": _FieldSpec("DB_POOL_MAX_OVERFLOW", False, _serialize_plain),
     "db_pool_recycle_seconds": _FieldSpec("DB_POOL_RECYCLE_SECONDS", True, _serialize_plain),
+    "startup_analysis_batch_size": _FieldSpec("STARTUP_ANALYSIS_BATCH_SIZE", False, _serialize_plain),
     "copy_job_timeout": _FieldSpec("COPY_JOB_TIMEOUT", False, _serialize_plain),
     "job_detail_files_page_size": _FieldSpec("JOB_DETAIL_FILES_PAGE_SIZE", False, _serialize_plain),
     "callback_default_url": _FieldSpec("CALLBACK_DEFAULT_URL", False, _serialize_callback_default_url),

--- a/app/services/copy_engine.py
+++ b/app/services/copy_engine.py
@@ -29,7 +29,6 @@ from app.utils.sanitize import describe_relative_paths, sanitize_error_message, 
 
 logger = logging.getLogger(__name__)
 
-STARTUP_ANALYSIS_BATCH_SIZE = 500
 STARTUP_ANALYSIS_SAMPLE_LIMIT = 16
 COPY_PENDING_BATCH_MULTIPLIER = 4
 
@@ -847,6 +846,7 @@ def _persist_startup_analysis_cache(
     source: Path,
     startup_entry_repo: StartupAnalysisEntryRepository,
 ) -> tuple[int, int, list[Path]]:
+    batch_size = settings.startup_analysis_batch_size
     file_batch: list[tuple[str, int]] = []
     directory_batch: list[tuple[str, int]] = []
     sample_files: list[Path] = []
@@ -864,7 +864,7 @@ def _persist_startup_analysis_cache(
         if entry_type == "directory":
             relative_directory = "" if path == source else str(_relative_path(path, source))
             directory_batch.append((relative_directory, path.stat().st_mtime_ns))
-            if len(directory_batch) >= STARTUP_ANALYSIS_BATCH_SIZE:
+            if len(directory_batch) >= batch_size:
                 _persist_startup_analysis_entry_batch(
                     startup_entry_repo,
                     job.id,
@@ -883,7 +883,7 @@ def _persist_startup_analysis_cache(
         file_count += 1
         total_bytes += size_bytes
 
-        if len(file_batch) >= STARTUP_ANALYSIS_BATCH_SIZE:
+        if len(file_batch) >= batch_size:
             _persist_startup_analysis_file_batch(db, job, file_batch, revision=revision, commit=False)
             _persist_startup_analysis_entry_batch(
                 startup_entry_repo,
@@ -937,6 +937,7 @@ def _persist_legacy_startup_analysis_cache(
     startup_entry_repo: StartupAnalysisEntryRepository,
     legacy_cache: tuple[list[dict[str, int | str]], list[dict[str, int | str]], int, int],
 ) -> list[Path]:
+    batch_size = settings.startup_analysis_batch_size
     file_entries, directory_entries, file_count, total_bytes = legacy_cache
     revision = int(job.startup_analysis_revision or 0) + 1
     job.startup_analysis_revision = revision
@@ -945,8 +946,8 @@ def _persist_legacy_startup_analysis_cache(
     startup_entry_repo.delete_by_job(job.id, commit=False)
 
     sample_files: list[Path] = []
-    for start in range(0, len(file_entries), STARTUP_ANALYSIS_BATCH_SIZE):
-        batch_entries = file_entries[start:start + STARTUP_ANALYSIS_BATCH_SIZE]
+    for start in range(0, len(file_entries), batch_size):
+        batch_entries = file_entries[start:start + batch_size]
         file_batch = [
             (str(entry["relative_path"]), int(entry["size_bytes"]))
             for entry in batch_entries
@@ -964,8 +965,8 @@ def _persist_legacy_startup_analysis_cache(
                 break
             sample_files.append(_source_path_for_relative_path(source, relative_path))
 
-    for start in range(0, len(directory_entries), STARTUP_ANALYSIS_BATCH_SIZE):
-        batch_entries = directory_entries[start:start + STARTUP_ANALYSIS_BATCH_SIZE]
+    for start in range(0, len(directory_entries), batch_size):
+        batch_entries = directory_entries[start:start + batch_size]
         directory_batch = [
             (str(entry["relative_path"]), int(entry["mtime_ns"]))
             for entry in batch_entries
@@ -1002,6 +1003,7 @@ def _cached_startup_analysis_is_current(
     file_repo: FileRepository,
     startup_entry_repo: StartupAnalysisEntryRepository,
 ) -> bool:
+    batch_size = settings.startup_analysis_batch_size
     file_count = int(job.startup_analysis_file_count or 0)
     total_bytes = int(job.startup_analysis_total_bytes or 0)
     revision = int(job.startup_analysis_revision or 0)
@@ -1012,7 +1014,7 @@ def _cached_startup_analysis_is_current(
     validated_total_bytes = 0
     last_file_id: int | None = None
     while True:
-        file_rows = file_repo.list_by_job_after_id(job.id, after_id=last_file_id, limit=STARTUP_ANALYSIS_BATCH_SIZE)
+        file_rows = file_repo.list_by_job_after_id(job.id, after_id=last_file_id, limit=batch_size)
         if not file_rows:
             break
         last_file_id = file_rows[-1].id
@@ -1041,7 +1043,7 @@ def _cached_startup_analysis_is_current(
             job.id,
             entry_type="directory",
             after_id=last_directory_id,
-            limit=STARTUP_ANALYSIS_BATCH_SIZE,
+            limit=batch_size,
         )
         if not directory_rows:
             break

--- a/docs/operations/04-configuration-reference.md
+++ b/docs/operations/04-configuration-reference.md
@@ -179,6 +179,7 @@ Required only when `SESSION_BACKEND=redis`. If Redis is unavailable, ECUBE autom
 | `AUDIT_LOG_RETENTION_DAYS` | `365`   | Days to retain audit log records. `0` = keep forever.                      |
 | `COPY_JOB_TIMEOUT`         | `3600`  | Maximum seconds for one file copy/checksum attempt before that file is marked `TIMEOUT`. `0` = no timeout. |
 | `JOB_DETAIL_FILES_PAGE_SIZE` | `40` | Default number of file rows shown per page on the Job Detail Files panel. Admins can change this from the Configuration page. Minimum `20`, maximum `100`. |
+| `STARTUP_ANALYSIS_BATCH_SIZE` | `500` | Maximum startup-analysis rows processed per batch while scanning, persisting, and validating source trees. Admins can change this from the Configuration page. Minimum `1`, maximum `5000`. Lower values reduce peak memory usage; higher values reduce database round trips. |
 | `NFS_CLIENT_VERSION` | `4.1` | Default NFS protocol version requested for network mounts when a share does not set an explicit override. Supported values: `4.2`, `4.1`, `4.0`, `3`. Admins can change this from the Configuration page under Shares. |
 | `USB_DISCOVERY_INTERVAL`   | `30`    | Seconds between automatic USB discovery sweeps. `0` = disabled.            |
 | `READINESS_MOUNT_CHECK_TIMEOUT_SECONDS` | `1.0` | Timeout in seconds for each mount check in `GET /health/ready`. Keep low to preserve fail-fast readiness behavior. |

--- a/docs/operations/13-user-manual.md
+++ b/docs/operations/13-user-manual.md
@@ -974,6 +974,7 @@ What this page is for:
 
 - Adjusting logging behavior (level, format, and file logging options)
 - Adjusting selected database pool settings exposed by the UI
+- Tuning startup-analysis batch size to balance peak memory use against database round trips during large source-tree scans
 - Setting or clearing the system-wide `Default Callback URL` used for job webhooks when a job does not supply its own callback URL
 - Setting or clearing the write-only webhook signing secret used for the `X-ECUBE-Signature` header
 - Setting or clearing the outbound webhook proxy URL used for callback delivery
@@ -1000,6 +1001,7 @@ Important operational notes:
 
 - Restart actions are never automatic from this page and always require explicit confirmation.
 - Restarting the application service can interrupt active operations. Prefer using a maintenance window or an idle period.
+- `Startup Analysis Batch Size` accepts values from `1` to `5000`. Lower values reduce peak memory use during startup analysis; higher values reduce database round trips.
 - The `Default Callback URL` must be a valid `https://` URL and is overridden by any job-specific `Webhook callback URL` entered on the Jobs page or Job Detail edit dialog.
 - The `Outbound Callback Proxy URL` must be a valid `http://` or `https://` URL and must not contain embedded credentials.
 - The `Webhook Signing Secret` field is write-only. Leave it blank to keep the current secret, enter a new value to rotate it, or use the clear checkbox to remove it.

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -582,6 +582,10 @@
         "label": "DB Pool Recycle Seconds",
         "help": "Changes to this value are applied after service restart."
       },
+      "startup_analysis_batch_size": {
+        "label": "Startup Analysis Batch Size",
+        "help": "Maximum number of startup-analysis rows processed per batch while scanning, persisting, and validating source trees. Lower values reduce peak memory usage but increase database round trips."
+      },
       "copy_job_timeout": {
         "label": "Per-file Copy Timeout (seconds)",
         "help": "Maximum time allowed for one file copy/checksum attempt. Set to 0 to disable timeout enforcement."

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -584,7 +584,7 @@
       },
       "startup_analysis_batch_size": {
         "label": "Startup Analysis Batch Size",
-        "help": "Maximum number of startup-analysis rows processed per batch while scanning, persisting, and validating source trees. Lower values reduce peak memory usage but increase database round trips."
+        "help": "Maximum number of startup-analysis rows processed per batch while scanning, persisting, and validating source trees. Allowed range: 1 to 5000. Lower values reduce peak memory usage but increase database round trips."
       },
       "copy_job_timeout": {
         "label": "Per-file Copy Timeout (seconds)",

--- a/frontend/src/views/ConfigurationView.vue
+++ b/frontend/src/views/ConfigurationView.vue
@@ -40,6 +40,7 @@ const form = ref({
   db_pool_size: 5,
   db_pool_max_overflow: 10,
   db_pool_recycle_seconds: -1,
+  startup_analysis_batch_size: 500,
   copy_job_timeout: 3600,
   job_detail_files_page_size: 40,
   callback_default_url: '',
@@ -62,6 +63,7 @@ const fieldOrder = [
   'db_pool_size',
   'db_pool_max_overflow',
   'db_pool_recycle_seconds',
+  'startup_analysis_batch_size',
   'copy_job_timeout',
   'job_detail_files_page_size',
   'callback_default_url',
@@ -383,6 +385,15 @@ onMounted(loadConfiguration)
 
       <article class="panel">
         <h2>{{ t('configuration.sections.copyJobs') }}</h2>
+
+        <label for="cfg-startup-analysis-batch-size">{{ t('configuration.fields.startup_analysis_batch_size.label') }}</label>
+        <input
+          id="cfg-startup-analysis-batch-size"
+          v-model.number="form.startup_analysis_batch_size"
+          type="number"
+          min="1"
+        />
+        <p class="field-help">{{ t('configuration.fields.startup_analysis_batch_size.help') }}</p>
 
         <label for="cfg-copy-job-timeout">{{ t('configuration.fields.copy_job_timeout.label') }}</label>
         <input id="cfg-copy-job-timeout" v-model.number="form.copy_job_timeout" type="number" min="0" />

--- a/frontend/src/views/ConfigurationView.vue
+++ b/frontend/src/views/ConfigurationView.vue
@@ -392,6 +392,7 @@ onMounted(loadConfiguration)
           v-model.number="form.startup_analysis_batch_size"
           type="number"
           min="1"
+          max="5000"
         />
         <p class="field-help">{{ t('configuration.fields.startup_analysis_batch_size.help') }}</p>
 

--- a/frontend/src/views/__tests__/ConfigurationView.spec.js
+++ b/frontend/src/views/__tests__/ConfigurationView.spec.js
@@ -36,6 +36,7 @@ function buildResponse(overrides = {}) {
     db_pool_size: 5,
     db_pool_max_overflow: 10,
     db_pool_recycle_seconds: -1,
+    startup_analysis_batch_size: 500,
     copy_job_timeout: 3600,
     job_detail_files_page_size: 40,
     callback_default_url: null,
@@ -110,6 +111,27 @@ describe('ConfigurationView logging defaults', () => {
     await flushPromises()
 
     expect(mocks.updateConfiguration).toHaveBeenCalledWith({ job_detail_files_page_size: 80 })
+  })
+
+  it('loads and saves the startup analysis batch size', async () => {
+    mocks.getConfiguration.mockResolvedValue(buildResponse({ startup_analysis_batch_size: 250 }))
+    mocks.updateConfiguration.mockResolvedValue({
+      restart_required: false,
+      restart_required_settings: [],
+      applied_immediately: ['startup_analysis_batch_size'],
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const batchSizeInput = wrapper.find('#cfg-startup-analysis-batch-size')
+    expect(batchSizeInput.element.value).toBe('250')
+
+    await batchSizeInput.setValue('125')
+    await wrapper.find('.action-row .btn.btn-primary').trigger('click')
+    await flushPromises()
+
+    expect(mocks.updateConfiguration).toHaveBeenCalledWith({ startup_analysis_batch_size: 125 })
   })
 
   it('loads and saves the system-wide callback default URL', async () => {

--- a/frontend/src/views/__tests__/ConfigurationView.spec.js
+++ b/frontend/src/views/__tests__/ConfigurationView.spec.js
@@ -126,6 +126,7 @@ describe('ConfigurationView logging defaults', () => {
 
     const batchSizeInput = wrapper.find('#cfg-startup-analysis-batch-size')
     expect(batchSizeInput.element.value).toBe('250')
+  expect(batchSizeInput.attributes('max')).toBe('5000')
 
     await batchSizeInput.setValue('125')
     await wrapper.find('.action-row .btn.btn-primary').trigger('click')

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -155,7 +155,7 @@ class TestSettingsDefaults:
         assert s.startup_analysis_batch_size == 500
 
     def test_startup_analysis_batch_size_rejects_values_above_maximum(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             Settings(database_url="sqlite://", startup_analysis_batch_size=5001)
 
     def test_oidc_allowed_algorithms_default(self):

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 
 from app.auth_providers import LdapGroupRoleResolver, get_role_resolver
 from app.config import Settings

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -374,6 +374,7 @@ class TestCopyJobTimeout:
         with patch("app.services.copy_engine.SessionLocal", _session_factory(db)):
             with patch("app.services.copy_engine.settings") as mock_settings:
                 mock_settings.copy_job_timeout = 1  # 1 second timeout
+                mock_settings.startup_analysis_batch_size = 500
                 mock_settings.copy_chunk_size_bytes = 1_048_576
                 mock_settings.copy_default_max_retries = 3
                 mock_settings.copy_default_retry_delay_seconds = 1.0
@@ -415,6 +416,7 @@ class TestCopyJobTimeout:
         with patch("app.services.copy_engine.SessionLocal", _session_factory(db)):
             with patch("app.services.copy_engine.settings") as mock_settings:
                 mock_settings.copy_job_timeout = 0
+                mock_settings.startup_analysis_batch_size = 500
                 mock_settings.copy_chunk_size_bytes = 1_048_576
                 mock_settings.copy_default_max_retries = 3
                 mock_settings.copy_default_retry_delay_seconds = 1.0

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -150,6 +150,10 @@ class TestSettingsDefaults:
         s = Settings(database_url="sqlite://")
         assert s.db_pool_recycle_seconds == -1
 
+    def test_startup_analysis_batch_size_default(self):
+        s = Settings(database_url="sqlite://")
+        assert s.startup_analysis_batch_size == 500
+
     def test_oidc_allowed_algorithms_default(self):
         s = Settings(database_url="sqlite://")
         assert s.oidc_allowed_algorithms == ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512"]

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -154,6 +154,10 @@ class TestSettingsDefaults:
         s = Settings(database_url="sqlite://")
         assert s.startup_analysis_batch_size == 500
 
+    def test_startup_analysis_batch_size_rejects_values_above_maximum(self):
+        with pytest.raises(ValueError):
+            Settings(database_url="sqlite://", startup_analysis_batch_size=5001)
+
     def test_oidc_allowed_algorithms_default(self):
         s = Settings(database_url="sqlite://")
         assert s.oidc_allowed_algorithms == ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512"]

--- a/tests/test_configuration_api.py
+++ b/tests/test_configuration_api.py
@@ -25,6 +25,10 @@ class TestConfigurationSchemaValidation:
         req = ConfigurationUpdateRequest(copy_job_timeout=120)
         assert req.copy_job_timeout == 120
 
+    def test_update_accepts_startup_analysis_batch_size(self):
+        req = ConfigurationUpdateRequest(startup_analysis_batch_size=250)
+        assert req.startup_analysis_batch_size == 250
+
     def test_update_accepts_nfs_client_version(self):
         req = ConfigurationUpdateRequest(nfs_client_version="4.2")
         assert req.nfs_client_version == "4.2"
@@ -102,6 +106,10 @@ class TestConfigurationSchemaValidation:
         with pytest.raises(ValidationError):
             ConfigurationUpdateRequest(job_detail_files_page_size=10)
 
+    def test_update_rejects_startup_analysis_batch_size_below_minimum(self):
+        with pytest.raises(ValidationError):
+            ConfigurationUpdateRequest(startup_analysis_batch_size=0)
+
 
 class TestConfigurationEndpoints:
     def test_get_configuration_admin_allowed(self, admin_client):
@@ -112,6 +120,7 @@ class TestConfigurationEndpoints:
         assert "log_level" in keys
         assert "nfs_client_version" in keys
         assert "db_pool_recycle_seconds" in keys
+        assert "startup_analysis_batch_size" in keys
         assert "copy_job_timeout" in keys
         assert "job_detail_files_page_size" in keys
         assert "callback_default_url" in keys
@@ -195,6 +204,29 @@ class TestConfigurationEndpoints:
 
         mock_write_env.assert_called_once()
         mock_configure_logging.assert_called_once()
+
+    @patch("app.services.configuration_service.database_service._write_env_settings")
+    def test_update_configuration_persists_startup_analysis_batch_size(
+        self,
+        mock_write_env,
+        admin_client,
+    ):
+        original_value = settings.startup_analysis_batch_size
+        try:
+            resp = admin_client.put(
+                "/admin/configuration",
+                json={"startup_analysis_batch_size": 128},
+            )
+            assert resp.status_code == 200, resp.json()
+
+            payload = resp.json()
+            assert "startup_analysis_batch_size" in payload["changed_settings"]
+            assert payload["restart_required"] is False
+
+            written = mock_write_env.call_args.args[0]
+            assert written.get("STARTUP_ANALYSIS_BATCH_SIZE") == "128"
+        finally:
+            settings.startup_analysis_batch_size = original_value
 
     @patch("app.services.configuration_service.database_service._write_env_settings")
     def test_update_configuration_persists_callback_default_url(

--- a/tests/test_configuration_api.py
+++ b/tests/test_configuration_api.py
@@ -110,6 +110,10 @@ class TestConfigurationSchemaValidation:
         with pytest.raises(ValidationError):
             ConfigurationUpdateRequest(startup_analysis_batch_size=0)
 
+    def test_update_rejects_startup_analysis_batch_size_above_maximum(self):
+        with pytest.raises(ValidationError):
+            ConfigurationUpdateRequest(startup_analysis_batch_size=5001)
+
 
 class TestConfigurationEndpoints:
     def test_get_configuration_admin_allowed(self, admin_client):
@@ -179,6 +183,13 @@ class TestConfigurationEndpoints:
     def test_get_configuration_non_admin_forbidden(self, client):
         resp = client.get("/admin/configuration")
         assert resp.status_code == 403
+
+    def test_update_configuration_rejects_startup_analysis_batch_size_above_maximum(self, admin_client):
+        resp = admin_client.put(
+            "/admin/configuration",
+            json={"startup_analysis_batch_size": 5001},
+        )
+        assert resp.status_code == 422, resp.json()
 
     @patch("app.services.configuration_service.database_service._write_env_settings")
     @patch("app.services.configuration_service.configure_logging")

--- a/tests/test_copy_engine.py
+++ b/tests/test_copy_engine.py
@@ -1236,7 +1236,7 @@ def test_prepare_job_startup_analysis_persists_entries_in_batches(db, tmp_path):
 
     job = _make_job(db, str(source_dir), target_mount_path=str(target_dir))
 
-    with patch.object(copy_engine, "STARTUP_ANALYSIS_BATCH_SIZE", 2):
+    with patch.object(copy_engine.settings, "startup_analysis_batch_size", 2):
         with patch("app.services.copy_engine._persist_startup_analysis_file_batch", wraps=copy_engine._persist_startup_analysis_file_batch) as persist_file_batch:
             copy_engine.prepare_job_startup_analysis(job.id)
 


### PR DESCRIPTION
Summary

This branch makes startup-analysis batching configurable instead of hard-coding it in the copy engine. That gives operators a supported tuning knob for large source trees, so they can reduce peak memory pressure during startup-analysis scanning, persistence, and validation while accepting the tradeoff of more database round trips when lower values are chosen.

Changes included

- Added a new application setting, startup analysis batch size, with a default of 500 and a minimum value of 1.
- Exposed the setting through the configuration update schema and the configuration persistence path so it can be read and saved like other admin-managed settings.
- Replaced the copy engine’s hard-coded startup-analysis batch constant with the configurable setting across:
  - startup-analysis cache persistence
  - legacy cache persistence
  - cached startup-analysis validation
- Added the new field to the configuration UI, including label/help text that explains the memory versus database-round-trip tradeoff.
- Added tests for:
  - default settings value
  - configuration schema acceptance and lower-bound validation
  - configuration API persistence behavior
  - copy-engine batching behavior using the configurable setting
  - configuration UI load/save behavior

User-facing / operator-facing effects

- Admins now have a visible configuration control for startup-analysis batch size in the copy-job configuration area.
- Lower values should reduce peak memory usage during startup analysis on large trees.
- Higher values should reduce batch overhead and database round trips.
- This change affects operator workflow and runtime tuning, but it does not change RBAC, audit logging, or hardware access boundaries.

Validation

- The branch includes focused backend and frontend tests covering the new setting’s defaults, API validation/persistence, copy-engine usage, and UI save flow.
- Editor diagnostics reported no errors in the touched backend, frontend, or test files.
- Automated test execution still needs to be run in a provisioned environment:
  - pytest was not available in this shell
  - the frontend unit test script was not executed here